### PR TITLE
kad: Implement put_record_to and try_put_record_to

### DIFF
--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -743,14 +743,15 @@ impl Kademlia {
 
                             let key = Key::new(record.key.clone());
 
-
                             if let Some(peers) = peers {
                                 // Put the record to the specified peers.
                                 let peers: VecDeque<_> = peers.into_iter().filter_map(|peer| {
-                                    if let KBucketEntry::Occupied(entry) = self.routing_table.entry(Key::from(peer)) {
-                                        Some(entry.clone())
-                                    } else {
-                                        None
+                                    match self.routing_table.entry(Key::from(peer)) {
+                                        // The routing table contains information about the peer address when:
+                                        // - Occupied: Established connection
+                                        // - Vacant: We'll try to establish the connection later, but the address is known.
+                                        KBucketEntry::Occupied(entry) | KBucketEntry::Vacant(entry) => Some(entry.clone()),
+                                        _ => None,
                                     }
                                 }).collect();
 

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -756,10 +756,10 @@ impl Kademlia {
 
                             // Put the record to the specified peers.
                             let peers = peers.into_iter().filter_map(|peer| {
-                                if let KBucketEntry::Occupied(entry) = self.routing_table.entry(Key::from(peer)) {
-                                    Some(entry.clone())
-                                } else {
-                                    None
+                                match self.routing_table.entry(Key::from(peer)) {
+                                    KBucketEntry::Occupied(entry) => Some(entry.clone()),
+                                    KBucketEntry::Vacant(entry) if !entry.addresses.is_empty() => Some(entry.clone()),
+                                    _ => None,
                                 }
                             }).collect();
 

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -741,7 +741,6 @@ impl Kademlia {
                         Some(KademliaCommand::PutRecord { record, query_id, peers }) => {
                             tracing::debug!(target: LOG_TARGET, ?query_id, key = ?record.key, "store record to DHT");
 
-                            self.store.put(record.clone());
                             let key = Key::new(record.key.clone());
 
 
@@ -761,6 +760,8 @@ impl Kademlia {
                                     peers
                                 );
                             } else {
+                                self.store.put(record.clone());
+
                                 self.engine.start_put_record(
                                     query_id,
                                     record,

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -745,7 +745,7 @@ impl Kademlia {
 
                             if let Some(peers) = peers {
                                 // Put the record to the specified peers.
-                                let peers: VecDeque<_> = peers.into_iter().filter_map(|peer| {
+                                let peers = peers.into_iter().filter_map(|peer| {
                                     match self.routing_table.entry(Key::from(peer)) {
                                         // The routing table contains information about the peer address when:
                                         // - Occupied: Established connection
@@ -755,11 +755,9 @@ impl Kademlia {
                                     }
                                 }).collect();
 
-                                self.engine.start_put_record(
-                                    query_id,
-                                    record,
-                                    peers
-                                );
+                                if let Err(error) = self.on_query_action(QueryAction::PutRecordToFoundNodes { record, peers }).await {
+                                    tracing::debug!(target: LOG_TARGET, ?error, "failed to put record to predefined peers");
+                                }
                             } else {
                                 self.store.put(record.clone());
 

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -747,10 +747,7 @@ impl Kademlia {
                                 // Put the record to the specified peers.
                                 let peers = peers.into_iter().filter_map(|peer| {
                                     match self.routing_table.entry(Key::from(peer)) {
-                                        // The routing table contains information about the peer address when:
-                                        // - Occupied: Established connection
-                                        // - Vacant: We'll try to establish the connection later, but the address is known.
-                                        KBucketEntry::Occupied(entry) | KBucketEntry::Vacant(entry) => Some(entry.clone()),
+                                        KBucketEntry::Occupied(entry) => Some(entry.clone()),
                                         _ => None,
                                     }
                                 }).collect();

--- a/src/protocol/libp2p/kademlia/query/find_many_nodes.rs
+++ b/src/protocol/libp2p/kademlia/query/find_many_nodes.rs
@@ -27,8 +27,7 @@ use crate::{
 };
 
 /// Context for multiple `FIND_NODE` queries.
-///
-/// TODO: implement https://github.com/paritytech/litep2p/issues/80.
+// TODO: implement https://github.com/paritytech/litep2p/issues/80.
 #[derive(Debug)]
 pub struct FindManyNodesContext {
     /// Query ID.

--- a/src/protocol/libp2p/kademlia/query/find_many_nodes.rs
+++ b/src/protocol/libp2p/kademlia/query/find_many_nodes.rs
@@ -26,27 +26,20 @@ use crate::{
     PeerId,
 };
 
-/// Logging target for the file.
-const LOG_TARGET: &str = "litep2p::ipfs::kademlia::query::find_many_nodes";
-
 /// Context for multiple `FIND_NODE` queries.
 #[derive(Debug)]
 pub struct FindManyNodesContext {
-    /// Local peer ID.
-    local_peer_id: PeerId,
-
     /// Query ID.
     pub query: QueryId,
 
     /// The peers we are looking for.
-    pub peers_to_report: Vec<PeerId>,
+    pub peers_to_report: Vec<KademliaPeer>,
 }
 
 impl FindManyNodesContext {
     /// Creates a new [`FindManyNodesContext`].
-    pub fn new(local_peer_id: PeerId, query: QueryId, peers_to_report: Vec<PeerId>) -> Self {
+    pub fn new(query: QueryId, peers_to_report: Vec<KademliaPeer>) -> Self {
         Self {
-            local_peer_id,
             query,
             peers_to_report,
         }

--- a/src/protocol/libp2p/kademlia/query/find_many_nodes.rs
+++ b/src/protocol/libp2p/kademlia/query/find_many_nodes.rs
@@ -27,6 +27,8 @@ use crate::{
 };
 
 /// Context for multiple `FIND_NODE` queries.
+///
+/// TODO: implement https://github.com/paritytech/litep2p/issues/80.
 #[derive(Debug)]
 pub struct FindManyNodesContext {
     /// Query ID.

--- a/src/protocol/libp2p/kademlia/query/find_many_nodes.rs
+++ b/src/protocol/libp2p/kademlia/query/find_many_nodes.rs
@@ -1,0 +1,70 @@
+// Copyright 2023 litep2p developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use crate::{
+    protocol::libp2p::kademlia::{
+        query::{QueryAction, QueryId},
+        types::KademliaPeer,
+    },
+    PeerId,
+};
+
+/// Logging target for the file.
+const LOG_TARGET: &str = "litep2p::ipfs::kademlia::query::find_many_nodes";
+
+/// Context for multiple `FIND_NODE` queries.
+#[derive(Debug)]
+pub struct FindManyNodesContext {
+    /// Local peer ID.
+    local_peer_id: PeerId,
+
+    /// Query ID.
+    pub query: QueryId,
+
+    /// The peers we are looking for.
+    pub peers_to_report: Vec<PeerId>,
+}
+
+impl FindManyNodesContext {
+    /// Creates a new [`FindManyNodesContext`].
+    pub fn new(local_peer_id: PeerId, query: QueryId, peers_to_report: Vec<PeerId>) -> Self {
+        Self {
+            local_peer_id,
+            query,
+            peers_to_report,
+        }
+    }
+
+    /// Register response failure for `peer`.
+    pub fn register_response_failure(&mut self, _peer: PeerId) {}
+
+    /// Register `FIND_NODE` response from `peer`.
+    pub fn register_response(&mut self, _peer: PeerId, _peers: Vec<KademliaPeer>) {}
+
+    /// Get next action for `peer`.
+    pub fn next_peer_action(&mut self, _peer: &PeerId) -> Option<QueryAction> {
+        None
+    }
+
+    /// Get next action for a `FIND_NODE` query.
+    pub fn next_action(&mut self) -> Option<QueryAction> {
+        return Some(QueryAction::QuerySucceeded { query: self.query });
+    }
+}

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -35,6 +35,7 @@ use std::collections::{HashMap, VecDeque};
 
 mod find_node;
 mod get_record;
+mod find_many_nodes;
 
 /// Logging target for the file.
 const LOG_TARGET: &str = "litep2p::ipfs::kademlia::query";
@@ -56,6 +57,15 @@ enum QueryType {
 
     /// `PUT_VALUE` query.
     PutRecord {
+        /// Record that needs to be stored.
+        record: Record,
+
+        /// Context for the `FIND_NODE` query
+        context: FindNodeContext<RecordKey>,
+    },
+
+    /// `PUT_VALUE` query to specified peers.
+    PutRecordToPeers {
         /// Record that needs to be stored.
         record: Record,
 

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -176,7 +176,7 @@ impl RoutingTable {
         }
     }
 
-    /// Get `limit` closests peers to `target` from the k-buckets.
+    /// Get `limit` closest peers to `target` from the k-buckets.
     pub fn closest<K: Clone>(&mut self, target: Key<K>, limit: usize) -> Vec<KademliaPeer> {
         ClosestBucketsIter::new(self.local_key.distance(&target))
             .map(|index| self.buckets[index.get()].closest_iter(&target))


### PR DESCRIPTION
This PR implements the `put_record_to` and `try_put_record_to` to selectively pick peers to update their records.

The main use-case from substrate would be the following:
- A peer is discovered to have an outdated authority record (needs https://github.com/paritytech/litep2p/pull/76)
- Update the record with the latest authority record available (part of this PR)

This PR provided peers to the engine if the peers are part of the kBucket. The first step of the discovery in substrate motivates this assumption. We can probably do things a bit more optimally since we know the peers part of the kBucket were discovered previously (or currently connected):
- The query starts with a [FindNodeContext](https://github.com/paritytech/litep2p/blob/96e827b54f9f937c6d0489bef6a438b48cf50e58/src/protocol/libp2p/kademlia/query/find_node.rs#L37), which in this case will do a peer discovery as well
- We could implement a `PutNodeContext` which circumvents the need to discover the peers and just forwards a kad `PUT_VALUE` to those peers
We'd have to double check that with libp2p as well (my brief looking over code points to this direction).

To unblock https://github.com/paritytech/polkadot-sdk/pull/3786 we can merge this and then come back with a better / optimal solution for this 

Builds on top of: https://github.com/paritytech/litep2p/pull/76

cc @paritytech/networking  
