### PR TITLE
kad: Refactor FindNode query, keep K best results and add tests

### DIFF
--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -243,4 +243,26 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
     }
 }
 
-// TODO: tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> FindNodeConfig<Vec<u8>> {
+        FindNodeConfig {
+            local_peer_id: PeerId::random(),
+            replication_factor: 20,
+            parallelism_factor: 10,
+            query: QueryId(0),
+            target: Key::new(vec![1, 2, 3].into()),
+        }
+    }
+
+    #[test]
+    fn completes_when_no_candidates() {
+        let config = default_config();
+        let mut context = FindNodeContext::new(config, VecDeque::new());
+        assert!(context.is_done());
+        let event = context.next_action().unwrap();
+        assert_eq!(event, QueryAction::QueryFailed { query: QueryId(0) });
+    }
+}

--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -137,11 +137,10 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
 
             // The response received from the peer is closer than the furthest response.
             if distance < furthest_distance {
-                // Update the entries only if the distance is not already present.
-                if !self.responses.contains_key(&distance) {
-                    self.responses.insert(distance, peer);
+                self.responses.insert(distance, peer);
 
-                    // Remove the furthest entry.
+                // Remove the furthest entry.
+                if self.responses.len() > self.config.replication_factor {
                     self.responses.pop_last();
                 }
             }

--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -444,8 +444,6 @@ mod tests {
     fn offers_closest_responses_with_better_candidates() {
         let (closest, furthest, config) = setup_closest_responses();
 
-        println!("Closest: {:?}, Furthest: {:?}", closest, furthest);
-
         // Scenario where the query is fulfilled however it continues because
         // there is a closer peer to query.
         let in_peers = vec![peer_to_kad(furthest)];
@@ -483,6 +481,11 @@ mod tests {
             _ => panic!("Unexpected event"),
         }
 
+        // Even if we have the total number of responses, we have at least one
+        // inflight query which might be closer to the target.
+        assert!(context.next_action().is_none());
+
+        // Query finishes when receiving the response back.
         context.register_response(closest, vec![]);
 
         let event = context.next_action().unwrap();

--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -131,9 +131,18 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
             self.responses.insert(distance, peer);
         } else {
             // Update the furthest peer if this response is closer.
-            if let Some(mut entry) = self.responses.last_entry() {
-                if entry.key() > &distance {
-                    entry.insert(peer);
+            // Find the furthest distance.
+            let furthest_distance =
+                self.responses.last_entry().map(|entry| *entry.key()).unwrap_or(distance);
+
+            // The response received from the peer is closer than the furthest response.
+            if distance < furthest_distance {
+                // Update the entries only if the distance is not already present.
+                if !self.responses.contains_key(&distance) {
+                    self.responses.insert(distance, peer);
+
+                    // Remove the furthest entry.
+                    self.responses.pop_last();
                 }
             }
         }

--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -32,17 +32,30 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 /// Logging target for the file.
 const LOG_TARGET: &str = "litep2p::ipfs::kademlia::query::find_node";
 
-/// Context for `FIND_NODE` queries.
+/// The configuration needed to instantiate a new [`FindNodeContext`].
 #[derive(Debug)]
-pub struct FindNodeContext<T: Clone + Into<Vec<u8>>> {
+pub struct FindNodeConfig<T: Clone + Into<Vec<u8>>> {
     /// Local peer ID.
-    local_peer_id: PeerId,
+    pub local_peer_id: PeerId,
+
+    /// Replication factor.
+    pub replication_factor: usize,
+
+    /// Parallelism factor.
+    pub parallelism_factor: usize,
 
     /// Query ID.
     pub query: QueryId,
 
     /// Target key.
     pub target: Key<T>,
+}
+
+/// Context for `FIND_NODE` queries.
+#[derive(Debug)]
+pub struct FindNodeContext<T: Clone + Into<Vec<u8>>> {
+    /// Query immutable config.
+    pub config: FindNodeConfig<T>,
 
     /// Peers from whom the `QueryEngine` is waiting to hear a response.
     pub pending: HashMap<PeerId, KademliaPeer>,
@@ -58,41 +71,25 @@ pub struct FindNodeContext<T: Clone + Into<Vec<u8>>> {
 
     /// Responses.
     pub responses: BTreeMap<Distance, KademliaPeer>,
-
-    /// Replication factor.
-    pub replication_factor: usize,
-
-    /// Parallelism factor.
-    pub parallelism_factor: usize,
 }
 
 impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
     /// Create new [`FindNodeContext`].
-    pub fn new(
-        local_peer_id: PeerId,
-        query: QueryId,
-        target: Key<T>,
-        in_peers: VecDeque<KademliaPeer>,
-        replication_factor: usize,
-        parallelism_factor: usize,
-    ) -> Self {
+    pub fn new(config: FindNodeConfig<T>, in_peers: VecDeque<KademliaPeer>) -> Self {
         let mut candidates = BTreeMap::new();
 
         for candidate in &in_peers {
-            let distance = target.distance(&candidate.key);
+            let distance = config.target.distance(&candidate.key);
             candidates.insert(distance, candidate.clone());
         }
 
         Self {
-            query,
-            target,
+            config,
+
             candidates,
-            local_peer_id,
             pending: HashMap::new(),
             queried: HashSet::new(),
             responses: BTreeMap::new(),
-            replication_factor,
-            parallelism_factor,
         }
     }
 
@@ -117,14 +114,14 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
         // calculate distance for `peer` from target and insert it if
         //  a) the map doesn't have 20 responses
         //  b) it can replace some other peer that has a higher distance
-        let distance = self.target.distance(&peer.key);
+        let distance = self.config.target.distance(&peer.key);
 
         // always mark the peer as queried to prevent it getting queried again
         self.queried.insert(peer.peer);
 
         // TODO: could this be written in another way?
         // TODO: only insert nodes from whom a response was received
-        match self.responses.len() < self.replication_factor {
+        match self.responses.len() < self.config.replication_factor {
             true => {
                 self.responses.insert(distance, peer);
             }
@@ -141,11 +138,11 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
             if !self.queried.contains(&candidate.peer)
                 && !self.pending.contains_key(&candidate.peer)
             {
-                if self.local_peer_id == candidate.peer {
+                if self.config.local_peer_id == candidate.peer {
                     continue;
                 }
 
-                let distance = self.target.distance(&candidate.key);
+                let distance = self.config.target.distance(&candidate.key);
                 self.candidates.insert(distance, candidate);
             }
         }
@@ -154,23 +151,23 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
     /// Get next action for `peer`.
     pub fn next_peer_action(&mut self, peer: &PeerId) -> Option<QueryAction> {
         self.pending.contains_key(peer).then_some(QueryAction::SendMessage {
-            query: self.query,
+            query: self.config.query,
             peer: *peer,
-            message: KademliaMessage::find_node(self.target.clone().into_preimage()),
+            message: KademliaMessage::find_node(self.config.target.clone().into_preimage()),
         })
     }
 
     /// Schedule next peer for outbound `FIND_NODE` query.
     pub fn schedule_next_peer(&mut self) -> QueryAction {
-        tracing::trace!(target: LOG_TARGET, query = ?self.query, "get next peer");
+        tracing::trace!(target: LOG_TARGET, query = ?self.config.query, "get next peer");
 
         let (_, candidate) = self.candidates.pop_first().expect("entry to exist");
         self.pending.insert(candidate.peer, candidate.clone());
 
         QueryAction::SendMessage {
-            query: self.query,
+            query: self.config.query,
             peer: candidate.peer,
-            message: KademliaMessage::find_node(self.target.clone().into_preimage()),
+            message: KademliaMessage::find_node(self.config.target.clone().into_preimage()),
         }
     }
 
@@ -179,14 +176,16 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
     pub fn next_action(&mut self) -> Option<QueryAction> {
         // we didn't receive any responses and there are no candidates or pending queries left.
         if self.responses.is_empty() && self.pending.is_empty() && self.candidates.is_empty() {
-            return Some(QueryAction::QueryFailed { query: self.query });
+            return Some(QueryAction::QueryFailed {
+                query: self.config.query,
+            });
         }
 
         // there are still possible peers to query or peers who are being queried
-        if self.responses.len() < self.replication_factor
+        if self.responses.len() < self.config.replication_factor
             && (!self.pending.is_empty() || !self.candidates.is_empty())
         {
-            if self.pending.len() == self.parallelism_factor || self.candidates.is_empty() {
+            if self.pending.len() == self.config.parallelism_factor || self.candidates.is_empty() {
                 return None;
             }
 
@@ -195,7 +194,9 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
 
         // query succeeded with one or more results
         if self.pending.is_empty() && self.candidates.is_empty() {
-            return Some(QueryAction::QuerySucceeded { query: self.query });
+            return Some(QueryAction::QuerySucceeded {
+                query: self.config.query,
+            });
         }
 
         // check if any candidate has lower distance thant the current worst
@@ -203,22 +204,27 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
         // entries
         if !self.candidates.is_empty() {
             let first_candidate_distance = self
+                .config
                 .target
                 .distance(&self.candidates.first_key_value().expect("candidate to exist").1.key);
             let worst_response_candidate =
                 *self.responses.last_entry().expect("response to exist").key();
 
             if first_candidate_distance < worst_response_candidate
-                && self.pending.len() < self.parallelism_factor
+                && self.pending.len() < self.config.parallelism_factor
             {
                 return Some(self.schedule_next_peer());
             }
 
-            return Some(QueryAction::QuerySucceeded { query: self.query });
+            return Some(QueryAction::QuerySucceeded {
+                query: self.config.query,
+            });
         }
 
-        if self.responses.len() == self.replication_factor {
-            return Some(QueryAction::QuerySucceeded { query: self.query });
+        if self.responses.len() == self.config.replication_factor {
+            return Some(QueryAction::QuerySucceeded {
+                query: self.config.query,
+            });
         }
 
         tracing::error!(

--- a/src/protocol/libp2p/kademlia/query/get_record.rs
+++ b/src/protocol/libp2p/kademlia/query/get_record.rs
@@ -85,7 +85,7 @@ pub struct GetRecordContext {
     /// Query immutable config.
     pub config: GetRecordConfig,
 
-    /// Cached Kadmelia message to send.
+    /// Cached Kademlia message to send.
     kad_message: Bytes,
 
     /// Peers from whom the `QueryEngine` is waiting to hear a response.


### PR DESCRIPTION
This PR refactors the FindNode query to make it more robust.
 - Avoid panics on unwraps and unimplemented logic
 - Separate config immutable variables from main query logic
 - Simplifies logic of next_action method
 - Private methods for internal logic

It also fixes a bug where only the last peer ID of our results was updated.
- we were registering the first 20 (repl factor) responses
- whenever we got a new response (better) we tried to update just the peerID_ of the last entry

This had a few implications:
- the first 19 entries are never updated with a better (closer) peer
- the distance of the last entry was never updated. And because of this, we might end up in a situation where the record is updated with a furthest distance

```rust
// Presume: 
last_entry: distance = 10, peer = A

// Registering a new response
new_response: distance = 2, peer = B
-> last entry: distance = 10, peer = B

// Registering a new response
new_response: distance = 7, peer = C
-> last entry: distance = 10, peer = C

// we should've kept B as best
```

### Testing Done
- Completes if there's no further candidate to query
- Fulfill number of parallel queries
- Completes on the number of responses
- Provides the closest response out of the batch
- Provides the closest response when the closest peer is indirectly found and K factor is already fulfilled

Closes https://github.com/paritytech/litep2p/issues/100

cc @paritytech/networking 