### PR TITLE
transport/manager: Add connection limits for inbound and outbound established connections

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,9 +29,9 @@ use crate::{
         notification, request_response, UserProtocol,
     },
     transport::{
-        quic::config::Config as QuicConfig, tcp::config::Config as TcpConfig,
-        webrtc::config::Config as WebRtcConfig, websocket::config::Config as WebSocketConfig,
-        MAX_PARALLEL_DIALS,
+        manager::limits::ConnectionLimitsConfig, quic::config::Config as QuicConfig,
+        tcp::config::Config as TcpConfig, webrtc::config::Config as WebRtcConfig,
+        websocket::config::Config as WebSocketConfig, MAX_PARALLEL_DIALS,
     },
     types::protocol::ProtocolName,
     PeerId,
@@ -109,6 +109,9 @@ pub struct ConfigBuilder {
 
     /// Maximum number of parallel dial attempts.
     max_parallel_dials: usize,
+
+    /// Connection limits config.
+    connection_limits: ConnectionLimitsConfig,
 }
 
 impl Default for ConfigBuilder {
@@ -137,6 +140,7 @@ impl ConfigBuilder {
             notification_protocols: HashMap::new(),
             request_response_protocols: HashMap::new(),
             known_addresses: Vec::new(),
+            connection_limits: ConnectionLimitsConfig::default(),
         }
     }
 
@@ -243,6 +247,12 @@ impl ConfigBuilder {
         self
     }
 
+    /// Set connection limits configuration.
+    pub fn with_connection_limits(mut self, config: ConnectionLimitsConfig) -> Self {
+        self.connection_limits = config;
+        self
+    }
+
     /// Build [`Litep2pConfig`].
     pub fn build(mut self) -> Litep2pConfig {
         let keypair = match self.keypair {
@@ -267,6 +277,7 @@ impl ConfigBuilder {
             notification_protocols: self.notification_protocols,
             request_response_protocols: self.request_response_protocols,
             known_addresses: self.known_addresses,
+            connection_limits: self.connection_limits,
         }
     }
 }
