### PR TITLE
kad: Add query id to log messages

### DIFF
--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -399,6 +399,7 @@ impl Kademlia {
                             target: LOG_TARGET,
                             ?peer,
                             ?target,
+                            ?query_id,
                             "handle `FIND_NODE` response",
                         );
 

--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -104,7 +104,7 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
     /// Register response failure for `peer`.
     pub fn register_response_failure(&mut self, peer: PeerId) {
         let Some(peer) = self.pending.remove(&peer) else {
-            tracing::debug!(target: LOG_TARGET, ?peer, "pending peer doesn't exist");
+            tracing::debug!(target: LOG_TARGET, query = ?self.config.query, ?peer, "pending peer doesn't exist");
             return;
         };
 
@@ -113,8 +113,10 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
 
     /// Register `FIND_NODE` response from `peer`.
     pub fn register_response(&mut self, peer: PeerId, peers: Vec<KademliaPeer>) {
+        tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, "received response from peer");
+
         let Some(peer) = self.pending.remove(&peer) else {
-            tracing::warn!(target: LOG_TARGET, ?peer, "received response from peer but didn't expect it");
+            tracing::warn!(target: LOG_TARGET, query = ?self.config.query, ?peer, "received response from peer but didn't expect it");
             debug_assert!(false);
             return;
         };

--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -104,7 +104,7 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
     /// Register response failure for `peer`.
     pub fn register_response_failure(&mut self, peer: PeerId) {
         let Some(peer) = self.pending.remove(&peer) else {
-            tracing::debug!(target: LOG_TARGET, query = ?self.config.query, ?peer, "pending peer doesn't exist");
+            tracing::warn!(target: LOG_TARGET, query = ?self.config.query, ?peer, "pending peer doesn't exist");
             return;
         };
 

--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -187,12 +187,14 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
         tracing::trace!(target: LOG_TARGET, query = ?self.config.query, "get next peer");
 
         let (_, candidate) = self.candidates.pop_first()?;
+        let peer = candidate.peer;
 
+        tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, "current candidate");
         self.pending.insert(candidate.peer, candidate.clone());
 
         Some(QueryAction::SendMessage {
             query: self.config.query,
-            peer: candidate.peer,
+            peer,
             message: self.kad_message.clone(),
         })
     }

--- a/src/protocol/libp2p/kademlia/query/get_record.rs
+++ b/src/protocol/libp2p/kademlia/query/get_record.rs
@@ -135,7 +135,7 @@ impl GetRecordContext {
     /// Register response failure for `peer`.
     pub fn register_response_failure(&mut self, peer: PeerId) {
         let Some(peer) = self.pending.remove(&peer) else {
-            tracing::trace!(target: LOG_TARGET, ?peer, "pending peer doesn't exist");
+            tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, "pending peer doesn't exist");
             return;
         };
 
@@ -149,8 +149,10 @@ impl GetRecordContext {
         record: Option<Record>,
         peers: Vec<KademliaPeer>,
     ) {
+        tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, "received response from peer");
+
         let Some(peer) = self.pending.remove(&peer) else {
-            tracing::trace!(target: LOG_TARGET, ?peer, "received response from peer but didn't expect it");
+            tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, "received response from peer but didn't expect it");
             return;
         };
 
@@ -207,10 +209,9 @@ impl GetRecordContext {
         tracing::trace!(target: LOG_TARGET, query = ?self.config.query, "get next peer");
 
         let (_, candidate) = self.candidates.pop_first()?;
-
         let peer = candidate.peer;
 
-        tracing::trace!(target: LOG_TARGET, ?peer, "current candidate");
+        tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, "current candidate");
         self.pending.insert(candidate.peer, candidate);
 
         Some(QueryAction::SendMessage {

--- a/src/protocol/libp2p/kademlia/query/get_record.rs
+++ b/src/protocol/libp2p/kademlia/query/get_record.rs
@@ -135,7 +135,7 @@ impl GetRecordContext {
     /// Register response failure for `peer`.
     pub fn register_response_failure(&mut self, peer: PeerId) {
         let Some(peer) = self.pending.remove(&peer) else {
-            tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, "pending peer doesn't exist");
+            tracing::warn!(target: LOG_TARGET, query = ?self.config.query, ?peer, "pending peer doesn't exist");
             return;
         };
 
@@ -152,7 +152,7 @@ impl GetRecordContext {
         tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, "received response from peer");
 
         let Some(peer) = self.pending.remove(&peer) else {
-            tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, "received response from peer but didn't expect it");
+            tracing::warn!(target: LOG_TARGET, query = ?self.config.query, ?peer, "received response from peer but didn't expect it");
             return;
         };
 


### PR DESCRIPTION


This tiny PR adds the query ID to some kademlia log messages from the `FIND_NODE` and `GET_RECORDS` commands. 

Used to provide better debug information and upgrade a few missing states from trace to warn. 

cc @paritytech/networking 