### PR TITLE
ci: Run CI on master and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,16 @@
 name: CI
 
 on:
+  push:
+    # Run jobs when commits are pushed to
+    # master or release-like branches:
+    branches:
+      - master
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # Run jobs for any external PR that wants
+    # to merge to master, too:
+    branches:
+      - master
 
 # Disable previous runs
 concurrency:


### PR DESCRIPTION
This PR also enabled the CI to run on commits pushed to master.
Modified the running behavior on the PRs, to only limit the CI to branches that are ready to be merged on master.

cc @dmitry-markin 