### PR TITLE
transport: Allow manual setting of keep-alive timeout

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     transport::{
         manager::limits::ConnectionLimitsConfig, tcp::config::Config as TcpConfig,
-        MAX_PARALLEL_DIALS,
+        KEEP_ALIVE_TIMEOUT, MAX_PARALLEL_DIALS,
     },
     types::protocol::ProtocolName,
     PeerId,
@@ -156,7 +156,7 @@ impl ConfigBuilder {
             request_response_protocols: HashMap::new(),
             known_addresses: Vec::new(),
             connection_limits: ConnectionLimitsConfig::default(),
-            keep_alive_timeout: Duration::from_secs(5),
+            keep_alive_timeout: KEEP_ALIVE_TIMEOUT,
         }
     }
 
@@ -273,7 +273,7 @@ impl ConfigBuilder {
     }
 
     /// Set keep alive timeout for connections.
-    pub fn set_keep_alive_timeout(mut self, timeout: Duration) -> Self {
+    pub fn with_keep_alive_timeout(mut self, timeout: Duration) -> Self {
         self.keep_alive_timeout = timeout;
         self
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,7 @@ use crate::transport::websocket::config::Config as WebSocketConfig;
 
 use multiaddr::Multiaddr;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 /// Connection role.
 #[derive(Debug, Copy, Clone)]
@@ -121,6 +121,9 @@ pub struct ConfigBuilder {
 
     /// Connection limits config.
     connection_limits: ConnectionLimitsConfig,
+
+    /// Close the connection if no substreams are open within this time frame.
+    keep_alive_timeout: Duration,
 }
 
 impl Default for ConfigBuilder {
@@ -153,6 +156,7 @@ impl ConfigBuilder {
             request_response_protocols: HashMap::new(),
             known_addresses: Vec::new(),
             connection_limits: ConnectionLimitsConfig::default(),
+            keep_alive_timeout: Duration::from_secs(5),
         }
     }
 
@@ -268,6 +272,12 @@ impl ConfigBuilder {
         self
     }
 
+    /// Set keep alive timeout for connections.
+    pub fn set_keep_alive_timeout(mut self, timeout: Duration) -> Self {
+        self.keep_alive_timeout = timeout;
+        self
+    }
+
     /// Build [`Litep2pConfig`].
     pub fn build(mut self) -> Litep2pConfig {
         let keypair = match self.keypair {
@@ -296,6 +306,7 @@ impl ConfigBuilder {
             request_response_protocols: self.request_response_protocols,
             known_addresses: self.known_addresses,
             connection_limits: self.connection_limits,
+            keep_alive_timeout: self.keep_alive_timeout,
         }
     }
 }
@@ -355,4 +366,7 @@ pub struct Litep2pConfig {
 
     /// Connection limits config.
     pub(crate) connection_limits: ConnectionLimitsConfig,
+
+    /// Close the connection if no substreams are open within this time frame.
+    pub(crate) keep_alive_timeout: Duration,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use multihash::Multihash;
 use transport::Endpoint;
 use types::ConnectionId;
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 pub use bandwidth::BandwidthSink;
 pub use error::Error;
@@ -171,6 +171,7 @@ impl Litep2p {
                 protocol,
                 config.fallback_names.clone(),
                 config.codec,
+                Duration::from_secs(5),
             );
             let executor = Arc::clone(&litep2p_config.executor);
             litep2p_config.executor.run(Box::pin(async move {
@@ -190,6 +191,7 @@ impl Litep2p {
                 protocol,
                 config.fallback_names.clone(),
                 config.codec,
+                config.timeout,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 RequestResponseProtocol::new(service, config).run().await
@@ -200,8 +202,12 @@ impl Litep2p {
         for (protocol_name, protocol) in litep2p_config.user_protocols.into_iter() {
             tracing::debug!(target: LOG_TARGET, protocol = ?protocol_name, "enable user protocol");
 
-            let service =
-                transport_manager.register_protocol(protocol_name, Vec::new(), protocol.codec());
+            let service = transport_manager.register_protocol(
+                protocol_name,
+                Vec::new(),
+                protocol.codec(),
+                Duration::from_secs(5),
+            );
             litep2p_config.executor.run(Box::pin(async move {
                 let _ = protocol.run(service).await;
             }));
@@ -219,6 +225,7 @@ impl Litep2p {
                 ping_config.protocol.clone(),
                 Vec::new(),
                 ping_config.codec,
+                Duration::from_secs(5),
             );
             litep2p_config.executor.run(Box::pin(async move {
                 Ping::new(service, ping_config).run().await
@@ -241,6 +248,7 @@ impl Litep2p {
                 main_protocol.clone(),
                 fallback_names,
                 kademlia_config.codec,
+                Duration::from_secs(5),
             );
             litep2p_config.executor.run(Box::pin(async move {
                 let _ = Kademlia::new(service, kademlia_config).run().await;
@@ -261,6 +269,7 @@ impl Litep2p {
                     identify_config.protocol.clone(),
                     Vec::new(),
                     identify_config.codec,
+                    Duration::from_secs(5),
                 );
                 identify_config.public = Some(litep2p_config.keypair.public().into());
 
@@ -280,6 +289,7 @@ impl Litep2p {
                 bitswap_config.protocol.clone(),
                 Vec::new(),
                 bitswap_config.codec,
+                Duration::from_secs(5),
             );
             litep2p_config.executor.run(Box::pin(async move {
                 Bitswap::new(service, bitswap_config).run().await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use multihash::Multihash;
 use transport::Endpoint;
 use types::ConnectionId;
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc};
 
 pub use bandwidth::BandwidthSink;
 pub use error::Error;
@@ -171,7 +171,7 @@ impl Litep2p {
                 protocol,
                 config.fallback_names.clone(),
                 config.codec,
-                Duration::from_secs(5),
+                litep2p_config.keep_alive_timeout,
             );
             let executor = Arc::clone(&litep2p_config.executor);
             litep2p_config.executor.run(Box::pin(async move {
@@ -191,7 +191,7 @@ impl Litep2p {
                 protocol,
                 config.fallback_names.clone(),
                 config.codec,
-                config.timeout,
+                litep2p_config.keep_alive_timeout,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 RequestResponseProtocol::new(service, config).run().await
@@ -206,7 +206,7 @@ impl Litep2p {
                 protocol_name,
                 Vec::new(),
                 protocol.codec(),
-                Duration::from_secs(5),
+                litep2p_config.keep_alive_timeout,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 let _ = protocol.run(service).await;
@@ -225,7 +225,7 @@ impl Litep2p {
                 ping_config.protocol.clone(),
                 Vec::new(),
                 ping_config.codec,
-                Duration::from_secs(5),
+                litep2p_config.keep_alive_timeout,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 Ping::new(service, ping_config).run().await
@@ -248,7 +248,7 @@ impl Litep2p {
                 main_protocol.clone(),
                 fallback_names,
                 kademlia_config.codec,
-                Duration::from_secs(5),
+                litep2p_config.keep_alive_timeout,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 let _ = Kademlia::new(service, kademlia_config).run().await;
@@ -269,7 +269,7 @@ impl Litep2p {
                     identify_config.protocol.clone(),
                     Vec::new(),
                     identify_config.codec,
-                    Duration::from_secs(5),
+                    litep2p_config.keep_alive_timeout,
                 );
                 identify_config.public = Some(litep2p_config.keypair.public().into());
 
@@ -289,7 +289,7 @@ impl Litep2p {
                 bitswap_config.protocol.clone(),
                 Vec::new(),
                 bitswap_config.codec,
-                Duration::from_secs(5),
+                litep2p_config.keep_alive_timeout,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 Bitswap::new(service, bitswap_config).run().await

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -874,7 +874,10 @@ mod tests {
     use crate::{
         codec::ProtocolCodec,
         crypto::ed25519::Keypair,
-        transport::manager::{limits::ConnectionLimitsConfig, TransportManager},
+        transport::{
+            manager::{limits::ConnectionLimitsConfig, TransportManager},
+            KEEP_ALIVE_TIMEOUT,
+        },
         types::protocol::ProtocolName,
         BandwidthSink,
     };
@@ -902,7 +905,7 @@ mod tests {
             Vec::new(),
             Default::default(),
             handle,
-            std::time::Duration::from_secs(5),
+            KEEP_ALIVE_TIMEOUT,
         );
         let (event_tx, event_rx) = channel(64);
         let (_cmd_tx, cmd_rx) = channel(64);

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -902,6 +902,7 @@ mod tests {
             Vec::new(),
             Default::default(),
             handle,
+            std::time::Duration::from_secs(5),
         );
         let (event_tx, event_rx) = channel(64);
         let (_cmd_tx, cmd_rx) = channel(64);

--- a/src/protocol/notification/tests/mod.rs
+++ b/src/protocol/notification/tests/mod.rs
@@ -29,7 +29,10 @@ use crate::{
         },
         InnerTransportEvent, ProtocolCommand, TransportService,
     },
-    transport::manager::{limits::ConnectionLimitsConfig, TransportManager},
+    transport::{
+        manager::{limits::ConnectionLimitsConfig, TransportManager},
+        KEEP_ALIVE_TIMEOUT,
+    },
     types::protocol::ProtocolName,
     BandwidthSink, PeerId,
 };
@@ -63,7 +66,7 @@ fn make_notification_protocol() -> (
         Vec::new(),
         std::sync::Arc::new(Default::default()),
         handle,
-        std::time::Duration::from_secs(5),
+        KEEP_ALIVE_TIMEOUT,
     );
     let (config, handle) = NotificationConfig::new(
         ProtocolName::from("/notif/1"),

--- a/src/protocol/notification/tests/mod.rs
+++ b/src/protocol/notification/tests/mod.rs
@@ -63,6 +63,7 @@ fn make_notification_protocol() -> (
         Vec::new(),
         std::sync::Arc::new(Default::default()),
         handle,
+        std::time::Duration::from_secs(5),
     );
     let (config, handle) = NotificationConfig::new(
         ProtocolName::from("/notif/1"),

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -61,6 +61,7 @@ fn protocol() -> (
         Vec::new(),
         std::sync::Arc::new(Default::default()),
         handle,
+        std::time::Duration::from_secs(5),
     );
     let (config, handle) =
         ConfigBuilder::new(ProtocolName::from("/req/1")).with_max_size(1024).build();

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -29,7 +29,10 @@ use crate::{
         InnerTransportEvent, TransportService,
     },
     substream::Substream,
-    transport::manager::{limits::ConnectionLimitsConfig, TransportManager},
+    transport::{
+        manager::{limits::ConnectionLimitsConfig, TransportManager},
+        KEEP_ALIVE_TIMEOUT,
+    },
     types::{RequestId, SubstreamId},
     BandwidthSink, Error, PeerId, ProtocolName,
 };
@@ -61,7 +64,7 @@ fn protocol() -> (
         Vec::new(),
         std::sync::Arc::new(Default::default()),
         handle,
-        std::time::Duration::from_secs(5),
+        KEEP_ALIVE_TIMEOUT,
     );
     let (config, handle) =
         ConfigBuilder::new(ProtocolName::from("/req/1")).with_max_size(1024).build();

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -51,6 +51,7 @@ use std::{
         Arc,
     },
     task::{Context, Poll},
+    time::Duration,
 };
 
 pub use handle::{TransportHandle, TransportManagerHandle};
@@ -322,6 +323,7 @@ impl TransportManager {
         protocol: ProtocolName,
         fallback_names: Vec<ProtocolName>,
         codec: ProtocolCodec,
+        keep_alive: Duration,
     ) -> TransportService {
         assert!(!self.protocol_names.contains(&protocol));
 
@@ -337,6 +339,7 @@ impl TransportManager {
             fallback_names.clone(),
             self.next_substream_id.clone(),
             self.transport_manager_handle.clone(),
+            keep_alive,
         );
 
         self.protocols.insert(
@@ -1793,11 +1796,13 @@ mod tests {
             ProtocolName::from("/notif/1"),
             Vec::new(),
             ProtocolCodec::UnsignedVarint(None),
+            Duration::from_secs(5),
         );
         manager.register_protocol(
             ProtocolName::from("/notif/1"),
             Vec::new(),
             ProtocolCodec::UnsignedVarint(None),
+            Duration::from_secs(5),
         );
     }
 
@@ -1818,6 +1823,7 @@ mod tests {
             ProtocolName::from("/notif/1"),
             Vec::new(),
             ProtocolCodec::UnsignedVarint(None),
+            Duration::from_secs(5),
         );
         manager.register_protocol(
             ProtocolName::from("/notif/2"),
@@ -1826,6 +1832,7 @@ mod tests {
                 ProtocolName::from("/notif/1"),
             ],
             ProtocolCodec::UnsignedVarint(None),
+            Duration::from_secs(5),
         );
     }
 
@@ -1849,6 +1856,7 @@ mod tests {
                 ProtocolName::from("/notif/1"),
             ],
             ProtocolCodec::UnsignedVarint(None),
+            Duration::from_secs(5),
         );
         manager.register_protocol(
             ProtocolName::from("/notif/2"),
@@ -1857,6 +1865,7 @@ mod tests {
                 ProtocolName::from("/notif/1/new"),
             ],
             ProtocolCodec::UnsignedVarint(None),
+            Duration::from_secs(5),
         );
     }
 

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -323,7 +323,7 @@ impl TransportManager {
         protocol: ProtocolName,
         fallback_names: Vec<ProtocolName>,
         codec: ProtocolCodec,
-        keep_alive: Duration,
+        keep_alive_timeout: Duration,
     ) -> TransportService {
         assert!(!self.protocol_names.contains(&protocol));
 
@@ -339,7 +339,7 @@ impl TransportManager {
             fallback_names.clone(),
             self.next_substream_id.clone(),
             self.transport_manager_handle.clone(),
-            keep_alive,
+            keep_alive_timeout,
         );
 
         self.protocols.insert(
@@ -1759,7 +1759,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        crypto::ed25519::Keypair, executor::DefaultExecutor, transport::dummy::DummyTransport,
+        crypto::ed25519::Keypair,
+        executor::DefaultExecutor,
+        transport::{dummy::DummyTransport, KEEP_ALIVE_TIMEOUT},
     };
     use std::{
         net::{Ipv4Addr, Ipv6Addr},
@@ -1796,13 +1798,13 @@ mod tests {
             ProtocolName::from("/notif/1"),
             Vec::new(),
             ProtocolCodec::UnsignedVarint(None),
-            Duration::from_secs(5),
+            KEEP_ALIVE_TIMEOUT,
         );
         manager.register_protocol(
             ProtocolName::from("/notif/1"),
             Vec::new(),
             ProtocolCodec::UnsignedVarint(None),
-            Duration::from_secs(5),
+            KEEP_ALIVE_TIMEOUT,
         );
     }
 
@@ -1823,7 +1825,7 @@ mod tests {
             ProtocolName::from("/notif/1"),
             Vec::new(),
             ProtocolCodec::UnsignedVarint(None),
-            Duration::from_secs(5),
+            KEEP_ALIVE_TIMEOUT,
         );
         manager.register_protocol(
             ProtocolName::from("/notif/2"),
@@ -1832,7 +1834,7 @@ mod tests {
                 ProtocolName::from("/notif/1"),
             ],
             ProtocolCodec::UnsignedVarint(None),
-            Duration::from_secs(5),
+            KEEP_ALIVE_TIMEOUT,
         );
     }
 
@@ -1856,7 +1858,7 @@ mod tests {
                 ProtocolName::from("/notif/1"),
             ],
             ProtocolCodec::UnsignedVarint(None),
-            Duration::from_secs(5),
+            KEEP_ALIVE_TIMEOUT,
         );
         manager.register_protocol(
             ProtocolName::from("/notif/2"),
@@ -1865,7 +1867,7 @@ mod tests {
                 ProtocolName::from("/notif/1/new"),
             ],
             ProtocolCodec::UnsignedVarint(None),
-            Duration::from_secs(5),
+            KEEP_ALIVE_TIMEOUT,
         );
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -47,6 +47,9 @@ pub(crate) const CONNECTION_OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// Timeout for opening a substream.
 pub(crate) const SUBSTREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Timeout for connection waiting new substreams.
+pub(crate) const KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Maximum number of parallel dial attempts.
 pub(crate) const MAX_PARALLEL_DIALS: usize = 8;
 


### PR DESCRIPTION
Allow configure time duration of keep_alive_timeouts in `TransportService`.
For `RequestResponseProtocol`, use its timeout configuration.
For other protocols, use the original default 5 seconds.

Related issue: #153 