### PR TITLE
[ci] Run ci for PR from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,28 @@ concurrency:
   cancel-in-progress: true
 
 # ${{ vars.CI_UNIFIED_IMAGE }} is defined in the repository variables
+env:
+  CI_IMAGE: "bullseye-1.75.0-2024-01-22-v20240222"
 
 jobs:
+  set-image:
+    # This workaround sets the container image for each job using 'set-image' job output.
+    # env variables don't work for PR from forks, so we need to use outputs.
+    runs-on: ubuntu-latest
+    outputs:
+      CI_IMAGE: ${{ steps.set_image.outputs.CI_IMAGE }}
+    steps:
+      - id: set_image
+        run: echo "CI_IMAGE=${{ env.CI_IMAGE }}" >> $GITHUB_OUTPUT
   fmt:
     name: Cargo fmt
     runs-on: ubuntu-latest
+    needs: [set-image]
     container:
-      image: ${{ vars.CI_IMAGE }}
+      image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
@@ -34,8 +45,9 @@ jobs:
   machete:
     name: Check unused dependencies
     runs-on: ubuntu-latest
+    needs: [set-image]
     container:
-      image: ${{ vars.CI_IMAGE }}
+      image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -49,14 +61,15 @@ jobs:
       - name: Install cargo-machete
         run: cargo install cargo-machete
 
-      - name: Check unused dependencies 
+      - name: Check unused dependencies
         run: cargo machete
 
   check:
     name: Cargo check
     runs-on: ubuntu-latest
+    needs: [set-image]
     container:
-      image: ${{ vars.CI_IMAGE }}
+      image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -73,8 +86,9 @@ jobs:
   doc:
     name: Check documentation
     runs-on: ubuntu-latest
+    needs: [set-image]
     container:
-      image: ${{ vars.CI_IMAGE }}
+      image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -90,8 +104,9 @@ jobs:
   clippy:
     name: Cargo clippy
     runs-on: ubuntu-latest
+    needs: [set-image]
     container:
-      image: ${{ vars.CI_IMAGE }}
+      image: ${{ needs.set-image.outputs.CI_IMAGE }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -112,8 +127,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: [set-image]
     container:
-      image: ${{ vars.CI_IMAGE }}
+      image: ${{ needs.set-image.outputs.CI_IMAGE }}
       options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 # ${{ vars.CI_UNIFIED_IMAGE }} is defined in the repository variables
 env:
-  CI_IMAGE: "bullseye-1.75.0-2024-01-22-v20240222"
+  CI_IMAGE: "paritytech/bullseye-1.75.0-2024-01-22-v20240222"
 
 jobs:
   set-image:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 # ${{ vars.CI_UNIFIED_IMAGE }} is defined in the repository variables
 env:
-  CI_IMAGE: "paritytech/bullseye-1.75.0-2024-01-22-v20240222"
+  CI_IMAGE: "paritytech/ci-unified:bullseye-1.75.0-2024-01-22-v20240222"
 
 jobs:
   set-image:


### PR DESCRIPTION
PR adds additional step to run all jobs from a container. The step is needed because when CI runs from forks repo variables are not accessible. 

cc https://github.com/paritytech/litep2p/pull/64#issuecomment-2011683117
cc https://github.com/paritytech/ci_cd/issues/964