### PR TITLE
kad: Limit MemoryStore entries

### DIFF
--- a/src/protocol/libp2p/kademlia/record.rs
+++ b/src/protocol/libp2p/kademlia/record.rs
@@ -104,7 +104,7 @@ impl Record {
     }
 
     /// Checks whether the record is expired w.r.t. the given `Instant`.
-    pub fn _is_expired(&self, now: Instant) -> bool {
+    pub fn is_expired(&self, now: Instant) -> bool {
         self.expires.map_or(false, |t| now >= t)
     }
 }

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -54,8 +54,18 @@ impl MemoryStore {
     }
 
     /// Try to get record from local store for `key`.
-    pub fn get(&self, key: &Key) -> Option<&Record> {
-        self.records.get(key)
+    pub fn get(&mut self, key: &Key) -> Option<&Record> {
+        let is_expired = self
+            .records
+            .get(key)
+            .map_or(false, |record| record.is_expired(std::time::Instant::now()));
+
+        if is_expired {
+            self.records.remove(key);
+            None
+        } else {
+            self.records.get(key)
+        }
     }
 
     /// Store record.

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -67,6 +67,15 @@ impl MemoryStore {
         let len = self.records.len();
         match self.records.entry(record.key.clone()) {
             Entry::Occupied(mut entry) => {
+                // Lean towards the new record.
+                if let (Some(stored_record_ttl), Some(new_record_ttl)) =
+                    (entry.get().expires, record.expires)
+                {
+                    if stored_record_ttl > new_record_ttl {
+                        return;
+                    }
+                }
+
                 entry.insert(record);
             }
 

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -32,6 +32,8 @@ pub enum MemoryStoreEvent {}
 pub struct MemoryStore {
     /// Records.
     records: HashMap<Key, Record>,
+    /// Configuration.
+    config: MemoryStoreConfig,
 }
 
 impl MemoryStore {
@@ -39,6 +41,15 @@ impl MemoryStore {
     pub fn new() -> Self {
         Self {
             records: HashMap::new(),
+            config: MemoryStoreConfig::default(),
+        }
+    }
+
+    /// Create new [`MemoryStore`] with the provided configuration.
+    pub fn with_config(config: MemoryStoreConfig) -> Self {
+        Self {
+            records: HashMap::new(),
+            config,
         }
     }
 
@@ -55,5 +66,22 @@ impl MemoryStore {
     /// Poll next event from the store.
     async fn next_event() -> Option<MemoryStoreEvent> {
         None
+    }
+}
+
+pub struct MemoryStoreConfig {
+    /// Maximum number of records to store.
+    pub max_records: usize,
+
+    /// Maximum size of a record in bytes.
+    pub max_record_size_bytes: usize,
+}
+
+impl Default for MemoryStoreConfig {
+    fn default() -> Self {
+        Self {
+            max_records: 1024,
+            max_record_size_bytes: 1024,
+        }
     }
 }


### PR DESCRIPTION
This PR ensures that the memory store entries are not growing indefinitely, which may cause:
- a memory leak and process being terminated
- using outdated records

The following changes are introduced: 
- records are stored in the memory store iff space is available
  - a record can replace another record iff it outlives the currently stored record
- records are removed from the store if they expire when the record is inspected
- record value must not exceed a sensible number of bytes


cc @dmitry-markin 