### PR TITLE
chore: Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.1] - 2023-05-24
+## [0.5.0] - 2023-05-24
 
-This is a small patch release that makes the `FindNode` command a bit more robst:
+This is a small release that makes the `FindNode` command a bit more robust:
 
 - The `FindNode` command now retains the K (replication factor) best results.
 - The `FindNode` command has been updated to handle errors and unexpected states without panicking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This is a small patch release that makes the `FindNode` command a bit more robst
 - The `FindNode` command now retains the K (replication factor) best results.
 - The `FindNode` command has been updated to handle errors and unexpected states without panicking.
 
+### Added
+
+- Add release checklist  ([#115](https://github.com/paritytech/litep2p/pull/115))
+
 ### Changed
 
 - kad: Refactor FindNode query, keep K best results and add tests  ([#114](https://github.com/paritytech/litep2p/pull/114))
@@ -32,7 +36,6 @@ Additionally, we've improved code coverage in the `kad` module by adding more te
 
 ### Added
 
-- Add release checklist  ([#115](https://github.com/paritytech/litep2p/pull/115))
 - Re-export `multihash` & `multiaddr` types  ([#79](https://github.com/paritytech/litep2p/pull/79))
 - kad: Expose all peer records of `GET_VALUE` query  ([#96](https://github.com/paritytech/litep2p/pull/96))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.1] - 2023-05-25
+## [0.4.1] - 2023-05-24
 
 This is a small patch release that makes the `FindNode` command a bit more robst:
 
@@ -16,7 +16,7 @@ This is a small patch release that makes the `FindNode` command a bit more robst
 
 - kad: Refactor FindNode query, keep K best results and add tests  ([#114](https://github.com/paritytech/litep2p/pull/114))
 
-## [0.4.0] - 2023-05-24
+## [0.4.0] - 2023-05-23
 
 This release introduces breaking changes to the litep2p crate, primarily affecting the `kad` module. Key updates include:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2023-05-25
+
+This is a small patch release that makes the `FindNode` command a bit more robst:
+
+- The `FindNode` command now retains the K (replication factor) best results.
+- The `FindNode` command has been updated to handle errors and unexpected states without panicking.
+
+### Changed
+
+- kad: Refactor FindNode query, keep K best results and add tests  ([#114](https://github.com/paritytech/litep2p/pull/114))
+
 ## [0.4.0] - 2023-05-24
 
 This release introduces breaking changes to the litep2p crate, primarily affecting the `kad` module. Key updates include:
@@ -14,10 +25,8 @@ This release introduces breaking changes to the litep2p crate, primarily affecti
 
 Significant refactoring has been done to enhance the efficiency and accuracy of the `kad` module. The updates are as follows:
 
-- The `FindNode` command now retains the K (replication factor) best results.
 - The `GetRecord` command now exposes all peer records.
-- Both `FindNode` and `GetRecord` commands have been updated to handle errors and unexpected states without panicking.
-- Both commands now accept a configuration parameter for cleaner instantiation.
+- The `GetRecord` command has been updated to handle errors and unexpected states without panicking.
 
 Additionally, we've improved code coverage in the `kad` module by adding more tests.
 
@@ -29,7 +38,6 @@ Additionally, we've improved code coverage in the `kad` module by adding more te
 
 ### Changed
 
-- kad: Refactor FindNode query, keep K best results and add tests  ([#114](https://github.com/paritytech/litep2p/pull/114))
 - multistream_select: Remove unneeded changelog.md  ([#116](https://github.com/paritytech/litep2p/pull/116))
 - kad: Refactor `GetRecord` query and add tests  ([#97](https://github.com/paritytech/litep2p/pull/97))
 - kad/store: Set memory-store on an incoming record for PutRecordTo  ([#88](https://github.com/paritytech/litep2p/pull/88))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2023-05-24
+
+This release introduces breaking changes to the litep2p crate, primarily affecting the `kad` module. Key updates include:
+
+- The `GetRecord` command now exposes all peer records, not just the latest one.
+- A new `RecordType` has been introduced to clearly distinguish between locally stored records and those discovered from the network.
+
+Significant refactoring has been done to enhance the efficiency and accuracy of the `kad` module. The updates are as follows:
+
+- The `FindNode` command now retains the K (replication factor) best results.
+- The `GetRecord` command now exposes all peer records.
+- Both `FindNode` and `GetRecord` commands have been updated to handle errors and unexpected states without panicking.
+- Both commands now accept a configuration parameter for cleaner instantiation.
+
+Additionally, we've improved code coverage in the `kad` module by adding more tests.
+
+### Added
+
+- Add release checklist  ([#115](https://github.com/paritytech/litep2p/pull/115))
+
+### Changed
+
+- kad: Refactor FindNode query, keep K best results and add tests  ([#114](https://github.com/paritytech/litep2p/pull/114))
+- multistream_select: Remove unneeded changelog.md  ([#116](https://github.com/paritytech/litep2p/pull/116))
+- kad: Refactor `GetRecord` query and add tests  ([#97](https://github.com/paritytech/litep2p/pull/97))
+- kad: Expose all peer records of `GET_VALUE` query  ([#96](https://github.com/paritytech/litep2p/pull/96))
+- kad/store: Set memory-store on an incoming record for PutRecordTo  ([#88](https://github.com/paritytech/litep2p/pull/88))
+- multistream: Dialer deny multiple /multistream/1.0.0 headers  ([#61](https://github.com/paritytech/litep2p/pull/61))
+- Re-export `multihash` & `multiaddr` types  ([#79](https://github.com/paritytech/litep2p/pull/79))
+- kad: Limit MemoryStore entries  ([#78](https://github.com/paritytech/litep2p/pull/78))
+- Refactor WebRTC code  ([#51](https://github.com/paritytech/litep2p/pull/51))
+- Revert "Bring `rustfmt.toml` in sync with polkadot-sdk (#71)"  ([#74](https://github.com/paritytech/litep2p/pull/74))
+
+### Fixed
+
+- Fix clippy  ([#83](https://github.com/paritytech/litep2p/pull/83))
+- crypto: Don't panic on unsupported key types  ([#84](https://github.com/paritytech/litep2p/pull/84))
+
 ## [0.3.0] - 2023-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,20 @@ Additionally, we've improved code coverage in the `kad` module by adding more te
 ### Added
 
 - Add release checklist  ([#115](https://github.com/paritytech/litep2p/pull/115))
+- Re-export `multihash` & `multiaddr` types  ([#79](https://github.com/paritytech/litep2p/pull/79))
+- kad: Expose all peer records of `GET_VALUE` query  ([#96](https://github.com/paritytech/litep2p/pull/96))
 
 ### Changed
 
 - kad: Refactor FindNode query, keep K best results and add tests  ([#114](https://github.com/paritytech/litep2p/pull/114))
 - multistream_select: Remove unneeded changelog.md  ([#116](https://github.com/paritytech/litep2p/pull/116))
 - kad: Refactor `GetRecord` query and add tests  ([#97](https://github.com/paritytech/litep2p/pull/97))
-- kad: Expose all peer records of `GET_VALUE` query  ([#96](https://github.com/paritytech/litep2p/pull/96))
 - kad/store: Set memory-store on an incoming record for PutRecordTo  ([#88](https://github.com/paritytech/litep2p/pull/88))
 - multistream: Dialer deny multiple /multistream/1.0.0 headers  ([#61](https://github.com/paritytech/litep2p/pull/61))
-- Re-export `multihash` & `multiaddr` types  ([#79](https://github.com/paritytech/litep2p/pull/79))
 - kad: Limit MemoryStore entries  ([#78](https://github.com/paritytech/litep2p/pull/78))
 - Refactor WebRTC code  ([#51](https://github.com/paritytech/litep2p/pull/51))
 - Revert "Bring `rustfmt.toml` in sync with polkadot-sdk (#71)"  ([#74](https://github.com/paritytech/litep2p/pull/74))
+- cargo: Update str0m from 0.4.1 to 0.5.1  ([#95](https://github.com/paritytech/litep2p/pull/95))
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "litep2p"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "litep2p"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "litep2p"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [build-dependencies]


### PR DESCRIPTION
## [0.5.0] - 2023-05-24

This is a small patch release that makes the `FindNode` command a bit more robst:

- The `FindNode` command now retains the K (replication factor) best results.
- The `FindNode` command has been updated to handle errors and unexpected states without panicking.

### Changed

- kad: Refactor FindNode query, keep K best results and add tests  ([#114](https://github.com/paritytech/litep2p/pull/114))

## [0.4.0] - 2023-05-23

This release introduces breaking changes to the litep2p crate, primarily affecting the `kad` module. Key updates include:

- The `GetRecord` command now exposes all peer records, not just the latest one.
- A new `RecordType` has been introduced to clearly distinguish between locally stored records and those discovered from the network.

Significant refactoring has been done to enhance the efficiency and accuracy of the `kad` module. The updates are as follows:

- The `GetRecord` command now exposes all peer records.
- The `GetRecord` command has been updated to handle errors and unexpected states without panicking.

Additionally, we've improved code coverage in the `kad` module by adding more tests.

### Added

- Add release checklist  ([#115](https://github.com/paritytech/litep2p/pull/115))
- Re-export `multihash` & `multiaddr` types  ([#79](https://github.com/paritytech/litep2p/pull/79))
- kad: Expose all peer records of `GET_VALUE` query  ([#96](https://github.com/paritytech/litep2p/pull/96))

### Changed

- multistream_select: Remove unneeded changelog.md  ([#116](https://github.com/paritytech/litep2p/pull/116))
- kad: Refactor `GetRecord` query and add tests  ([#97](https://github.com/paritytech/litep2p/pull/97))
- kad/store: Set memory-store on an incoming record for PutRecordTo  ([#88](https://github.com/paritytech/litep2p/pull/88))
- multistream: Dialer deny multiple /multistream/1.0.0 headers  ([#61](https://github.com/paritytech/litep2p/pull/61))
- kad: Limit MemoryStore entries  ([#78](https://github.com/paritytech/litep2p/pull/78))
- Refactor WebRTC code  ([#51](https://github.com/paritytech/litep2p/pull/51))
- Revert "Bring `rustfmt.toml` in sync with polkadot-sdk (#71)"  ([#74](https://github.com/paritytech/litep2p/pull/74))
- cargo: Update str0m from 0.4.1 to 0.5.1  ([#95](https://github.com/paritytech/litep2p/pull/95))

### Fixed

- Fix clippy  ([#83](https://github.com/paritytech/litep2p/pull/83))
- crypto: Don't panic on unsupported key types  ([#84](https://github.com/paritytech/litep2p/pull/84))