### PR TITLE
transport/common: Share DNS lookups between TCP and WebSocket

### DIFF
--- a/src/transport/common/listener.rs
+++ b/src/transport/common/listener.rs
@@ -59,7 +59,7 @@ pub enum AddressType {
 
 impl AddressType {
     /// Resolve the address to a concrete IP.
-    async fn lookup_ip(self) -> crate::Result<SocketAddr> {
+    pub async fn lookup_ip(self) -> crate::Result<SocketAddr> {
         let (url, port, is_dns6) = match self {
             // We already have the IP address.
             AddressType::Socket(address) => return Ok(address),

--- a/src/transport/tcp/connection.rs
+++ b/src/transport/tcp/connection.rs
@@ -455,7 +455,7 @@ impl TcpConnection {
             AddressType::Socket(address) => Multiaddr::empty()
                 .with(Protocol::from(address.ip()))
                 .with(Protocol::Tcp(address.port())),
-            AddressType::Dns(address, port) => Multiaddr::empty()
+            AddressType::Dns { address, port, .. } => Multiaddr::empty()
                 .with(Protocol::Dns(Cow::Owned(address)))
                 .with(Protocol::Tcp(port)),
         };


### PR DESCRIPTION
Move the dns resolving to a dedicated common module and return specific errors on failures. 

Part of: https://github.com/paritytech/litep2p/issues/70