@@ -320,4 +331,7 @@ pub struct Litep2pConfig {
 
     /// Known addresses.
     pub(crate) known_addresses: Vec<(PeerId, Vec<Multiaddr>)>,
+
+    /// Connection limits config.
+    pub(crate) connection_limits: ConnectionLimitsConfig,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,7 @@
 
 use crate::{
     protocol::Direction,
+    transport::manager::limits::ConnectionLimitsError,
     types::{protocol::ProtocolName, ConnectionId, SubstreamId},
     PeerId,
 };
@@ -118,6 +119,8 @@ pub enum Error {
     ChannelClogged,
     #[error("Connection doesn't exist: `{0:?}`")]
     ConnectionDoesntExist(ConnectionId),
+    #[error("Exceeded connection limits `{0:?}`")]
+    ConnectionLimit(ConnectionLimitsError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -240,6 +243,12 @@ impl From<quinn::ConnectionError> for Error {
             quinn::ConnectionError::TimedOut => Error::Timeout,
             error => Error::Quinn(error),
         }
+    }
+}
+
+impl From<ConnectionLimitsError> for Error {
+    fn from(error: ConnectionLimitsError) -> Self {
+        Error::ConnectionLimit(error)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ impl Litep2p {
             supported_transports,
             bandwidth_sink.clone(),
             litep2p_config.max_parallel_dials,
+            litep2p_config.connection_limits,
         );
 
         // add known addresses to `TransportManager`, if any exist

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -897,8 +897,11 @@ mod tests {
 
     use super::*;
     use crate::{
-        codec::ProtocolCodec, crypto::ed25519::Keypair, transport::manager::TransportManager,
-        types::protocol::ProtocolName, BandwidthSink,
+        codec::ProtocolCodec,
+        crypto::ed25519::Keypair,
+        transport::manager::{limits::ConnectionLimitsConfig, TransportManager},
+        types::protocol::ProtocolName,
+        BandwidthSink,
     };
     use tokio::sync::mpsc::channel;
 
@@ -914,6 +917,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         let peer = PeerId::random();

--- a/src/protocol/mdns.rs
+++ b/src/protocol/mdns.rs
@@ -334,7 +334,11 @@ impl Mdns {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{crypto::ed25519::Keypair, transport::manager::TransportManager, BandwidthSink};
+    use crate::{
+        crypto::ed25519::Keypair,
+        transport::manager::{limits::ConnectionLimitsConfig, TransportManager},
+        BandwidthSink,
+    };
     use futures::StreamExt;
     use multiaddr::Protocol;
 
@@ -350,6 +354,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         let mdns1 = Mdns::new(
@@ -372,6 +377,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         let mdns2 = Mdns::new(

--- a/src/protocol/notification/tests/mod.rs
+++ b/src/protocol/notification/tests/mod.rs
@@ -29,7 +29,7 @@ use crate::{
         },
         InnerTransportEvent, ProtocolCommand, TransportService,
     },
-    transport::manager::TransportManager,
+    transport::manager::{limits::ConnectionLimitsConfig, TransportManager},
     types::protocol::ProtocolName,
     BandwidthSink, PeerId,
 };
@@ -53,6 +53,7 @@ fn make_notification_protocol() -> (
         HashSet::new(),
         BandwidthSink::new(),
         8usize,
+        ConnectionLimitsConfig::default(),
     );
 
     let peer = PeerId::random();

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -29,7 +29,7 @@ use crate::{
         InnerTransportEvent, TransportService,
     },
     substream::Substream,
-    transport::manager::TransportManager,
+    transport::manager::{limits::ConnectionLimitsConfig, TransportManager},
     types::{RequestId, SubstreamId},
     BandwidthSink, Error, PeerId, ProtocolName,
 };
@@ -51,6 +51,7 @@ fn protocol() -> (
         HashSet::new(),
         BandwidthSink::new(),
         8usize,
+        ConnectionLimitsConfig::default(),
     );
 
     let peer = PeerId::random();

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -20,7 +20,7 @@
 
 //! Limits for the transport manager.
 
-use crate::{types::ConnectionId, PeerId};
+use crate::types::ConnectionId;
 
 use std::collections::HashSet;
 

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -81,6 +81,26 @@ impl ConnectionLimits {
         }
     }
 
+    /// Called when dialing an address.
+    ///
+    /// Returns the number of outgoing connections permitted to be established.
+    /// It is guaranteed that at least one connection can be established if the method returns `Ok`.
+    /// The number of available outgoing connections can influence the maximum parallel dials to a
+    /// single address.
+    ///
+    /// If the maximum number of outgoing connections is not set, `Ok(usize::MAX)` is returned.
+    pub fn on_dial_address(&mut self) -> Result<usize, ConnectionLimitsError> {
+        if let Some(max_outgoing_connections) = self.config.max_outgoing_connections {
+            if self.outgoing_connections.len() >= max_outgoing_connections {
+                return Err(ConnectionLimitsError::MaxOutgoingConnectionsExceeded);
+            }
+
+            return Ok(max_outgoing_connections - self.outgoing_connections.len());
+        }
+
+        Ok(usize::MAX)
+    }
+
     /// Called when a new connection is established.
     pub fn on_connection_established(
         &mut self,

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -1,0 +1,60 @@
+// Copyright 2024 litep2p developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Limits for the transport manager.
+
+/// Configuration for the connection limits.
+#[derive(Debug, Clone, Default)]
+pub struct ConnectionLimitsConfig {
+    /// Maximum number of connections that can be established.
+    max_connections: Option<usize>,
+    /// Maximum number of incoming connections that can be established.
+    max_incoming_connections: Option<usize>,
+    /// Maximum number of outgoing connections that can be established.
+    max_outgoing_connections: Option<usize>,
+    /// Maximum number of connections that can be established per peer.
+    max_connections_per_peer: Option<usize>,
+}
+
+impl ConnectionLimitsConfig {
+    /// Configures the maximum number of connections that can be established.
+    pub fn max_connections(mut self, limit: Option<usize>) -> Self {
+        self.max_connections = limit;
+        self
+    }
+
+    /// Configures the maximum number of incoming connections that can be established.
+    pub fn max_incoming_connections(mut self, limit: Option<usize>) -> Self {
+        self.max_incoming_connections = limit;
+        self
+    }
+
+    /// Configures the maximum number of outgoing connections that can be established.
+    pub fn max_outgoing_connections(mut self, limit: Option<usize>) -> Self {
+        self.max_outgoing_connections = limit;
+        self
+    }
+
+    /// Configures the maximum number of connections that can be established per peer.
+    pub fn max_connections_per_peer(mut self, limit: Option<usize>) -> Self {
+        self.max_connections_per_peer = limit;
+        self
+    }
+}

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -84,7 +84,6 @@ impl ConnectionLimits {
     /// Called when a new connection is established.
     pub fn on_connection_established(
         &mut self,
-        peer: PeerId,
         connection_id: ConnectionId,
         is_listener: bool,
     ) -> Result<(), ConnectionLimitsError> {
@@ -118,7 +117,7 @@ impl ConnectionLimits {
     }
 
     /// Called when a connection is closed.
-    pub fn on_connection_closed(&mut self, peer: PeerId, connection_id: ConnectionId) {
+    pub fn on_connection_closed(&mut self, connection_id: ConnectionId) {
         self.incoming_connections.remove(&connection_id);
         self.outgoing_connections.remove(&connection_id);
     }
@@ -127,19 +126,15 @@ impl ConnectionLimits {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{types::ConnectionId, PeerId};
+    use crate::types::ConnectionId;
 
     #[test]
     fn connection_limits() {
         let config = ConnectionLimitsConfig::default()
             .max_incoming_connections(Some(3))
-            .max_outgoing_connections(Some(2))
-            .max_connections_per_peer(Some(2));
+            .max_outgoing_connections(Some(2));
         let mut limits = ConnectionLimits::new(config);
 
-        let peer_a = PeerId::random();
-        let peer_b = PeerId::random();
-        let peer_c = PeerId::random();
         let connection_id_in_1 = ConnectionId::random();
         let connection_id_in_2 = ConnectionId::random();
         let connection_id_out_1 = ConnectionId::random();
@@ -148,66 +143,42 @@ mod tests {
         let connection_id_out_3 = ConnectionId::random();
 
         // Establish incoming connection.
-        assert!(limits
-            .on_connection_established(peer_a.clone(), connection_id_in_1, true)
-            .is_ok());
+        assert!(limits.on_connection_established(connection_id_in_1, true).is_ok());
         assert_eq!(limits.incoming_connections.len(), 1);
 
-        assert!(limits
-            .on_connection_established(peer_b.clone(), connection_id_in_2, true)
-            .is_ok());
+        assert!(limits.on_connection_established(connection_id_in_2, true).is_ok());
         assert_eq!(limits.incoming_connections.len(), 2);
 
-        assert!(limits
-            .on_connection_established(peer_c.clone(), connection_id_in_3, true)
-            .is_ok());
+        assert!(limits.on_connection_established(connection_id_in_3, true).is_ok());
         assert_eq!(limits.incoming_connections.len(), 3);
 
         assert_eq!(
-            limits
-                .on_connection_established(PeerId::random(), ConnectionId::random(), true)
-                .unwrap_err(),
+            limits.on_connection_established(ConnectionId::random(), true).unwrap_err(),
             ConnectionLimitsError::MaxIncomingConnectionsExceeded
         );
         assert_eq!(limits.incoming_connections.len(), 3);
 
         // Establish outgoing connection.
-        assert!(limits
-            .on_connection_established(peer_a.clone(), connection_id_out_1, false)
-            .is_ok());
+        assert!(limits.on_connection_established(connection_id_out_1, false).is_ok());
         assert_eq!(limits.incoming_connections.len(), 3);
         assert_eq!(limits.outgoing_connections.len(), 1);
 
-        assert!(limits
-            .on_connection_established(peer_b.clone(), connection_id_out_2, false)
-            .is_ok());
+        assert!(limits.on_connection_established(connection_id_out_2, false).is_ok());
         assert_eq!(limits.incoming_connections.len(), 3);
         assert_eq!(limits.outgoing_connections.len(), 2);
 
         assert_eq!(
-            limits
-                .on_connection_established(peer_c.clone(), connection_id_out_3, false)
-                .unwrap_err(),
+            limits.on_connection_established(connection_id_out_3, false).unwrap_err(),
             ConnectionLimitsError::MaxOutgoingConnectionsExceeded
         );
 
         // Close connections with peer a.
-        limits.on_connection_closed(peer_a.clone(), connection_id_in_1);
+        limits.on_connection_closed(connection_id_in_1);
         assert_eq!(limits.incoming_connections.len(), 2);
         assert_eq!(limits.outgoing_connections.len(), 2);
-        assert_eq!(limits.connections_per_peer.len(), 3);
 
-        limits.on_connection_closed(peer_a.clone(), connection_id_out_1);
+        limits.on_connection_closed(connection_id_out_1);
         assert_eq!(limits.incoming_connections.len(), 2);
         assert_eq!(limits.outgoing_connections.len(), 1);
-        assert_eq!(limits.connections_per_peer.len(), 2);
-
-        // We have room for another incoming connection, however the limit for peer b is reached.
-        assert_eq!(
-            limits
-                .on_connection_established(peer_b.clone(), connection_id_in_3, false)
-                .unwrap_err(),
-            ConnectionLimitsError::MaxConnectionsPerPeerExceeded
-        );
     }
 }

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -57,6 +57,7 @@ pub use handle::{TransportHandle, TransportManagerHandle};
 pub use types::SupportedTransport;
 
 mod address;
+pub mod limits;
 mod types;
 
 pub(crate) mod handle;

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -1659,6 +1659,19 @@ mod tests {
         sync::Arc,
     };
 
+    /// Setup TCP address and connection id.
+    fn setup_dial_addr(peer: PeerId, connection_id: u16) -> (Multiaddr, ConnectionId) {
+        let dial_address = Multiaddr::empty()
+            .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
+            .with(Protocol::Tcp(8888 + connection_id))
+            .with(Protocol::P2p(
+                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
+            ));
+        let connection_id = ConnectionId::from(connection_id as usize);
+
+        (dial_address, connection_id)
+    }
+
     #[test]
     #[should_panic]
     #[cfg(debug_assertions)]
@@ -3378,23 +3391,11 @@ mod tests {
         let peer = PeerId::random();
         let second_peer = PeerId::random();
 
-        let setup_dial_addr = |connection_id: u16| {
-            let dial_address = Multiaddr::empty()
-                .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
-                .with(Protocol::Tcp(8888 + connection_id))
-                .with(Protocol::P2p(
-                    Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-                ));
-            let connection_id = ConnectionId::from(connection_id as usize);
-
-            (dial_address, connection_id)
-        };
-
         // Setup addresses.
-        let (first_addr, first_connection_id) = setup_dial_addr(0);
-        let (second_addr, second_connection_id) = setup_dial_addr(1);
-        let (_, third_connection_id) = setup_dial_addr(2);
-        let (_, remote_connection_id) = setup_dial_addr(3);
+        let (first_addr, first_connection_id) = setup_dial_addr(peer, 0);
+        let (second_addr, second_connection_id) = setup_dial_addr(second_peer, 1);
+        let (_, third_connection_id) = setup_dial_addr(peer, 2);
+        let (_, remote_connection_id) = setup_dial_addr(peer, 3);
 
         // Peer established the first inbound connection.
         let result = manager
@@ -3466,18 +3467,6 @@ mod tests {
         let peer = PeerId::random();
         let second_peer = PeerId::random();
         let third_peer = PeerId::random();
-
-        let setup_dial_addr = |peer: PeerId, connection_id: u16| {
-            let dial_address = Multiaddr::empty()
-                .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
-                .with(Protocol::Tcp(8888 + connection_id))
-                .with(Protocol::P2p(
-                    Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-                ));
-            let connection_id = ConnectionId::from(connection_id as usize);
-
-            (dial_address, connection_id)
-        };
 
         // Setup addresses.
         let (first_addr, first_connection_id) = setup_dial_addr(peer, 0);

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -3526,6 +3526,11 @@ mod tests {
         // Close one connection.
         let _ = manager.on_connection_closed(peer, first_connection_id).unwrap();
         // We can now dial again.
-        manager.dial_address(first_addr).await.unwrap();
+        manager.dial_address(first_addr.clone()).await.unwrap();
+
+        let result = manager
+            .on_connection_established(peer, &Endpoint::dialer(first_addr, first_connection_id))
+            .unwrap();
+        assert_eq!(result, ConnectionEstablishedResult::Accept);
     }
 }

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -1639,6 +1639,8 @@ impl TransportManager {
 
 #[cfg(test)]
 mod tests {
+    use limits::ConnectionLimitsConfig;
+
     use super::*;
     use crate::{
         crypto::ed25519::Keypair, executor::DefaultExecutor, transport::dummy::DummyTransport,
@@ -1653,8 +1655,13 @@ mod tests {
     #[cfg(debug_assertions)]
     fn duplicate_protocol() {
         let sink = BandwidthSink::new();
-        let (mut manager, _handle) =
-            TransportManager::new(Keypair::generate(), HashSet::new(), sink, 8usize);
+        let (mut manager, _handle) = TransportManager::new(
+            Keypair::generate(),
+            HashSet::new(),
+            sink,
+            8usize,
+            ConnectionLimitsConfig::default(),
+        );
 
         manager.register_protocol(
             ProtocolName::from("/notif/1"),
@@ -1673,8 +1680,13 @@ mod tests {
     #[cfg(debug_assertions)]
     fn fallback_protocol_as_duplicate_main_protocol() {
         let sink = BandwidthSink::new();
-        let (mut manager, _handle) =
-            TransportManager::new(Keypair::generate(), HashSet::new(), sink, 8usize);
+        let (mut manager, _handle) = TransportManager::new(
+            Keypair::generate(),
+            HashSet::new(),
+            sink,
+            8usize,
+            ConnectionLimitsConfig::default(),
+        );
 
         manager.register_protocol(
             ProtocolName::from("/notif/1"),
@@ -1696,8 +1708,13 @@ mod tests {
     #[cfg(debug_assertions)]
     fn duplicate_fallback_protocol() {
         let sink = BandwidthSink::new();
-        let (mut manager, _handle) =
-            TransportManager::new(Keypair::generate(), HashSet::new(), sink, 8usize);
+        let (mut manager, _handle) = TransportManager::new(
+            Keypair::generate(),
+            HashSet::new(),
+            sink,
+            8usize,
+            ConnectionLimitsConfig::default(),
+        );
 
         manager.register_protocol(
             ProtocolName::from("/notif/1"),
@@ -1722,8 +1739,13 @@ mod tests {
     #[cfg(debug_assertions)]
     fn duplicate_transport() {
         let sink = BandwidthSink::new();
-        let (mut manager, _handle) =
-            TransportManager::new(Keypair::generate(), HashSet::new(), sink, 8usize);
+        let (mut manager, _handle) = TransportManager::new(
+            Keypair::generate(),
+            HashSet::new(),
+            sink,
+            8usize,
+            ConnectionLimitsConfig::default(),
+        );
 
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1734,7 +1756,13 @@ mod tests {
         let keypair = Keypair::generate();
         let local_peer_id = PeerId::from_public_key(&keypair.public().into());
         let sink = BandwidthSink::new();
-        let (mut manager, _handle) = TransportManager::new(keypair, HashSet::new(), sink, 8usize);
+        let (mut manager, _handle) = TransportManager::new(
+            keypair,
+            HashSet::new(),
+            sink,
+            8usize,
+            ConnectionLimitsConfig::default(),
+        );
 
         assert!(manager.dial(local_peer_id).await.is_err());
     }
@@ -1746,6 +1774,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1775,6 +1804,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -1836,6 +1866,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1866,6 +1897,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1910,6 +1942,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1928,6 +1961,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1956,6 +1990,7 @@ mod tests {
             HashSet::from_iter([SupportedTransport::Tcp, SupportedTransport::Quic]),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         // ipv6
@@ -2014,6 +2049,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -2080,6 +2116,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -2166,6 +2203,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -2250,6 +2288,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2354,6 +2393,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2456,6 +2496,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2562,6 +2603,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2690,6 +2732,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         manager.on_dial_failure(ConnectionId::random()).unwrap();
@@ -2708,6 +2751,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2728,6 +2772,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         manager.on_connection_closed(PeerId::random(), ConnectionId::random()).unwrap();
     }
@@ -2745,6 +2790,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         manager
             .on_connection_opened(
@@ -2768,6 +2814,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2791,6 +2838,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2817,6 +2865,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         manager
@@ -2837,6 +2886,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2856,6 +2906,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         assert!(manager.next().await.is_none());
@@ -2868,6 +2919,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         let peer = {
@@ -2915,6 +2967,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         let peer = {
@@ -2958,6 +3011,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         let peer = {
@@ -3001,6 +3055,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         // transport doesn't start with ip/dns
@@ -3066,6 +3121,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
 
         async fn call_manager(manager: &mut TransportManager, address: Multiaddr) {
@@ -3119,6 +3175,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -3210,6 +3267,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -490,7 +490,9 @@ mod tests {
         codec::ProtocolCodec,
         crypto::ed25519::Keypair,
         executor::DefaultExecutor,
-        transport::manager::{ProtocolContext, SupportedTransport, TransportManager},
+        transport::manager::{
+            limits::ConnectionLimitsConfig, ProtocolContext, SupportedTransport, TransportManager,
+        },
         types::protocol::ProtocolName,
         BandwidthSink, PeerId,
     };
@@ -683,6 +685,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
+            ConnectionLimitsConfig::default(),
         );
         let handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(


### PR DESCRIPTION
This PR adds connection limits for: 
- maximum number of inbound established (negotiated) connections
- maximum number of outbound established (negotiated) connections
- any dial attempts are immediately rejected if we reach capacity for the maximum number of outbound established connections

The public API exposes for the connection limits a builder, both on the Litep2pConfig, as well for the limits:

```rust
let litep2p_config = Config::default()
 .with_connection_limits(ConnectionLimitsConfig::default()
      .max_incoming_connections(Some(3))
      .max_outgoing_connections(Some(2)));
```

The connection limits increments and decrements connections identified by their `ConnectionId(usize)`.
Regarding memory consumption, we use 2 hash-maps that require `sizeof(usize) * (num_of_inbound + num_of_outbound)` for elements. Where,`num_of_inbound` may be capped to `max_incoming_connections` and `num_of_outbound` to `max_outgoing_connections`.

We do not need to introduce a limit on the total number of connections established with a single peer. Litep2p already assumes we can have a maximum of 2 established connections for each peer.

We could also limit the number of inbound non negotiated connections, similar to how we handle outbound connections via dial methods. However, each protocol eagerly accepts and negotiates all inbound connections.
This is not optimal, because we can save resources (CPU + mem) by rejecting non negotiated connections when we are at inbound capacity.

To achieve this, a refactoring needs to move the accepting of inbound connections back into the ownership of the TransportManger, instead of the Transport itself. This PR introduces some changes, to also make it easier for review will look into it as a follow-up:
- https://github.com/paritytech/litep2p/issues/186

Part of:
- https://github.com/paritytech/litep2p/issues/17
