### PR TITLE
kademlia: Preserve publisher & expiration time in DHT records

### DIFF
--- a/src/protocol/libp2p/kademlia/config.rs
+++ b/src/protocol/libp2p/kademlia/config.rs
@@ -65,6 +65,9 @@ pub struct Config {
     /// Incoming records validation mode.
     pub(super) validation_mode: IncomingRecordValidationMode,
 
+    /// Default record TTl.
+    pub(super) record_ttl: Duration,
+
     /// TX channel for sending events to `KademliaHandle`.
     pub(super) event_tx: Sender<KademliaEvent>,
 
@@ -94,13 +97,14 @@ impl Config {
                 protocol_names,
                 update_mode,
                 validation_mode,
+                record_ttl,
                 codec: ProtocolCodec::UnsignedVarint(None),
                 replication_factor,
                 known_peers,
                 cmd_rx,
                 event_tx,
             },
-            KademliaHandle::new(cmd_tx, event_rx, record_ttl),
+            KademliaHandle::new(cmd_tx, event_rx),
         )
     }
 

--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -31,7 +31,6 @@ use std::{
     num::NonZeroUsize,
     pin::Pin,
     task::{Context, Poll},
-    time::{Duration, Instant},
 };
 
 /// Quorum.
@@ -223,23 +222,15 @@ pub struct KademliaHandle {
 
     /// Next query ID.
     next_query_id: usize,
-
-    /// Default TTL for the records.
-    record_ttl: Duration,
 }
 
 impl KademliaHandle {
     /// Create new [`KademliaHandle`].
-    pub(super) fn new(
-        cmd_tx: Sender<KademliaCommand>,
-        event_rx: Receiver<KademliaEvent>,
-        record_ttl: Duration,
-    ) -> Self {
+    pub(super) fn new(cmd_tx: Sender<KademliaCommand>, event_rx: Receiver<KademliaEvent>) -> Self {
         Self {
             cmd_tx,
             event_rx,
             next_query_id: 0usize,
-            record_ttl,
         }
     }
 
@@ -265,9 +256,7 @@ impl KademliaHandle {
     }
 
     /// Store record to DHT.
-    pub async fn put_record(&mut self, mut record: Record) -> QueryId {
-        record.expires = record.expires.or_else(|| Some(Instant::now() + self.record_ttl));
-
+    pub async fn put_record(&mut self, record: Record) -> QueryId {
         let query_id = self.next_query_id();
         let _ = self.cmd_tx.send(KademliaCommand::PutRecord { record, query_id }).await;
 
@@ -277,12 +266,10 @@ impl KademliaHandle {
     /// Store record to DHT to the given peers.
     pub async fn put_record_to_peers(
         &mut self,
-        mut record: Record,
+        record: Record,
         peers: Vec<PeerId>,
         update_local_store: bool,
     ) -> QueryId {
-        record.expires = record.expires.or_else(|| Some(Instant::now() + self.record_ttl));
-
         let query_id = self.next_query_id();
         let _ = self
             .cmd_tx
@@ -314,9 +301,7 @@ impl KademliaHandle {
 
     /// Store the record in the local store. Used in combination with
     /// [`IncomingRecordValidationMode::Manual`].
-    pub async fn store_record(&mut self, mut record: Record) {
-        record.expires = record.expires.or_else(|| Some(Instant::now() + self.record_ttl));
-
+    pub async fn store_record(&mut self, record: Record) {
         let _ = self.cmd_tx.send(KademliaCommand::StoreRecord { record }).await;
     }
 
@@ -337,9 +322,7 @@ impl KademliaHandle {
     }
 
     /// Try to initiate `PUT_VALUE` query and if the channel is clogged, return an error.
-    pub fn try_put_record(&mut self, mut record: Record) -> Result<QueryId, ()> {
-        record.expires = record.expires.or_else(|| Some(Instant::now() + self.record_ttl));
-
+    pub fn try_put_record(&mut self, record: Record) -> Result<QueryId, ()> {
         let query_id = self.next_query_id();
         self.cmd_tx
             .try_send(KademliaCommand::PutRecord { record, query_id })
@@ -351,12 +334,10 @@ impl KademliaHandle {
     /// return an error.
     pub fn try_put_record_to_peers(
         &mut self,
-        mut record: Record,
+        record: Record,
         peers: Vec<PeerId>,
         update_local_store: bool,
     ) -> Result<QueryId, ()> {
-        record.expires = record.expires.or_else(|| Some(Instant::now() + self.record_ttl));
-
         let query_id = self.next_query_id();
         self.cmd_tx
             .try_send(KademliaCommand::PutRecordToPeers {
@@ -384,9 +365,7 @@ impl KademliaHandle {
 
     /// Try to store the record in the local store, and if the channel is clogged, return an error.
     /// Used in combination with [`IncomingRecordValidationMode::Manual`].
-    pub fn try_store_record(&mut self, mut record: Record) -> Result<(), ()> {
-        record.expires = record.expires.or_else(|| Some(Instant::now() + self.record_ttl));
-
+    pub fn try_store_record(&mut self, record: Record) -> Result<(), ()> {
         self.cmd_tx.try_send(KademliaCommand::StoreRecord { record }).map_err(|_| ())
     }
 }

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -45,7 +45,10 @@ use futures::StreamExt;
 use multiaddr::Multiaddr;
 use tokio::sync::mpsc::{Receiver, Sender};
 
-use std::collections::{hash_map::Entry, HashMap};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    time::{Duration, Instant},
+};
 
 pub use self::handle::RecordsType;
 pub use config::{Config, ConfigBuilder};
@@ -147,6 +150,9 @@ pub(crate) struct Kademlia {
     /// Incoming records validation mode.
     validation_mode: IncomingRecordValidationMode,
 
+    /// Default record TTL.
+    record_ttl: Duration,
+
     /// Query engine.
     engine: QueryEngine,
 
@@ -181,6 +187,7 @@ impl Kademlia {
             pending_substreams: HashMap::new(),
             update_mode: config.update_mode,
             validation_mode: config.validation_mode,
+            record_ttl: config.record_ttl,
             replication_factor: config.replication_factor,
             engine: QueryEngine::new(local_peer_id, config.replication_factor, PARALLELISM_FACTOR),
         }
@@ -778,8 +785,11 @@ impl Kademlia {
                         Some(KademliaCommand::PutRecord { mut record, query_id }) => {
                             tracing::debug!(target: LOG_TARGET, ?query_id, key = ?record.key, "store record to DHT");
 
-                            // For `PUT_RECORD` requests originating locally we are always the publisher.
+                            // For `PUT_VALUE` requests originating locally we are always the publisher.
                             record.publisher = Some(self.local_key.clone().into_preimage());
+
+                            // Make sure TTL is set.
+                            record.expires = record.expires.or_else(|| Some(Instant::now() + self.record_ttl));
 
                             let key = Key::new(record.key.clone());
 
@@ -791,8 +801,11 @@ impl Kademlia {
                                 self.routing_table.closest(key, self.replication_factor).into(),
                             );
                         }
-                        Some(KademliaCommand::PutRecordToPeers { record, query_id, peers, update_local_store }) => {
+                        Some(KademliaCommand::PutRecordToPeers { mut record, query_id, peers, update_local_store }) => {
                             tracing::debug!(target: LOG_TARGET, ?query_id, key = ?record.key, "store record to DHT to specified peers");
+
+                            // Make sure TTL is set.
+                            record.expires = record.expires.or_else(|| Some(Instant::now() + self.record_ttl));
 
                             if update_local_store {
                                 self.store.put(record.clone());
@@ -857,12 +870,15 @@ impl Kademlia {
                             self.service.add_known_address(&peer, addresses.into_iter());
 
                         }
-                        Some(KademliaCommand::StoreRecord { record }) => {
+                        Some(KademliaCommand::StoreRecord { mut record }) => {
                             tracing::debug!(
                                 target: LOG_TARGET,
                                 key = ?record.key,
                                 "store record in local store",
                             );
+
+                            // Make sure TTL is set.
+                            record.expires = record.expires.or_else(|| Some(Instant::now() + self.record_ttl));
 
                             self.store.put(record);
                         }
@@ -917,6 +933,7 @@ mod tests {
             replication_factor: 20usize,
             update_mode: RoutingTableUpdateMode::Automatic,
             validation_mode: IncomingRecordValidationMode::Automatic,
+            record_ttl: Duration::from_secs(36 * 60 * 60),
             event_tx,
             cmd_rx,
         };

--- a/src/protocol/libp2p/kademlia/types.rs
+++ b/src/protocol/libp2p/kademlia/types.rs
@@ -49,7 +49,7 @@ construct_uint! {
 /// the hash digests, interpreted as an integer. See [`Key::distance`].
 #[derive(Clone, Debug)]
 pub struct Key<T: Clone> {
-    _preimage: T,
+    preimage: T,
     bytes: KeyBytes,
 }
 
@@ -59,17 +59,17 @@ impl<T: Clone> Key<T> {
     ///
     /// The preimage of type `T` is preserved.
     /// See [`Key::into_preimage`] for more details.
-    pub fn new(_preimage: T) -> Key<T>
+    pub fn new(preimage: T) -> Key<T>
     where
         T: Borrow<[u8]>,
     {
-        let bytes = KeyBytes::new(_preimage.borrow());
-        Key { _preimage, bytes }
+        let bytes = KeyBytes::new(preimage.borrow());
+        Key { preimage, bytes }
     }
 
     /// Convert [`Key`] into its preimage.
     pub fn into_preimage(self) -> T {
-        self._preimage
+        self.preimage
     }
 
     /// Computes the distance of the keys according to the XOR metric.
@@ -94,8 +94,8 @@ impl<T: Clone> Key<T> {
     ///
     /// Only used for testing
     #[cfg(test)]
-    pub fn from_bytes(bytes: KeyBytes, _preimage: T) -> Key<T> {
-        Self { bytes, _preimage }
+    pub fn from_bytes(bytes: KeyBytes, preimage: T) -> Key<T> {
+        Self { bytes, preimage }
     }
 }
 
@@ -108,10 +108,7 @@ impl<T: Clone> From<Key<T>> for KeyBytes {
 impl From<PeerId> for Key<PeerId> {
     fn from(p: PeerId) -> Self {
         let bytes = KeyBytes(Sha256::digest(p.to_bytes()));
-        Key {
-            _preimage: p,
-            bytes,
-        }
+        Key { preimage: p, bytes }
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug with publisher & expiration time not being preserved in DHT records.

Resolves https://github.com/paritytech/litep2p/issues/129.