### PR TITLE
kad: Update routing table on kademlia established connections

### DIFF
--- a/src/protocol/libp2p/kademlia/bucket.rs
+++ b/src/protocol/libp2p/kademlia/bucket.rs
@@ -94,7 +94,7 @@ impl KBucket {
 
         for i in 0..self.nodes.len() {
             match self.nodes[i].connection {
-                ConnectionType::NotConnected | ConnectionType::CannotConnect => {
+                ConnectionType::NotConnected => {
                     return KBucketEntry::Vacant(&mut self.nodes[i]);
                 }
                 _ => continue,

--- a/src/protocol/libp2p/kademlia/bucket.rs
+++ b/src/protocol/libp2p/kademlia/bucket.rs
@@ -68,13 +68,17 @@ impl KBucket {
         }
     }
 
+    /// Get the index position of the key in the k-bucket.
+    fn get_index<K: Clone>(&self, key: &Key<K>) -> Option<usize> {
+        self.nodes.iter().position(|p| p.key.as_ref() == key.as_ref())
+    }
+
     /// Get entry into the bucket.
     // TODO: this is horrible code
     pub fn entry<K: Clone>(&mut self, key: Key<K>) -> KBucketEntry<'_> {
-        for i in 0..self.nodes.len() {
-            if self.nodes[i].key == key {
-                return KBucketEntry::Occupied(&mut self.nodes[i]);
-            }
+        // Return the entry if present.
+        if let Some(index) = self.get_index(&key) {
+            return KBucketEntry::Occupied(&mut self.nodes[index]);
         }
 
         if self.nodes.len() < 20 {
@@ -83,6 +87,7 @@ impl KBucket {
                 vec![],
                 ConnectionType::NotConnected,
             ));
+
             let len = self.nodes.len() - 1;
             return KBucketEntry::Vacant(&mut self.nodes[len]);
         }

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -203,6 +203,11 @@ impl Kademlia {
                 match self.routing_table.entry(Key::from(peer)) {
                     KBucketEntry::Occupied(entry) => {
                         entry.connection = ConnectionType::Connected;
+
+                        // Update the address if not already present.
+                        if !entry.addresses.iter().any(|address| address == endpoint.address()) {
+                            entry.addresses.push(endpoint.address().clone());
+                        }
                     }
                     mut vacant @ KBucketEntry::Vacant(_) => {
                         // Can only insert a new peer if the routing table update mode is set to
@@ -211,10 +216,9 @@ impl Kademlia {
                         // Otherwise, the user is responsible of adding the peer manually if it
                         // deems necessary.
                         if std::matches!(self.update_mode, RoutingTableUpdateMode::Automatic) {
-                            let (endpoint_address, _) = endpoint.into_parts();
                             vacant.insert(KademliaPeer::new(
                                 peer,
-                                vec![endpoint_address],
+                                vec![endpoint.address().clone()],
                                 ConnectionType::Connected,
                             ));
                         }

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -166,10 +166,24 @@ impl RoutingTable {
 
         match self.entry(Key::from(peer)) {
             KBucketEntry::Occupied(entry) => {
+                tracing::trace!(
+                    target: LOG_TARGET,
+                    ?peer,
+                    ?connection,
+                    ?entry,
+                    "Peer present into the routing table, overwriting entry",
+                );
+
                 entry.addresses = addresses;
                 entry.connection = connection;
             }
             mut entry @ KBucketEntry::Vacant(_) => {
+                tracing::trace!(
+                    target: LOG_TARGET,
+                    ?peer,
+                    ?connection,
+                    "Adding peer to the routing table into a vacant entry",
+                );
                 entry.insert(KademliaPeer::new(peer, addresses, connection));
             }
             KBucketEntry::LocalNode => tracing::warn!(

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -445,7 +445,7 @@ mod tests {
         entry.insert(KademliaPeer::new(
             peer,
             vec!["/ip6/::1/tcp/8888".parse().unwrap()],
-            ConnectionType::CanConnect,
+            ConnectionType::Connected,
         ));
 
         // verify the node is still there
@@ -456,7 +456,7 @@ mod tests {
             KBucketEntry::Occupied(&mut KademliaPeer::new(
                 peer,
                 addresses,
-                ConnectionType::CanConnect,
+                ConnectionType::Connected,
             ))
         );
     }
@@ -497,7 +497,7 @@ mod tests {
         entry.insert(KademliaPeer::new(
             peer,
             vec!["/ip6/::1/tcp/8888".parse().unwrap()],
-            ConnectionType::CanConnect,
+            ConnectionType::Connected,
         ));
     }
 

--- a/src/protocol/libp2p/kademlia/types.rs
+++ b/src/protocol/libp2p/kademlia/types.rs
@@ -201,12 +201,6 @@ pub enum ConnectionType {
 
     /// Sender is connected to the peer.
     Connected,
-
-    /// Sender has recently been connected to the peer.
-    CanConnect,
-
-    /// Sender is unable to connect to the peer.
-    CannotConnect,
 }
 
 impl TryFrom<i32> for ConnectionType {
@@ -216,8 +210,6 @@ impl TryFrom<i32> for ConnectionType {
         match value {
             0 => Ok(ConnectionType::NotConnected),
             1 => Ok(ConnectionType::Connected),
-            2 => Ok(ConnectionType::CanConnect),
-            3 => Ok(ConnectionType::CannotConnect),
             _ => Err(()),
         }
     }
@@ -228,8 +220,6 @@ impl From<ConnectionType> for i32 {
         match connection {
             ConnectionType::NotConnected => 0,
             ConnectionType::Connected => 1,
-            ConnectionType::CanConnect => 2,
-            ConnectionType::CannotConnect => 3,
         }
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -104,6 +104,22 @@ impl Endpoint {
     pub fn is_listener(&self) -> bool {
         std::matches!(self, Self::Listener { .. })
     }
+
+    /// Transform the endpoint into its parts.
+    ///
+    /// This is useful when the direction of the connection is not needed.
+    pub fn into_parts(self) -> (Multiaddr, ConnectionId) {
+        match self {
+            Self::Dialer {
+                address,
+                connection_id,
+            } => (address, connection_id),
+            Self::Listener {
+                address,
+                connection_id,
+            } => (address, connection_id),
+        }
+    }
 }
 
 /// Transport event.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -104,22 +104,6 @@ impl Endpoint {
     pub fn is_listener(&self) -> bool {
         std::matches!(self, Self::Listener { .. })
     }
-
-    /// Transform the endpoint into its parts.
-    ///
-    /// This is useful when the direction of the connection is not needed.
-    pub fn into_parts(self) -> (Multiaddr, ConnectionId) {
-        match self {
-            Self::Dialer {
-                address,
-                connection_id,
-            } => (address, connection_id),
-            Self::Listener {
-                address,
-                connection_id,
-            } => (address, connection_id),
-        }
-    }
 }
 
 /// Transport event.


### PR DESCRIPTION
In this PR:
- Established connections from the kademlia component are reported immediately to the routing table iff the mode is in `Automatic`.
- The kademlia on connection established address is reported to the routing table for healthier tracking of addresses. This improves a bit the discoverability of peers, especially in cases where the `RoutingTableUpdate::Manual` option is set (ie Substrate)
- Refactor the `Kbucket::entry` function to iterate only once through the nodes, instead of twice
- Remove unneeded routing table ConnectionType's `CannotConnect` and `CanConnect`. The terminology comes from the kademlia peer status in low-level commands. However, the routing table only needs to know if the peer is connected or disconnected (similar to libp2p).

cc @paritytech/networking 