### PR TITLE
kad: Expose the peer that provided the kad record 

### DIFF
--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{
-    protocol::libp2p::kademlia::{QueryId, Record, RecordKey},
+    protocol::libp2p::kademlia::{PeerRecord, QueryId, Record, RecordKey},
     PeerId,
 };
 
@@ -137,7 +137,7 @@ pub enum KademliaEvent {
         query_id: QueryId,
 
         /// Found record.
-        record: Record,
+        record: PeerRecord,
     },
 
     /// `PUT_VALUE` query succeeded.

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -50,7 +50,7 @@ use std::collections::{hash_map::Entry, HashMap};
 pub use config::{Config, ConfigBuilder};
 pub use handle::{KademliaEvent, KademliaHandle, Quorum, RoutingTableUpdateMode};
 pub use query::QueryId;
-pub use record::{Key as RecordKey, Record};
+pub use record::{Key as RecordKey, PeerRecord, Record};
 
 /// Logging target for the file.
 const LOG_TARGET: &str = "litep2p::ipfs::kademlia";
@@ -639,7 +639,7 @@ impl Kademlia {
                 Ok(())
             }
             QueryAction::GetRecordQueryDone { query_id, record } => {
-                self.store.put(record.clone());
+                self.store.put(record.record.clone());
 
                 let _ =
                     self.event_tx.send(KademliaEvent::GetRecordSuccess { query_id, record }).await;
@@ -757,7 +757,7 @@ impl Kademlia {
                                 (Some(record), Quorum::One) => {
                                     let _ = self
                                         .event_tx
-                                        .send(KademliaEvent::GetRecordSuccess { query_id, record: record.clone() })
+                                        .send(KademliaEvent::GetRecordSuccess { query_id, record: PeerRecord { record: record.clone(), peer: None } })
                                         .await;
                                 }
                                 (record, _) => {

--- a/src/protocol/libp2p/kademlia/query/get_record.rs
+++ b/src/protocol/libp2p/kademlia/query/get_record.rs
@@ -24,7 +24,7 @@ use crate::{
     protocol::libp2p::kademlia::{
         message::KademliaMessage,
         query::{QueryAction, QueryId},
-        record::{Key as RecordKey, Record},
+        record::{Key as RecordKey, PeerRecord, Record},
         types::{Distance, KademliaPeer, Key},
         Quorum,
     },
@@ -66,7 +66,7 @@ pub struct GetRecordContext {
     pub candidates: BTreeMap<Distance, KademliaPeer>,
 
     /// Found records.
-    pub found_records: Vec<Record>,
+    pub found_records: Vec<PeerRecord>,
 
     /// Replication factor.
     pub replication_factor: usize,
@@ -110,7 +110,7 @@ impl GetRecordContext {
     }
 
     /// Get the found record.
-    pub fn found_record(mut self) -> Record {
+    pub fn found_record(mut self) -> PeerRecord {
         self.found_records.pop().expect("record to exist since query succeeded")
     }
 
@@ -138,7 +138,10 @@ impl GetRecordContext {
 
         // TODO: validate record
         if let Some(record) = record {
-            self.found_records.push(record);
+            self.found_records.push(PeerRecord {
+                record,
+                peer: Some(peer.peer),
+            });
         }
 
         // add the queried peer to `queried` and all new peers which haven't been

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     protocol::libp2p::kademlia::{
         message::KademliaMessage,
         query::{find_node::FindNodeContext, get_record::GetRecordContext},
-        record::{Key as RecordKey, Record},
+        record::{Key as RecordKey, PeerRecord, Record},
         types::{KademliaPeer, Key},
         Quorum,
     },
@@ -97,7 +97,7 @@ pub enum QueryAction {
         peers: Vec<KademliaPeer>,
     },
 
-    /// Store the record to nodest closest to target key.
+    /// Store the record to nodes closest to target key.
     // TODO: horrible name
     PutRecordToFoundNodes {
         /// Target peer.
@@ -113,7 +113,7 @@ pub enum QueryAction {
         query_id: QueryId,
 
         /// Found record.
-        record: Record,
+        record: PeerRecord,
     },
 
     // TODO: remove

--- a/src/protocol/libp2p/kademlia/record.rs
+++ b/src/protocol/libp2p/kademlia/record.rs
@@ -108,3 +108,14 @@ impl Record {
         self.expires.map_or(false, |t| now >= t)
     }
 }
+
+/// A record either received by the given peer or retrieved from the local
+/// record store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerRecord {
+    /// The peer from whom the record was received. `None` if the record was
+    /// retrieved from local storage.
+    pub peer: Option<PeerId>,
+
+    pub record: Record,
+}


### PR DESCRIPTION
This PR exposes the Peer ID that provided the kademlia record
- The `PeerRecord` wrapper is introduced over a kad `Record` and contains the peer that provided the said record
- `GetRecordSuccess` event is extended to provide to the end user the `PeerRecord`

While at it, have extended a test to check that the peer id is propagated through queries 

Created to unblock https://github.com/paritytech/polkadot-sdk/pull/3786

cc @paritytech/networking 