### PR TITLE
kad: Set default ttl 36h for kad records

### DIFF
--- a/tests/protocol/kademlia.rs
+++ b/tests/protocol/kademlia.rs
@@ -231,7 +231,7 @@ async fn records_are_stored_manually() {
         .await;
 
     // Publish the record.
-    let record = Record::new(vec![1, 2, 3], vec![0x01]);
+    let mut record = Record::new(vec![1, 2, 3], vec![0x01]);
     kad_handle1.put_record(record.clone()).await;
 
     loop {
@@ -246,6 +246,7 @@ async fn records_are_stored_manually() {
                 match event {
                     Some(KademliaEvent::IncomingRecord { record: got_record }) => {
                         assert_eq!(got_record, record);
+                        assert!(got_record.expires.is_none());
                         kad_handle2.store_record(got_record).await;
 
                         // Check if the record was stored.
@@ -255,6 +256,8 @@ async fn records_are_stored_manually() {
                     Some(KademliaEvent::GetRecordSuccess { query_id: _, records }) => {
                         match records {
                             RecordsType::LocalStore(got_record) => {
+                                assert!(got_record.expires.is_some());
+                                record.expires = got_record.expires;
                                 assert_eq!(got_record, record);
                                 break
                             }


### PR DESCRIPTION
This PR introduces a default TTL for records.
- the default is set to 36h if the record ttl is unspecified
- this ensures the local memory store is not polluted with records without TTL

Part of: https://github.com/paritytech/litep2p/issues/129