### PR TITLE
kad: Expose all peer records of `GET_VALUE` query

### DIFF
--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{
-    protocol::libp2p::kademlia::{QueryId, Record, RecordKey},
+    protocol::libp2p::kademlia::{PeerRecord, QueryId, Record, RecordKey},
     PeerId,
 };
 
@@ -28,7 +28,6 @@ use multiaddr::Multiaddr;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use std::{
-    collections::HashMap,
     num::NonZeroUsize,
     pin::Pin,
     task::{Context, Poll},
@@ -183,7 +182,7 @@ pub enum RecordsType {
     LocalStore(Record),
 
     /// Records found in the network.
-    Network(HashMap<Record, Vec<PeerId>>),
+    Network(Vec<PeerRecord>),
 }
 
 /// Handle for communicating with the Kademlia protocol.

--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{
-    protocol::libp2p::kademlia::{PeerRecord, QueryId, Record, RecordKey},
+    protocol::libp2p::kademlia::{QueryId, Record, RecordKey},
     PeerId,
 };
 
@@ -28,6 +28,7 @@ use multiaddr::Multiaddr;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use std::{
+    collections::HashMap,
     num::NonZeroUsize,
     pin::Pin,
     task::{Context, Poll},
@@ -153,8 +154,8 @@ pub enum KademliaEvent {
         /// Query ID.
         query_id: QueryId,
 
-        /// Found record.
-        record: PeerRecord,
+        /// Found records.
+        records: RecordsType,
     },
 
     /// `PUT_VALUE` query succeeded.
@@ -171,6 +172,18 @@ pub enum KademliaEvent {
         /// Query ID.
         query_id: QueryId,
     },
+}
+
+/// The type of the DHT records.
+#[derive(Debug, Clone)]
+pub enum RecordsType {
+    /// Record was found in the local store.
+    ///
+    /// This contains only a single result.
+    LocalStore(Record),
+
+    /// Records found in the network.
+    Network(HashMap<Record, Vec<PeerId>>),
 }
 
 /// Handle for communicating with the Kademlia protocol.

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -52,7 +52,7 @@ pub use handle::{KademliaEvent, KademliaHandle, Quorum, RoutingTableUpdateMode};
 pub use query::QueryId;
 pub use record::{Key as RecordKey, PeerRecord, Record};
 
-use self::handle::RecordsType;
+pub use self::handle::RecordsType;
 
 /// Logging target for the file.
 const LOG_TARGET: &str = "litep2p::ipfs::kademlia";

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -642,10 +642,19 @@ impl Kademlia {
                 // Considering this gives a view of all peers and their records, some peers may have
                 // outdated records. Store only the record which is backed by most
                 // peers.
-                let rec =
-                    records.iter().max_by_key(|(_, peers)| peers.len()).map(|(key, _)| key.clone());
+                let rec = records
+                    .iter()
+                    .map(|peer_record| &peer_record.record)
+                    .fold(HashMap::new(), |mut acc, rec| {
+                        *acc.entry(rec).or_insert(0) += 1;
+                        acc
+                    })
+                    .into_iter()
+                    .max_by_key(|(_, v)| *v)
+                    .map(|(k, _)| k);
+
                 if let Some(record) = rec {
-                    self.store.put(record);
+                    self.store.put(record.clone());
                 }
 
                 let _ = self

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -642,9 +642,16 @@ impl Kademlia {
                 // Considering this gives a view of all peers and their records, some peers may have
                 // outdated records. Store only the record which is backed by most
                 // peers.
+                let now = std::time::Instant::now();
                 let rec = records
                     .iter()
-                    .map(|peer_record| &peer_record.record)
+                    .filter_map(|peer_record| {
+                        if peer_record.record.is_expired(now) {
+                            None
+                        } else {
+                            Some(&peer_record.record)
+                        }
+                    })
                     .fold(HashMap::new(), |mut acc, rec| {
                         *acc.entry(rec).or_insert(0) += 1;
                         acc

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -908,7 +908,7 @@ mod tests {
 
     #[tokio::test]
     async fn check_get_records_update() {
-        let (mut kademlia, _context, _manager) = _make_kademlia();
+        let (mut kademlia, _context, _manager) = make_kademlia();
 
         let key = RecordKey::from(vec![1, 2, 3]);
         let records = vec![

--- a/src/protocol/libp2p/kademlia/query/get_record.rs
+++ b/src/protocol/libp2p/kademlia/query/get_record.rs
@@ -136,9 +136,10 @@ impl GetRecordContext {
             return;
         };
 
-        // TODO: validate record
         if let Some(record) = record {
-            self.found_records.entry(record).or_default().push(peer.peer);
+            if !record.is_expired(std::time::Instant::now()) {
+                self.found_records.entry(record).or_default().push(peer.peer);
+            }
         }
 
         // add the queried peer to `queried` and all new peers which haven't been

--- a/src/protocol/libp2p/kademlia/query/get_record.rs
+++ b/src/protocol/libp2p/kademlia/query/get_record.rs
@@ -66,7 +66,7 @@ pub struct GetRecordContext {
     pub candidates: BTreeMap<Distance, KademliaPeer>,
 
     /// Found records.
-    pub found_records: Vec<PeerRecord>,
+    pub found_records: HashMap<Record, Vec<PeerId>>,
 
     /// Replication factor.
     pub replication_factor: usize,
@@ -105,13 +105,13 @@ impl GetRecordContext {
             parallelism_factor,
             pending: HashMap::new(),
             queried: HashSet::new(),
-            found_records: Vec::new(),
+            found_records: HashMap::new(),
         }
     }
 
-    /// Get the found record.
-    pub fn found_record(mut self) -> PeerRecord {
-        self.found_records.pop().expect("record to exist since query succeeded")
+    /// Get the found records.
+    pub fn found_records(mut self) -> HashMap<Record, Vec<PeerId>> {
+        self.found_records
     }
 
     /// Register response failure for `peer`.
@@ -138,10 +138,7 @@ impl GetRecordContext {
 
         // TODO: validate record
         if let Some(record) = record {
-            self.found_records.push(PeerRecord {
-                record,
-                peer: Some(peer.peer),
-            });
+            self.found_records.entry(record).or_default().push(peer.peer);
         }
 
         // add the queried peer to `queried` and all new peers which haven't been

--- a/src/protocol/libp2p/kademlia/query/get_record.rs
+++ b/src/protocol/libp2p/kademlia/query/get_record.rs
@@ -66,7 +66,7 @@ pub struct GetRecordContext {
     pub candidates: BTreeMap<Distance, KademliaPeer>,
 
     /// Found records.
-    pub found_records: HashMap<Record, Vec<PeerId>>,
+    pub found_records: Vec<PeerRecord>,
 
     /// Replication factor.
     pub replication_factor: usize,
@@ -105,12 +105,12 @@ impl GetRecordContext {
             parallelism_factor,
             pending: HashMap::new(),
             queried: HashSet::new(),
-            found_records: HashMap::new(),
+            found_records: Vec::new(),
         }
     }
 
     /// Get the found records.
-    pub fn found_records(mut self) -> HashMap<Record, Vec<PeerId>> {
+    pub fn found_records(mut self) -> Vec<PeerRecord> {
         self.found_records
     }
 
@@ -138,7 +138,10 @@ impl GetRecordContext {
 
         if let Some(record) = record {
             if !record.is_expired(std::time::Instant::now()) {
-                self.found_records.entry(record).or_default().push(peer.peer);
+                self.found_records.push(PeerRecord {
+                    peer: peer.peer,
+                    record,
+                });
             }
         }
 

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     protocol::libp2p::kademlia::{
         message::KademliaMessage,
         query::{find_node::FindNodeContext, get_record::GetRecordContext},
-        record::{Key as RecordKey, PeerRecord, Record},
+        record::{Key as RecordKey, Record},
         types::{KademliaPeer, Key},
         Quorum,
     },
@@ -400,7 +400,7 @@ impl QueryEngine {
             },
             QueryType::GetRecord { context } => QueryAction::GetRecordQueryDone {
                 query_id: context.query,
-                record: context.found_record(),
+                records: context.found_records(),
             },
         }
     }

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -124,8 +124,12 @@ pub enum QueryAction {
         /// Query ID.
         query_id: QueryId,
 
-        /// Found record.
-        record: PeerRecord,
+        /// Found records.
+        ///
+        /// Note: records that do not have any peers associated with them are received from the
+        /// local store. For those cases, the records will contain only the record from the local
+        /// store.
+        records: HashMap<Record, Vec<PeerId>>,
     },
 
     // TODO: remove

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -752,10 +752,21 @@ mod tests {
 
         let peers: std::collections::HashSet<_> = peers.into_iter().map(|p| p.peer).collect();
         match engine.next_action() {
-            Some(QueryAction::GetRecordQueryDone { record, .. }) => {
-                assert!(peers.contains(&record.peer.expect("Peer Id must be provided")));
-                assert_eq!(record.record.key, original_record.key);
-                assert_eq!(record.record.value, original_record.value);
+            Some(QueryAction::GetRecordQueryDone { records, .. }) => {
+                let query_peers = records
+                    .iter()
+                    .flat_map(|(_, peers)| peers)
+                    .cloned()
+                    .collect::<std::collections::HashSet<_>>();
+                assert_eq!(peers, query_peers);
+
+                let records = records.keys().collect::<Vec<_>>();
+                // One single record found across peers.
+                assert_eq!(records.len(), 1);
+                let record = records[0];
+
+                assert_eq!(record.key, original_record.key);
+                assert_eq!(record.value, original_record.value);
             }
             _ => panic!("invalid event received"),
         }

--- a/src/protocol/libp2p/kademlia/record.rs
+++ b/src/protocol/libp2p/kademlia/record.rs
@@ -74,7 +74,7 @@ impl From<Multihash> for Key {
 }
 
 /// A record stored in the DHT.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Record {
     /// Key of the record.
     pub key: Key,

--- a/src/protocol/libp2p/kademlia/record.rs
+++ b/src/protocol/libp2p/kademlia/record.rs
@@ -109,13 +109,12 @@ impl Record {
     }
 }
 
-/// A record either received by the given peer or retrieved from the local
-/// record store.
+/// A record received by the given peer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PeerRecord {
-    /// The peer from whom the record was received. `None` if the record was
-    /// retrieved from local storage.
-    pub peer: Option<PeerId>,
+    /// The peer from whom the record was received
+    pub peer: PeerId,
 
+    /// The provided record.
     pub record: Record,
 }


### PR DESCRIPTION
This PR extends the `GetRecordSucess` variant of kad queries to provide all the query information.
Previously, only the last stored query record was returned to the user.

In the libp2p crate, an event is generated for every found record. However, litep2p responds only when the query finishes.
Records are extended to offer similar information back to the user while sending a minimum number of events.

- A new `RecordsType` is introduced to avoid confusion about records extracted from the local store and records found on the network
- We save the record backed by the most number of peers in our local store
- A panic is removed from the `kad/query` since we now operate with a multitude of records and potentially none
- Expired records are now ignored




cc @paritytech/networking 