### PR TITLE
transport: Fix double lock and state overwrite on disconnected peers

### DIFF
--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -102,7 +102,7 @@ impl AddressRecord {
 
     /// Update score of an address.
     pub fn update_score(&mut self, score: i32) {
-        self.score += score;
+        self.score = self.score.saturating_add(score);
     }
 
     /// Set `ConnectionId` for the [`AddressRecord`].

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -710,8 +710,6 @@ impl TransportManager {
                 ?connection_id,
                 "dial failed for a connection that doesn't exist",
             );
-            debug_assert!(false);
-
             Error::InvalidState
         })?;
 
@@ -1398,8 +1396,6 @@ impl TransportManager {
                 ?connection_id,
                 "open failure but dial record doesn't exist",
             );
-
-            debug_assert!(false);
             return Err(Error::InvalidState);
         };
 

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -629,11 +629,9 @@ impl TransportManager {
                 Entry::Occupied(occupied) => {
                     let context = occupied.into_mut();
 
-                    // `context.addresses.insert` does not overwrite the existing record.
-                    // This inserts the record with a score of 0 if it doesn't exist, for
-                    // keeping track of the potential address. This becomes useful for
-                    // consecutive `fn dial` calls.
-                    // However, the record score cannot be updated in the future.
+                    // For a better address tacking, see:
+                    // https://github.com/paritytech/litep2p/issues/180
+                    //
                     // TODO: context.addresses.insert(record.clone());
 
                     tracing::debug!(

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -633,7 +633,8 @@ impl TransportManager {
                     // This inserts the record with a score of 0 if it doesn't exist, for
                     // keeping track of the potential address. This becomes useful for
                     // consecutive `fn dial` calls.
-                    context.addresses.insert(record.clone());
+                    // However, the record score cannot be updated in the future.
+                    // TODO: context.addresses.insert(record.clone());
 
                     tracing::debug!(
                         target: LOG_TARGET,
@@ -3426,9 +3427,8 @@ mod tests {
                 state => panic!("invalid state: {state:?}"),
             }
 
-            // The address is saved.
             assert!(!peer_context.addresses.contains(&dial_address));
-            assert!(peer_context.addresses.contains(&second_address));
+            assert!(!peer_context.addresses.contains(&second_address));
         }
     }
 }

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -629,6 +629,12 @@ impl TransportManager {
                 Entry::Occupied(occupied) => {
                     let context = occupied.into_mut();
 
+                    // `context.addresses.insert` does not overwrite the existing record.
+                    // This inserts the record with a score of 0 if it doesn't exist, for
+                    // keeping track of the potential address. This becomes useful for
+                    // consecutive `fn dial` calls.
+                    context.addresses.insert(record.clone());
+
                     tracing::debug!(
                         target: LOG_TARGET,
                         peer = ?remote_peer_id,
@@ -655,7 +661,6 @@ impl TransportManager {
                             return Ok(());
                         }
                         PeerState::Disconnected { dial_record: None } => {
-                            // TODO: verify that the address is not in `context.addresses` already.
                             context.state = PeerState::Dialing {
                                 record: record.clone(),
                             };

--- a/src/transport/manager/types.rs
+++ b/src/transport/manager/types.rs
@@ -55,7 +55,7 @@ pub enum PeerState {
         ///
         /// While the local node was dialing a remote peer, the remote peer might've dialed
         /// the local node and connection was established successfully. This dial address
-        /// is stored for processing later when the dial attempt conclused as either
+        /// is stored for processing later when the dial attempt concluded as either
         /// successful/failed.
         dial_record: Option<AddressRecord>,
     },
@@ -97,7 +97,7 @@ pub struct PeerContext {
     /// Peer state.
     pub state: PeerState,
 
-    /// Seconary connection, if it's open.
+    /// Secondary connection, if it's open.
     pub secondary_connection: Option<AddressRecord>,
 
     /// Known addresses of peer.


### PR DESCRIPTION
This PR fixes an issue where the secondary connection is rejected because it has a different connection ID.

The issue comes from `fn dial_address` which can overwrite the state of a disconnected peer with in-flight dial requests. 


### High level repro case
- T0: dial_address 1
- T1: dial_address 2 which overwrites address 1
- T2: dialed address 1 responds with a connection
- T3: connection is rejected

While at it, this PR also:
- removes the need to double lock the peer state (once to read and once to write)
- enforces connection ID checks on dial records in `on_dial_failure`
- adjust the repro case from https://github.com/paritytech/litep2p/pull/176 for the fix

### Detailed repro case

- T0: Dial address A connection ID 1 -> State : Dialing { in-flight-1 }
- T1: Connection is established by remote address C connection ID 3 -> State : Connected {  in-flight-dial  1 }
- T2: Closed connection established in T2 -> State : Disconnected { in-flight-dial 1}

// This is where the state was wrongfully overwritten
- T3: Dial address B connection ID 2 -> State: Dialing { in-flight-2 } 

- T4: Connection is established by remote address C connection ID 3 -> State : Connected {  in-flight-dial  2 }

// The issue was detected here
- T5: Dial from T0 receives a response however it expects in-flight-dial 1 and the state has in-flight-dial 2


Closes: https://github.com/paritytech/litep2p/issues/172

