### PR TITLE
kad/store: Set memory-store on an incoming record for PutRecordTo

### DIFF
--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -102,6 +102,9 @@ pub(crate) enum KademliaCommand {
 
         /// Use the following peers for the put request.
         peers: Vec<PeerId>,
+
+        /// Update local store.
+        update_local_store: bool,
     },
 
     /// Get record from DHT.
@@ -222,7 +225,12 @@ impl KademliaHandle {
     }
 
     /// Store record to DHT to the given peers.
-    pub async fn put_record_to_peers(&mut self, record: Record, peers: Vec<PeerId>) -> QueryId {
+    pub async fn put_record_to_peers(
+        &mut self,
+        record: Record,
+        peers: Vec<PeerId>,
+        update_local_store: bool,
+    ) -> QueryId {
         let query_id = self.next_query_id();
         let _ = self
             .cmd_tx
@@ -230,6 +238,7 @@ impl KademliaHandle {
                 record,
                 query_id,
                 peers,
+                update_local_store,
             })
             .await;
 
@@ -282,6 +291,7 @@ impl KademliaHandle {
         &mut self,
         record: Record,
         peers: Vec<PeerId>,
+        update_local_store: bool,
     ) -> Result<QueryId, ()> {
         let query_id = self.next_query_id();
         self.cmd_tx
@@ -289,6 +299,7 @@ impl KademliaHandle {
                 record,
                 query_id,
                 peers,
+                update_local_store,
             })
             .map(|_| query_id)
             .map_err(|_| ())

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -749,10 +749,12 @@ impl Kademlia {
                                 self.routing_table.closest(key, self.replication_factor).into(),
                             );
                         }
-                        Some(KademliaCommand::PutRecordToPeers { record, query_id, peers }) => {
+                        Some(KademliaCommand::PutRecordToPeers { record, query_id, peers, update_local_store }) => {
                             tracing::debug!(target: LOG_TARGET, ?query_id, key = ?record.key, "store record to DHT to specified peers");
 
-                            self.store.put(record.clone());
+                            if update_local_store {
+                                self.store.put(record.clone());
+                            }
 
                             // Put the record to the specified peers.
                             let peers = peers.into_iter().filter_map(|peer| {

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -752,6 +752,8 @@ impl Kademlia {
                         Some(KademliaCommand::PutRecordToPeers { record, query_id, peers }) => {
                             tracing::debug!(target: LOG_TARGET, ?query_id, key = ?record.key, "store record to DHT to specified peers");
 
+                            self.store.put(record.clone());
+
                             // Put the record to the specified peers.
                             let peers = peers.into_iter().filter_map(|peer| {
                                 if peer == self.service.local_peer_id {

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -754,6 +754,10 @@ impl Kademlia {
 
                             // Put the record to the specified peers.
                             let peers = peers.into_iter().filter_map(|peer| {
+                                if peer == self.service.local_peer_id {
+                                    return None;
+                                }
+
                                 match self.routing_table.entry(Key::from(peer)) {
                                     KBucketEntry::Occupied(entry) => Some(entry.clone()),
                                     KBucketEntry::Vacant(entry) if !entry.addresses.is_empty() => Some(entry.clone()),


### PR DESCRIPTION
Small PR to always update the local store on `PutRecordToPeers`.

This is introduced to facilitate the use-case from:
- https://github.com/paritytech/polkadot-sdk/pull/3786/files#diff-5c2ed434b83c3fc3e5b6e2d2bc1895ec870d39e6b77a0f44b3f012694b5a943aR426

Where the `update_local_store` flag is used to optimize kad MemoryStore updates. However, for us this represents a hashmap insert.

While at it, have also filtered out peers that are equal to our local peer ID. 

cc @dmitry-markin 