### PR TITLE
Release 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,7 +2881,7 @@ checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "litep2p"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,7 +2881,7 @@ checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "litep2p"
-version = "0.4.0-rc.1"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.3.0"
+version = "0.4.0-rc.1"
 edition = "2021"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.4.0-rc.1"
+version = "0.4.0"
 edition = "2021"
 
 [build-dependencies]


### PR DESCRIPTION
Had to do a release for the [SDK](https://github.com/paritytech/polkadot-sdk/pull/4560) to unblock the release. Tag `v0.4.0` is pushed.

Changes:
- **Bump to 0.4.0**
