### PR TITLE
ping: Make ping fault tolerant wrt outbound substreams races

### DIFF
--- a/src/protocol/libp2p/ping/mod.rs
+++ b/src/protocol/libp2p/ping/mod.rs
@@ -197,7 +197,11 @@ impl Ping {
                                     self.on_outbound_substream(peer, substream_id, substream);
                                 }
                                 None => {
-                                    todo!("substream {substream_id:?} does not exist");
+                                    tracing::warn!(
+                                        target: LOG_TARGET,
+                                        ?substream_id,
+                                        "outbound ping substream ID does not exist",
+                                    );
                                 }
                             }
                         }


### PR DESCRIPTION
We have discovered a race between the TransportService and Protocol interface.

This issue was first seen on the identify protocol:
- https://github.com/paritytech/litep2p/issues/103

After looking a bit closely into it, indeed there might be a chance for the following to happen:
- T0: Transport service sends `TransportEvent::ConnectionEstablished` and `TransportEvent::SubstreamOpened` 
- T1: The peer disconnects
- T2: Ping protocol receives an `TransportEvent::ConnectionEstablished` event for a disconnected peer
- T3: `Ping::on_connection_established` fails to open a substream and `pending_open` is never populated
- T4: Ping protocol receives an `TransportEvent::SubstreamOpened` event which would have panicked litep2p

This PR replaces the `todo!` in case of the race with a warning, and we'll no longer panic.

It is still good to capture those as warnings for visibility, even if there's no implied side-effect on our code.
