### PR TITLE
kad: Do not update memory store on incoming `GetRecordSuccess`

### DIFF
--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -991,7 +991,7 @@ mod tests {
         let action = QueryAction::GetRecordQueryDone { query_id, records };
         assert!(kademlia.on_query_action(action).await.is_ok());
 
-        // Check the local storage should not get updated updated.
+        // Check the local storage should not get updated.
         assert!(kademlia.store.get(&key).is_none());
     }
 }

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -656,31 +656,6 @@ impl Kademlia {
                 Ok(())
             }
             QueryAction::GetRecordQueryDone { query_id, records } => {
-                // Considering this gives a view of all peers and their records, some peers may have
-                // outdated records. Store only the record which is backed by most
-                // peers.
-                let now = std::time::Instant::now();
-                let rec = records
-                    .iter()
-                    .filter_map(|peer_record| {
-                        if peer_record.record.is_expired(now) {
-                            None
-                        } else {
-                            Some(&peer_record.record)
-                        }
-                    })
-                    .fold(HashMap::new(), |mut acc, rec| {
-                        *acc.entry(rec).or_insert(0) += 1;
-                        acc
-                    })
-                    .into_iter()
-                    .max_by_key(|(_, v)| *v)
-                    .map(|(k, _)| k);
-
-                if let Some(record) = rec {
-                    self.store.put(record.clone());
-                }
-
                 let _ = self
                     .event_tx
                     .send(KademliaEvent::GetRecordSuccess {

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -951,7 +951,7 @@ mod tests {
         let action = QueryAction::GetRecordQueryDone { query_id, records };
         assert!(kademlia.on_query_action(action).await.is_ok());
 
-        // Check the local storage should not get updated updated.
+        // Check the local storage should not get updated.
         assert!(kademlia.store.get(&key).is_none());
     }
 

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -951,9 +951,8 @@ mod tests {
         let action = QueryAction::GetRecordQueryDone { query_id, records };
         assert!(kademlia.on_query_action(action).await.is_ok());
 
-        // Check the local storage was updated.
-        let record = kademlia.store.get(&key).unwrap();
-        assert_eq!(record.value, vec![0x1]);
+        // Check the local storage should not get updated updated.
+        assert!(kademlia.store.get(&key).is_none());
     }
 
     #[tokio::test]
@@ -992,8 +991,7 @@ mod tests {
         let action = QueryAction::GetRecordQueryDone { query_id, records };
         assert!(kademlia.on_query_action(action).await.is_ok());
 
-        // Check the local storage was updated.
-        let record = kademlia.store.get(&key).unwrap();
-        assert_eq!(record.value, vec![0x2]);
+        // Check the local storage should not get updated updated.
+        assert!(kademlia.store.get(&key).is_none());
     }
 }


### PR DESCRIPTION
This PR ensures that the records discovered by the `GetRecord` query are not propagated to the memory store.
This makes the litep2p behavior similar to the libp2p.

Another approach could be to put the record into the memory store if the validation mode is `Automatic`. However, for networks with a large number of records, this will exhaust the limit of our memory store.

Thanks @alexggh for catching this 🙏 

Fix for:
- https://github.com/paritytech/litep2p/pull/190

cc @paritytech/networking 