### PR TITLE
crypto: Don't panic on unsupported key types

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -100,7 +100,10 @@ impl TryFrom<keys_proto::PublicKey> for PublicKey {
         match key_type {
             keys_proto::KeyType::Ed25519 =>
                 Ok(ed25519::PublicKey::decode(&pubkey.data).map(PublicKey::Ed25519)?),
-            _ => unimplemented!("unsupported key type"),
+            _ => Err(Error::Other(format!(
+                "Unsupported key type: {}",
+                key_type.as_str_name()
+            ))),
         }
     }
 }


### PR DESCRIPTION
This PR ensures that litep2p does not panic when decoding public keys from received TCP noise handshake.

The code operated under the assumption that only the `ed25519` key is valid in the context of Substrate.
However, peers could still use a different key (`rsa` / `ecdsa`) and cause the code to panic.
In those cases, an error is returned which terminates the negotiation handshake.

Discovered during testing a sync node with litep2p backend on kusama as part of https://github.com/paritytech/litep2p/pull/83.

```bash

Version: 1.10.0-cd9d08d6311

   0: sp_panic_handler::set::{{closure}}
   1: std::panicking::rust_panic_with_hook
   2: std::panicking::begin_panic_handler::{{closure}}
   3: std::sys_common::backtrace::__rust_end_short_backtrace
   4: rust_begin_unwind
   5: core::panicking::panic_fmt
   6: <litep2p::crypto::PublicKey as core::convert::TryFrom<litep2p::crypto::keys_proto::PublicKey>>::try_from
   7: litep2p::crypto::PublicKey::from_protobuf_encoding
   8: litep2p::crypto::noise::parse_peer_id
   9: litep2p::transport::tcp::connection::TcpConnection::negotiate_connection::{{closure}}
  10: <tokio::time::timeout::Timeout<T> as core::future::future::Future>::poll
  11: <litep2p::transport::tcp::TcpTransport as litep2p::transport::Transport>::negotiate::{{closure}}
  12: <futures_util::stream::futures_unordered::FuturesUnordered<Fut> as futures_core::stream::Stream>::poll_next
  13: <litep2p::transport::tcp::TcpTransport as futures_core::stream::Stream>::poll_next
  14: <litep2p::transport::manager::TransportContext as futures_core::stream::Stream>::poll_next
  15: litep2p::transport::manager::TransportManager::next::{{closure}}
  16: <tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
  17: <sc_network::litep2p::Litep2pNetworkBackend as sc_network::service::traits::NetworkBackend<B,H>>::run::{{closure}}
  18: sc_service::build_network_future::{{closure}}::{{closure}}::{{closure}}
  19: <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
  20: <sc_service::task_manager::prometheus_future::PrometheusFuture<T> as core::future::future::Future>::poll
  21: <futures_util::future::select::Select<A,B> as core::future::future::Future>::poll
  22: <tracing_futures::Instrumented<T> as core::future::future::Future>::poll
  23: tokio::runtime::park::CachedParkThread::block_on
  24: tokio::runtime::context::runtime::enter_runtime
  25: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
  26: tokio::runtime::task::core::Core<T,S>::poll
  27: tokio::runtime::task::harness::Harness<T,S>::poll
  28: tokio::runtime::blocking::pool::Inner::run
  29: std::sys_common::backtrace::__rust_begin_short_backtrace
  30: core::ops::function::FnOnce::call_once{{vtable.shim}}
  31: std::sys::pal::unix::thread::Thread::new::thread_start
  32: <unknown>
  33: <unknown>


Thread 'tokio-runtime-worker' panicked at 'not implemented: unsupported key type', /home/ubuntu/.cargo/git/checkouts/litep2p-2515ad90543f141a/153d388/src/crypto/mod.rs:103
```

cc @dmitry-markin 