### PR TITLE
transport: Reject secondary connections with different connection IDs

### DIFF
--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -34,7 +34,7 @@ pub struct AddressRecord {
     /// Address.
     address: Multiaddr,
 
-    /// Connection ID, if specifed.
+    /// Connection ID, if specified.
     connection_id: Option<ConnectionId>,
 }
 

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -977,14 +977,18 @@ impl TransportManager {
                                 Some(endpoint.connection_id()),
                             ));
                         }
-                        Some(record) => tracing::warn!(
-                            target: LOG_TARGET,
-                            ?peer,
-                            connection_id = ?endpoint.connection_id(),
-                            address = ?endpoint.address(),
-                            dial_record = ?record,
-                            "unknown connection opened as secondary connection, discarding",
-                        ),
+                        Some(record) => {
+                            tracing::warn!(
+                                target: LOG_TARGET,
+                                ?peer,
+                                connection_id = ?endpoint.connection_id(),
+                                address = ?endpoint.address(),
+                                dial_record = ?record,
+                                "unknown connection opened as secondary connection, discarding",
+                            );
+
+                            return Ok(ConnectionEstablishedResult::Reject);
+                        }
                     },
                 },
                 PeerState::Dialing { ref record, .. } => {

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -75,7 +75,7 @@ const SCORE_CONNECT_SUCCESS: i32 = 100i32;
 /// Score for a non-working address.
 const SCORE_CONNECT_FAILURE: i32 = -100i32;
 
-/// TODO:
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ConnectionEstablishedResult {
     /// Accept connection and inform `Litep2p` about the connection.
     Accept,
@@ -2255,14 +2255,15 @@ mod tests {
             ));
 
         // remote peer connected to local node
-        manager
+        let established_result = manager
             .on_connection_established(
                 peer,
                 &Endpoint::listener(address1, ConnectionId::from(0usize)),
             )
             .unwrap();
+        assert_eq!(established_result, ConnectionEstablishedResult::Accept);
 
-        // verify that the peer state is `Connected` with no seconary connection
+        // verify that the peer state is `Connected` with no secondary connection
         {
             let peers = manager.peers.read();
             let peer = peers.get(&peer).unwrap();
@@ -2277,13 +2278,14 @@ mod tests {
             }
         }
 
-        // second connection is established, verify that the seconary connection is tracked
-        manager
+        // second connection is established, verify that the secondary connection is tracked
+        let established_result = manager
             .on_connection_established(
                 peer,
                 &Endpoint::listener(address2.clone(), ConnectionId::from(1usize)),
             )
             .unwrap();
+        assert_eq!(established_result, ConnectionEstablishedResult::Accept);
 
         let peers = manager.peers.read();
         let context = peers.get(&peer).unwrap();
@@ -2301,12 +2303,13 @@ mod tests {
         drop(peers);
 
         // tertiary connection is ignored
-        manager
+        let established_result = manager
             .on_connection_established(
                 peer,
                 &Endpoint::listener(address3.clone(), ConnectionId::from(2usize)),
             )
             .unwrap();
+        assert_eq!(established_result, ConnectionEstablishedResult::Reject);
 
         let peers = manager.peers.read();
         let peer = peers.get(&peer).unwrap();

--- a/src/transport/manager/types.rs
+++ b/src/transport/manager/types.rs
@@ -55,7 +55,7 @@ pub enum PeerState {
         ///
         /// While the local node was dialing a remote peer, the remote peer might've dialed
         /// the local node and connection was established successfully. This dial address
-        /// is stored for processing later when the dial attempt conclused as either
+        /// is stored for processing later when the dial attempt concluded as either
         /// successful/failed.
         dial_record: Option<AddressRecord>,
     },

--- a/src/transport/manager/types.rs
+++ b/src/transport/manager/types.rs
@@ -97,7 +97,7 @@ pub struct PeerContext {
     /// Peer state.
     pub state: PeerState,
 
-    /// Seconary connection, if it's open.
+    /// Secondary connection, if it's open.
     pub secondary_connection: Option<AddressRecord>,
 
     /// Known addresses of peer.


### PR DESCRIPTION
This PR ensures that the transport manager rejects secondary connections.

When the secondary connection is rejected, the internal `dial_record` is preserved.

Added a test to validate this behavior, with multiple wrong endpoints.

Part of: https://github.com/paritytech/litep2p/issues/172
Will keep the issue opened for to further into it. 

cc @paritytech/networking 
