### PR TITLE
multistream/negotiated: Propagate poll_close on unreceived protocol messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,6 +1785,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures_ringbuf"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6628abb6eb1fc74beaeb20cd0670c43d158b0150f7689b38c3eaf663f99bdec7"
+dependencies = [
+ "futures",
+ "log",
+ "ringbuf",
+ "rustc_version",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,6 +2892,7 @@ dependencies = [
  "futures",
  "futures-rustls",
  "futures-timer",
+ "futures_ringbuf",
  "hex-literal",
  "indexmap 2.1.0",
  "libc",
@@ -4368,6 +4381,15 @@ dependencies = [
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ringbuf"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79abed428d1fd2a128201cec72c5f6938e2da607c6f3745f769fabea399d950a"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ sc-network = "0.28.0"
 sc-utils = "8.0.0"
 serde_json = "1.0.108"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+futures_ringbuf = "0.4.0"
 
 [features]
 custom_sc_network = []

--- a/src/multistream_select/dialer_select.rs
+++ b/src/multistream_select/dialer_select.rs
@@ -544,16 +544,12 @@ mod tests {
                 dialer_select_proto(client_connection, protos, Version::V1Lazy).await.unwrap();
             assert_eq!(proto, "/proto1");
 
-            // In Libp2p the lazy negotation of protocols can be closed at any time,
+            // The lazy negotation of protocols can be closed at any time,
             // even if the negotiation is not yet done.
-
-            // However, for the Litep2p the negotation must conclude before closing the
-            // lazy negotation of protocol. We'll wait for the close until the
-            // server has produced a message, in this test that means forever.
             io.close().await.unwrap();
         });
 
-        assert!(tokio::time::timeout(Duration::from_secs(10), client).await.is_err());
+        tokio::time::timeout(Duration::from_secs(10), client).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/multistream_select/negotiated.rs
+++ b/src/multistream_select/negotiated.rs
@@ -323,7 +323,7 @@ where
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        // Ensure all data has been flushed and expected negotiation messages
+        // Ensure all data has been flushed and potentially negotiation messages
         // have been received.
         ready!(self.as_mut().poll_flush(cx).map_err(Into::<io::Error>::into)?);
 

--- a/src/multistream_select/negotiated.rs
+++ b/src/multistream_select/negotiated.rs
@@ -176,6 +176,10 @@ impl<TInner> Negotiated<TInner> {
                                 header: None,
                             };
                             continue;
+                        } else {
+                            // If we received a header message but it doesn't match the expected
+                            // one, or we have already received the message return an error.
+                            return Poll::Ready(Err(ProtocolError::InvalidMessage.into()));
                         }
                     }
 

--- a/src/multistream_select/negotiated.rs
+++ b/src/multistream_select/negotiated.rs
@@ -325,7 +325,6 @@ where
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         // Ensure all data has been flushed and expected negotiation messages
         // have been received.
-        ready!(self.as_mut().poll(cx).map_err(Into::<io::Error>::into)?);
         ready!(self.as_mut().poll_flush(cx).map_err(Into::<io::Error>::into)?);
 
         // Continue with the shutdown of the underlying I/O stream.


### PR DESCRIPTION
This PR ensures that lazily negotiated protocols can be closed before the specific protocol message has been received.

Closes: https://github.com/paritytech/litep2p/issues/60

cc @paritytech/networking 