### PR TITLE
Make transports optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,4 +147,4 @@ jobs:
           cache-all-crates: true
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
           cache-all-crates: true
 
       - name: Cargo check
-        run: cargo check
+        run: cargo check --all-features
 
   doc:
     name: Check documentation
@@ -126,7 +126,7 @@ jobs:
           cache-all-crates: true
 
       - name: Run clippy
-        run: cargo clippy
+        run: cargo clippy --all-features
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ network-interface = "1.1.1"
 parking_lot = "0.12.3"
 pin-project = "1.1.0"
 prost = "0.12.6"
-quinn = { version = "0.9.3", default-features = false, features = ["tls-rustls", "runtime-tokio"] }
+quinn = { version = "0.9.3", default-features = false, features = ["tls-rustls", "runtime-tokio"], optional = true }
 rand = { version = "0.8.0", features = ["getrandom"] }
 rcgen = "0.10.0"
 ring = "0.16.20"
@@ -36,10 +36,10 @@ simple-dns = "0.7.0"
 smallvec = "1.13.2"
 snow = { version = "0.9.3", features = ["ring-resolver"], default-features = false }
 socket2 = { version = "0.5.7", features = ["all"] }
-str0m = "0.5.1"
+str0m = { version = "0.5.1", optional = true }
 thiserror = "1.0.61"
 tokio-stream = "0.1.12"
-tokio-tungstenite = { version = "0.20.0", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.20.0", features = ["rustls-tls-native-roots"], optional = true }
 tokio-util = { version = "0.7.11", features = ["compat", "io", "codec"] }
 tokio = { version = "1.26.0", features = ["rt", "net", "io-util", "time", "macros", "sync", "parking_lot"] }
 tracing = { version = "0.1.40", features = ["log"] }
@@ -47,7 +47,7 @@ trust-dns-resolver = "0.23.2"
 uint = "0.9.5"
 unsigned-varint = { version = "0.8.0", features = ["codec"] }
 url = "2.4.0"
-webpki = "0.22.4"
+webpki = { version = "0.22.4", optional = true }
 x25519-dalek = "2.0.0"
 x509-parser = "0.16.0"
 yasna = "0.5.0"
@@ -87,6 +87,10 @@ futures_ringbuf = "0.4.0"
 
 [features]
 custom_sc_network = []
+tls = ["dep:webpki"]
+quick = ["tls", "dep:quinn"]
+webrtc = ["dep:str0m"]
+websocket = ["dep:tokio-tungstenite"]
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,10 +87,17 @@ futures_ringbuf = "0.4.0"
 
 [features]
 custom_sc_network = []
-tls = ["dep:webpki"]
-quic = ["tls", "dep:quinn"]
+quic = ["dep:webpki", "dep:quinn"]
 webrtc = ["dep:str0m"]
 websocket = ["dep:tokio-tungstenite"]
 
 [profile.release]
 debug = true
+
+[[example]]
+name = "echo_notification"
+required-features = ["quic"]
+
+[[example]]
+name = "syncing"
+required-features = ["quic"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ futures_ringbuf = "0.4.0"
 [features]
 custom_sc_network = []
 tls = ["dep:webpki"]
-quick = ["tls", "dep:quinn"]
+quic = ["tls", "dep:quinn"]
 webrtc = ["dep:str0m"]
 websocket = ["dep:tokio-tungstenite"]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,8 +36,8 @@ use crate::{
     PeerId,
 };
 
-#[cfg(feature = "quick")]
-use crate::transport::quick::config::Config as QuicConfig;
+#[cfg(feature = "quic")]
+use crate::transport::quic::config::Config as QuicConfig;
 #[cfg(feature = "webrtc")]
 use crate::transport::webrtc::config::Config as WebRtcConfig;
 #[cfg(feature = "websocket")]
@@ -72,7 +72,7 @@ pub struct ConfigBuilder {
     tcp: Option<TcpConfig>,
 
     /// QUIC transport config.
-    #[cfg(feature = "quick")]
+    #[cfg(feature = "quic")]
     quic: Option<QuicConfig>,
 
     /// WebRTC transport config.
@@ -134,7 +134,7 @@ impl ConfigBuilder {
     pub fn new() -> Self {
         Self {
             tcp: None,
-            #[cfg(feature = "quick")]
+            #[cfg(feature = "quic")]
             quic: None,
             #[cfg(feature = "webrtc")]
             webrtc: None,
@@ -163,7 +163,7 @@ impl ConfigBuilder {
     }
 
     /// Add QUIC transport configuration, enabling the transport.
-    #[cfg(feature = "quick")]
+    #[cfg(feature = "quic")]
     pub fn with_quic(mut self, config: QuicConfig) -> Self {
         self.quic = Some(config);
         self
@@ -279,7 +279,7 @@ impl ConfigBuilder {
             keypair,
             tcp: self.tcp.take(),
             mdns: self.mdns.take(),
-            #[cfg(feature = "quick")]
+            #[cfg(feature = "quic")]
             quic: self.quic.take(),
             #[cfg(feature = "webrtc")]
             webrtc: self.webrtc.take(),
@@ -306,7 +306,7 @@ pub struct Litep2pConfig {
     pub(crate) tcp: Option<TcpConfig>,
 
     /// QUIC transport config.
-    #[cfg(feature = "quick")]
+    #[cfg(feature = "quic")]
     pub(crate) quic: Option<QuicConfig>,
 
     /// WebRTC transport config.

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,13 +29,19 @@ use crate::{
         notification, request_response, UserProtocol,
     },
     transport::{
-        manager::limits::ConnectionLimitsConfig, quic::config::Config as QuicConfig,
-        tcp::config::Config as TcpConfig, webrtc::config::Config as WebRtcConfig,
-        websocket::config::Config as WebSocketConfig, MAX_PARALLEL_DIALS,
+        manager::limits::ConnectionLimitsConfig, tcp::config::Config as TcpConfig,
+        MAX_PARALLEL_DIALS,
     },
     types::protocol::ProtocolName,
     PeerId,
 };
+
+#[cfg(feature = "quick")]
+use crate::transport::quick::config::Config as QuicConfig;
+#[cfg(feature = "webrtc")]
+use crate::transport::webrtc::config::Config as WebRtcConfig;
+#[cfg(feature = "websocket")]
+use crate::transport::websocket::config::Config as WebSocketConfig;
 
 use multiaddr::Multiaddr;
 
@@ -66,12 +72,15 @@ pub struct ConfigBuilder {
     tcp: Option<TcpConfig>,
 
     /// QUIC transport config.
+    #[cfg(feature = "quick")]
     quic: Option<QuicConfig>,
 
     /// WebRTC transport config.
+    #[cfg(feature = "webrtc")]
     webrtc: Option<WebRtcConfig>,
 
     /// WebSocket transport config.
+    #[cfg(feature = "websocket")]
     websocket: Option<WebSocketConfig>,
 
     /// Keypair.
@@ -125,8 +134,11 @@ impl ConfigBuilder {
     pub fn new() -> Self {
         Self {
             tcp: None,
+            #[cfg(feature = "quick")]
             quic: None,
+            #[cfg(feature = "webrtc")]
             webrtc: None,
+            #[cfg(feature = "websocket")]
             websocket: None,
             keypair: None,
             ping: None,
@@ -151,18 +163,21 @@ impl ConfigBuilder {
     }
 
     /// Add QUIC transport configuration, enabling the transport.
+    #[cfg(feature = "quick")]
     pub fn with_quic(mut self, config: QuicConfig) -> Self {
         self.quic = Some(config);
         self
     }
 
     /// Add WebRTC transport configuration, enabling the transport.
+    #[cfg(feature = "webrtc")]
     pub fn with_webrtc(mut self, config: WebRtcConfig) -> Self {
         self.webrtc = Some(config);
         self
     }
 
     /// Add WebSocket transport configuration, enabling the transport.
+    #[cfg(feature = "websocket")]
     pub fn with_websocket(mut self, config: WebSocketConfig) -> Self {
         self.websocket = Some(config);
         self
@@ -264,8 +279,11 @@ impl ConfigBuilder {
             keypair,
             tcp: self.tcp.take(),
             mdns: self.mdns.take(),
+            #[cfg(feature = "quick")]
             quic: self.quic.take(),
+            #[cfg(feature = "webrtc")]
             webrtc: self.webrtc.take(),
+            #[cfg(feature = "websocket")]
             websocket: self.websocket.take(),
             ping: self.ping.take(),
             identify: self.identify.take(),
@@ -288,12 +306,15 @@ pub struct Litep2pConfig {
     pub(crate) tcp: Option<TcpConfig>,
 
     /// QUIC transport config.
+    #[cfg(feature = "quick")]
     pub(crate) quic: Option<QuicConfig>,
 
     /// WebRTC transport config.
+    #[cfg(feature = "webrtc")]
     pub(crate) webrtc: Option<WebRtcConfig>,
 
     /// WebSocket transport config.
+    #[cfg(feature = "websocket")]
     pub(crate) websocket: Option<WebSocketConfig>,
 
     /// Keypair.

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -25,6 +25,7 @@ use crate::{error::*, peer_id::*};
 
 pub mod ed25519;
 pub(crate) mod noise;
+#[cfg(feature = "tls")]
 pub(crate) mod tls;
 pub(crate) mod keys_proto {
     include!(concat!(env!("OUT_DIR"), "/keys_proto.rs"));

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -25,7 +25,7 @@ use crate::{error::*, peer_id::*};
 
 pub mod ed25519;
 pub(crate) mod noise;
-#[cfg(feature = "tls")]
+#[cfg(feature = "quic")]
 pub(crate) mod tls;
 pub(crate) mod keys_proto {
     include!(concat!(env!("OUT_DIR"), "/keys_proto.rs"));

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -95,8 +95,8 @@ impl TryFrom<keys_proto::PublicKey> for PublicKey {
     type Error = Error;
 
     fn try_from(pubkey: keys_proto::PublicKey) -> Result<Self, Self::Error> {
-        let key_type = keys_proto::KeyType::from_i32(pubkey.r#type)
-            .ok_or_else(|| Error::Other(format!("Unknown key type: {}", pubkey.r#type)))?;
+        let key_type = keys_proto::KeyType::try_from(pubkey.r#type)
+            .map_err(|_| Error::Other(format!("Unknown key type: {}", pubkey.r#type)))?;
 
         match key_type {
             keys_proto::KeyType::Ed25519 =>

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -143,6 +143,7 @@ impl NoiseContext {
     }
 
     /// Create new [`NoiseContext`] with prologue.
+    #[cfg(feature = "webrtc")]
     pub fn with_prologue(id_keys: &Keypair, prologue: Vec<u8>) -> crate::Result<Self> {
         let noise: Builder<'_> = Builder::with_resolver(
             NOISE_PARAMETERS.parse().expect("qed; Valid noise pattern"),
@@ -160,6 +161,7 @@ impl NoiseContext {
     }
 
     /// Get remote public key from the received Noise payload.
+    #[cfg(feature = "webrtc")]
     pub fn get_remote_public_key(&mut self, reply: &[u8]) -> crate::Result<PublicKey> {
         let (len_slice, reply) = reply.split_at(2);
         let len = u16::from_be_bytes(len_slice.try_into().map_err(|_| error::Error::InvalidData)?)

--- a/src/crypto/noise/protocol.rs
+++ b/src/crypto/noise/protocol.rs
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::crypto::{self, noise::x25519_spec};
+use crate::crypto::noise::x25519_spec;
 
 use rand::SeedableRng;
 use zeroize::Zeroize;
@@ -28,16 +28,6 @@ use zeroize::Zeroize;
 pub struct Keypair<T: Zeroize> {
     pub secret: SecretKey<T>,
     pub public: PublicKey<T>,
-}
-
-/// The associated public identity of a DH keypair.
-#[derive(Clone)]
-pub struct KeypairIdentity {
-    /// The public identity key.
-    pub public: crypto::PublicKey,
-
-    /// The signature over the public DH key.
-    pub signature: Option<Vec<u8>>,
 }
 
 /// DH secret key.

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,7 +112,7 @@ pub enum Error {
     NoAddressAvailable(PeerId),
     #[error("Connection closed")]
     ConnectionClosed,
-    #[cfg(feature = "quick")]
+    #[cfg(feature = "quic")]
     #[error("Quinn error: `{0}`")]
     Quinn(quinn::ConnectionError),
     #[error("Invalid certificate")]
@@ -241,7 +241,7 @@ impl From<prost::EncodeError> for Error {
     }
 }
 
-#[cfg(feature = "quick")]
+#[cfg(feature = "quic")]
 impl From<quinn::ConnectionError> for Error {
     fn from(error: quinn::ConnectionError) -> Self {
         match error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,18 +83,21 @@ pub enum Error {
     DnsAddressResolutionFailed,
     #[error("Transport error: `{0}`")]
     TransportError(String),
+    #[cfg(feature = "tls")]
     #[error("Failed to generate certificate: `{0}`")]
     CertificateGeneration(#[from] crate::crypto::tls::certificate::GenError),
     #[error("Invalid data")]
     InvalidData,
     #[error("Input rejected")]
     InputRejected,
+    #[cfg(feature = "websocket")]
     #[error("WebSocket error: `{0}`")]
     WebSocket(#[from] tokio_tungstenite::tungstenite::error::Error),
     #[error("Insufficient peers")]
     InsufficientPeers,
     #[error("Substream doens't exist")]
     SubstreamDoesntExist,
+    #[cfg(feature = "webrtc")]
     #[error("`str0m` error: `{0}`")]
     WebRtc(#[from] str0m::RtcError),
     #[error("Remote peer disconnected")]
@@ -109,6 +112,7 @@ pub enum Error {
     NoAddressAvailable(PeerId),
     #[error("Connection closed")]
     ConnectionClosed,
+    #[cfg(feature = "quick")]
     #[error("Quinn error: `{0}`")]
     Quinn(quinn::ConnectionError),
     #[error("Invalid certificate")]
@@ -237,6 +241,7 @@ impl From<prost::EncodeError> for Error {
     }
 }
 
+#[cfg(feature = "quick")]
 impl From<quinn::ConnectionError> for Error {
     fn from(error: quinn::ConnectionError) -> Self {
         match error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,7 +83,7 @@ pub enum Error {
     DnsAddressResolutionFailed,
     #[error("Transport error: `{0}`")]
     TransportError(String),
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "quic")]
     #[error("Failed to generate certificate: `{0}`")]
     CertificateGeneration(#[from] crate::crypto::tls::certificate::GenError),
     #[error("Invalid data")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,13 +38,17 @@ use crate::{
     },
     transport::{
         manager::{SupportedTransport, TransportManager},
-        quic::QuicTransport,
         tcp::TcpTransport,
-        webrtc::WebRtcTransport,
-        websocket::WebSocketTransport,
         TransportBuilder, TransportEvent,
     },
 };
+
+#[cfg(feature = "quick")]
+use crate::transport::quick::QuicTransport;
+#[cfg(feature = "webrtc")]
+use crate::transport::webrtc::WebRtcTransport;
+#[cfg(feature = "websocket")]
+use crate::transport::websocket::WebSocketTransport;
 
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
@@ -297,6 +301,7 @@ impl Litep2p {
         }
 
         // enable quic transport if the config exists
+        #[cfg(feature = "quick")]
         if let Some(config) = litep2p_config.quic.take() {
             let handle = transport_manager.transport_handle(Arc::clone(&litep2p_config.executor));
             let (transport, transport_listen_addresses) =
@@ -313,6 +318,7 @@ impl Litep2p {
         }
 
         // enable webrtc transport if the config exists
+        #[cfg(feature = "webrtc")]
         if let Some(config) = litep2p_config.webrtc.take() {
             let handle = transport_manager.transport_handle(Arc::clone(&litep2p_config.executor));
             let (transport, transport_listen_addresses) =
@@ -329,6 +335,7 @@ impl Litep2p {
         }
 
         // enable websocket transport if the config exists
+        #[cfg(feature = "websocket")]
         if let Some(config) = litep2p_config.websocket.take() {
             let handle = transport_manager.transport_handle(Arc::clone(&litep2p_config.executor));
             let (transport, transport_listen_addresses) =
@@ -396,14 +403,17 @@ impl Litep2p {
             .tcp
             .is_some()
             .then(|| supported_transports.insert(SupportedTransport::Tcp));
+        #[cfg(feature = "quick")]
         config
             .quic
             .is_some()
             .then(|| supported_transports.insert(SupportedTransport::Quic));
+        #[cfg(feature = "websocket")]
         config
             .websocket
             .is_some()
             .then(|| supported_transports.insert(SupportedTransport::WebSocket));
+        #[cfg(feature = "webrtc")]
         config
             .webrtc
             .is_some()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use crate::{
     },
 };
 
-#[cfg(feature = "quick")]
+#[cfg(feature = "quic")]
 use crate::transport::quick::QuicTransport;
 #[cfg(feature = "webrtc")]
 use crate::transport::webrtc::WebRtcTransport;
@@ -301,7 +301,7 @@ impl Litep2p {
         }
 
         // enable quic transport if the config exists
-        #[cfg(feature = "quick")]
+        #[cfg(feature = "quic")]
         if let Some(config) = litep2p_config.quic.take() {
             let handle = transport_manager.transport_handle(Arc::clone(&litep2p_config.executor));
             let (transport, transport_listen_addresses) =
@@ -403,7 +403,7 @@ impl Litep2p {
             .tcp
             .is_some()
             .then(|| supported_transports.insert(SupportedTransport::Tcp));
-        #[cfg(feature = "quick")]
+        #[cfg(feature = "quic")]
         config
             .quic
             .is_some()
@@ -525,7 +525,6 @@ mod tests {
 
         let config = ConfigBuilder::new()
             .with_tcp(Default::default())
-            .with_quic(Default::default())
             .with_notification_protocol(config1)
             .with_notification_protocol(config2)
             .with_libp2p_ping(ping_config)
@@ -601,7 +600,6 @@ mod tests {
 
         let config = ConfigBuilder::new()
             .with_tcp(Default::default())
-            .with_quic(Default::default())
             .with_notification_protocol(config1)
             .with_notification_protocol(config2)
             .with_libp2p_ping(ping_config)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 
 #[cfg(feature = "quic")]
-use crate::transport::quick::QuicTransport;
+use crate::transport::quic::QuicTransport;
 #[cfg(feature = "webrtc")]
 use crate::transport::webrtc::WebRtcTransport;
 #[cfg(feature = "websocket")]
@@ -76,8 +76,10 @@ pub mod types;
 pub mod yamux;
 
 mod bandwidth;
-mod mock;
 mod multistream_select;
+
+#[cfg(test)]
+mod mock;
 
 /// Public result type used by the crate.
 pub type Result<T> = std::result::Result<T, error::Error>;

--- a/src/multistream_select/length_delimited.rs
+++ b/src/multistream_select/length_delimited.rs
@@ -25,7 +25,6 @@ use std::{
     io,
     pin::Pin,
     task::{Context, Poll},
-    u16,
 };
 
 const MAX_LEN_BYTES: u16 = 2;

--- a/src/protocol/notification/mod.rs
+++ b/src/protocol/notification/mod.rs
@@ -531,7 +531,7 @@ impl NotificationProtocol {
         let Some(context) = self.peers.get_mut(&peer) else {
             tracing::error!(target: LOG_TARGET, ?peer, "peer doesn't exist for outbound substream");
             debug_assert!(false);
-            return Err(Error::PeerDoesntExist(peer.clone()));
+            return Err(Error::PeerDoesntExist(peer));
         };
 
         let pending_peer = self.pending_outbound.remove(&substream_id);
@@ -661,7 +661,7 @@ impl NotificationProtocol {
         let Some(context) = self.peers.get_mut(&peer) else {
             tracing::error!(target: LOG_TARGET, ?peer, "peer doesn't exist for inbound substream");
             debug_assert!(false);
-            return Err(Error::PeerDoesntExist(peer.clone()));
+            return Err(Error::PeerDoesntExist(peer));
         };
 
         tracing::debug!(

--- a/src/protocol/protocol_set.rs
+++ b/src/protocol/protocol_set.rs
@@ -38,14 +38,13 @@ use futures::{stream::FuturesUnordered, Stream, StreamExt};
 use multiaddr::Multiaddr;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
+#[cfg(any(feature = "quic", feature = "webrtc", feature = "websocket"))]
+use std::sync::atomic::Ordering;
 use std::{
     collections::HashMap,
     fmt::Debug,
     pin::Pin,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::{atomic::AtomicUsize, Arc},
     task::{Context, Poll},
 };
 
@@ -213,6 +212,7 @@ pub struct ProtocolSet {
     mgr_tx: Sender<TransportManagerEvent>,
     connection: ConnectionHandle,
     rx: Receiver<ProtocolCommand>,
+    #[allow(unused)]
     next_substream_id: Arc<AtomicUsize>,
     fallback_names: HashMap<ProtocolName, ProtocolName>,
 }
@@ -253,6 +253,7 @@ impl ProtocolSet {
     }
 
     /// Get next substream ID.
+    #[cfg(any(feature = "quic", feature = "webrtc", feature = "websocket"))]
     pub fn next_substream_id(&self) -> SubstreamId {
         SubstreamId::from(self.next_substream_id.fetch_add(1usize, Ordering::Relaxed))
     }

--- a/src/transport/common/listener.rs
+++ b/src/transport/common/listener.rs
@@ -370,7 +370,7 @@ fn multiaddr_to_socket_address(
                     ?protocol,
                     "invalid transport protocol, expected `Tcp`",
                 );
-                return Err(Error::AddressError(AddressError::InvalidProtocol));
+                Err(Error::AddressError(AddressError::InvalidProtocol))
             }
         };
 

--- a/src/transport/manager/handle.rs
+++ b/src/transport/manager/handle.rs
@@ -287,7 +287,7 @@ pub struct TransportHandle {
     pub protocols: HashMap<ProtocolName, ProtocolContext>,
     pub next_connection_id: Arc<AtomicUsize>,
     pub next_substream_id: Arc<AtomicUsize>,
-    pub protocol_names: Vec<ProtocolName>,
+    pub _protocol_names: Vec<ProtocolName>,
     pub bandwidth_sink: BandwidthSink,
     pub executor: Arc<dyn Executor>,
 }

--- a/src/transport/manager/handle.rs
+++ b/src/transport/manager/handle.rs
@@ -287,7 +287,6 @@ pub struct TransportHandle {
     pub protocols: HashMap<ProtocolName, ProtocolContext>,
     pub next_connection_id: Arc<AtomicUsize>,
     pub next_substream_id: Arc<AtomicUsize>,
-    pub _protocol_names: Vec<ProtocolName>,
     pub bandwidth_sink: BandwidthSink,
     pub executor: Arc<dyn Executor>,
 }

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -357,7 +357,7 @@ impl TransportManager {
             keypair: self.keypair.clone(),
             protocols: self.protocols.clone(),
             bandwidth_sink: self.bandwidth_sink.clone(),
-            protocol_names: self.protocol_names.iter().cloned().collect(),
+            _protocol_names: self.protocol_names.iter().cloned().collect(),
             next_substream_id: self.next_substream_id.clone(),
             next_connection_id: self.next_connection_id.clone(),
         }

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -357,7 +357,6 @@ impl TransportManager {
             keypair: self.keypair.clone(),
             protocols: self.protocols.clone(),
             bandwidth_sink: self.bandwidth_sink.clone(),
-            _protocol_names: self.protocol_names.iter().cloned().collect(),
             next_substream_id: self.next_substream_id.clone(),
             next_connection_id: self.next_connection_id.clone(),
         }

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -499,33 +499,35 @@ impl TransportManager {
         );
 
         let mut transports = HashSet::new();
+        #[cfg(feature = "websocket")]
         let mut websocket = Vec::new();
+        #[cfg(feature = "quic")]
         let mut quic = Vec::new();
         let mut tcp = Vec::new();
 
         for (address, record) in &mut records {
             record.set_connection_id(connection_id);
 
-            let mut iter = address.iter();
-            match iter.find(|protocol| std::matches!(protocol, Protocol::QuicV1)) {
-                Some(_) => {
-                    quic.push(address.clone());
-                    transports.insert(SupportedTransport::Quic);
-                }
-                _ => match address
-                    .iter()
-                    .find(|protocol| std::matches!(protocol, Protocol::Ws(_) | Protocol::Wss(_)))
-                {
-                    Some(_) => {
-                        websocket.push(address.clone());
-                        transports.insert(SupportedTransport::WebSocket);
-                    }
-                    None => {
-                        tcp.push(address.clone());
-                        transports.insert(SupportedTransport::Tcp);
-                    }
-                },
+            #[cfg(feature = "quic")]
+            if address.iter().find(|p| std::matches!(p, Protocol::QuicV1)).is_some() {
+                quic.push(address.clone());
+                transports.insert(SupportedTransport::Quic);
+                continue;
             }
+
+            #[cfg(feature = "websocket")]
+            if address
+                .iter()
+                .find(|p| std::matches!(p, Protocol::Ws(_) | Protocol::Wss(_)))
+                .is_some()
+            {
+                websocket.push(address.clone());
+                transports.insert(SupportedTransport::WebSocket);
+                continue;
+            }
+
+            tcp.push(address.clone());
+            transports.insert(SupportedTransport::Tcp);
         }
 
         peers.insert(
@@ -548,6 +550,7 @@ impl TransportManager {
                 .open(connection_id, tcp)?;
         }
 
+        #[cfg(feature = "quic")]
         if !quic.is_empty() {
             self.transports
                 .get_mut(&SupportedTransport::Quic)
@@ -555,6 +558,7 @@ impl TransportManager {
                 .open(connection_id, quic)?;
         }
 
+        #[cfg(feature = "websocket")]
         if !websocket.is_empty() {
             self.transports
                 .get_mut(&SupportedTransport::WebSocket)
@@ -604,10 +608,12 @@ impl TransportManager {
             .ok_or_else(|| Error::TransportNotSupported(record.address().clone()))?
         {
             Protocol::Tcp(_) => match protocol_stack.next() {
+                #[cfg(feature = "websocket")]
                 Some(Protocol::Ws(_)) | Some(Protocol::Wss(_)) => SupportedTransport::WebSocket,
                 Some(Protocol::P2p(_)) => SupportedTransport::Tcp,
                 _ => return Err(Error::TransportNotSupported(record.address().clone())),
             },
+            #[cfg(feature = "quic")]
             Protocol::Udp(_) => match protocol_stack
                 .next()
                 .ok_or_else(|| Error::TransportNotSupported(record.address().clone()))?
@@ -622,7 +628,7 @@ impl TransportManager {
                 tracing::error!(
                     target: LOG_TARGET,
                     ?protocol,
-                    "invalid protocol, expected `tcp`"
+                    "invalid protocol"
                 );
 
                 return Err(Error::TransportNotSupported(record.address().clone()));
@@ -2020,9 +2026,14 @@ mod tests {
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .try_init();
 
+        let mut transports = HashSet::new();
+        transports.insert(SupportedTransport::Tcp);
+        #[cfg(feature = "quic")]
+        transports.insert(SupportedTransport::Quic);
+
         let (_manager, handle) = TransportManager::new(
             Keypair::generate(),
-            HashSet::from_iter([SupportedTransport::Tcp, SupportedTransport::Quic]),
+            transports,
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
@@ -2054,7 +2065,10 @@ mod tests {
             .with(Protocol::P2p(
                 Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
             ));
+        #[cfg(feature = "quic")]
         assert!(handle.supported_transport(&address));
+        #[cfg(not(feature = "quic"))]
+        assert!(!handle.supported_transport(&address));
 
         // websocket
         let address = Multiaddr::empty()

--- a/src/transport/manager/types.rs
+++ b/src/transport/manager/types.rs
@@ -34,12 +34,15 @@ pub enum SupportedTransport {
     Tcp,
 
     /// QUIC.
+    #[cfg(feature = "quic")]
     Quic,
 
     /// WebRTC
+    #[cfg(feature = "webrtc")]
     WebRtc,
 
     /// WebSocket
+    #[cfg(feature = "websocket")]
     WebSocket,
 }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -28,9 +28,12 @@ use multiaddr::Multiaddr;
 use std::{fmt::Debug, time::Duration};
 
 pub(crate) mod common;
+#[cfg(feature = "quic")]
 pub mod quic;
 pub mod tcp;
+#[cfg(feature = "webrtc")]
 pub mod webrtc;
+#[cfg(feature = "websocket")]
 pub mod websocket;
 
 pub(crate) mod dummy;

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -495,7 +495,7 @@ mod tests {
 
         let handle1 = TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            protocol_names: Vec::new(),
+            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair1.clone(),
@@ -522,7 +522,7 @@ mod tests {
 
         let handle2 = TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            protocol_names: Vec::new(),
+            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair2.clone(),

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -495,7 +495,6 @@ mod tests {
 
         let handle1 = TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair1.clone(),
@@ -522,7 +521,6 @@ mod tests {
 
         let handle2 = TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair2.clone(),

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -514,7 +514,7 @@ mod tests {
 
         let handle1 = crate::transport::manager::TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            protocol_names: Vec::new(),
+            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair1.clone(),
@@ -545,7 +545,7 @@ mod tests {
 
         let handle2 = crate::transport::manager::TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            protocol_names: Vec::new(),
+            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair2.clone(),
@@ -594,7 +594,7 @@ mod tests {
 
         let handle1 = crate::transport::manager::TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            protocol_names: Vec::new(),
+            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair1.clone(),
@@ -630,7 +630,7 @@ mod tests {
 
         let handle2 = crate::transport::manager::TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            protocol_names: Vec::new(),
+            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair2.clone(),

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -514,7 +514,6 @@ mod tests {
 
         let handle1 = crate::transport::manager::TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair1.clone(),
@@ -545,7 +544,6 @@ mod tests {
 
         let handle2 = crate::transport::manager::TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair2.clone(),
@@ -594,7 +592,6 @@ mod tests {
 
         let handle1 = crate::transport::manager::TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair1.clone(),
@@ -630,7 +627,6 @@ mod tests {
 
         let handle2 = crate::transport::manager::TransportHandle {
             executor: Arc::new(DefaultExecutor {}),
-            _protocol_names: Vec::new(),
             next_substream_id: Default::default(),
             next_connection_id: Default::default(),
             keypair: keypair2.clone(),

--- a/src/yamux/connection/stream.rs
+++ b/src/yamux/connection/stream.rs
@@ -494,7 +494,7 @@ impl Shared {
             WindowUpdateMode::OnRead => {
                 debug_assert!(self.config.receive_window >= self.window);
                 let bytes_received = self.config.receive_window.saturating_sub(self.window);
-                let buffer_len: u32 = self.buffer.len().try_into().unwrap_or(std::u32::MAX);
+                let buffer_len: u32 = self.buffer.len().try_into().unwrap_or(u32::MAX);
 
                 bytes_received.saturating_sub(buffer_len)
             }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 litep2p developers
+// Copyright 2024 litep2p developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -18,7 +18,27 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-mod common;
-mod conformance;
-mod connection;
-mod protocol;
+use litep2p::{config::ConfigBuilder, transport::tcp::config::Config as TcpConfig};
+
+#[cfg(feature = "quic")]
+use litep2p::transport::quic::config::Config as QuicConfig;
+#[cfg(feature = "websocket")]
+use litep2p::transport::websocket::config::Config as WebSocketConfig;
+
+pub(crate) enum Transport {
+    Tcp(TcpConfig),
+    #[cfg(feature = "quic")]
+    Quic(QuicConfig),
+    #[cfg(feature = "websocket")]
+    WebSocket(WebSocketConfig),
+}
+
+pub(crate) fn add_transport(config: ConfigBuilder, transport: Transport) -> ConfigBuilder {
+    match transport {
+        Transport::Tcp(transport) => config.with_tcp(transport),
+        #[cfg(feature = "quic")]
+        Transport::Quic(transport) => config.with_quic(transport),
+        #[cfg(feature = "websocket")]
+        Transport::WebSocket(transport) => config.with_websocket(transport),
+    }
+}

--- a/tests/conformance/rust/mod.rs
+++ b/tests/conformance/rust/mod.rs
@@ -24,5 +24,5 @@ mod identify;
 mod kademlia;
 #[cfg(test)]
 mod ping;
-#[cfg(test)]
+#[cfg(all(test, feature = "quic"))]
 mod quic_ping;

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -40,26 +40,10 @@ use tokio::net::TcpListener;
 #[cfg(feature = "quic")]
 use tokio::net::UdpSocket;
 
+use crate::common::{add_transport, Transport};
+
 #[cfg(test)]
 mod protocol_dial_invalid_address;
-
-enum Transport {
-    Tcp(TcpConfig),
-    #[cfg(feature = "quic")]
-    Quic(QuicConfig),
-    #[cfg(feature = "websocket")]
-    WebSocket(WebSocketConfig),
-}
-
-fn add_transport(config: ConfigBuilder, transport: Transport) -> ConfigBuilder {
-    match transport {
-        Transport::Tcp(transport) => config.with_tcp(transport),
-        #[cfg(feature = "quic")]
-        Transport::Quic(transport) => config.with_quic(transport),
-        #[cfg(feature = "websocket")]
-        Transport::WebSocket(transport) => config.with_websocket(transport),
-    }
-}
 
 #[tokio::test]
 async fn two_litep2ps_work_tcp() {

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -51,6 +51,16 @@ enum Transport {
     WebSocket(WebSocketConfig),
 }
 
+fn add_transport(config: ConfigBuilder, transport: Transport) -> ConfigBuilder {
+    match transport {
+        Transport::Tcp(transport) => config.with_tcp(transport),
+        #[cfg(feature = "quic")]
+        Transport::Quic(transport) => config.with_quic(transport),
+        #[cfg(feature = "websocket")]
+        Transport::WebSocket(transport) => config.with_websocket(transport),
+    }
+}
+
 #[tokio::test]
 async fn two_litep2ps_work_tcp() {
     two_litep2ps_work(
@@ -102,28 +112,14 @@ async fn two_litep2ps_work(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => config1.with_quic(config),
-        #[cfg(feature = "websocket")]
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (ping_config2, _ping_event_stream2) = PingConfig::default();
     let config2 = ConfigBuilder::new()
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => config2.with_quic(config),
-        #[cfg(feature = "webscoekt")]
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -211,28 +207,14 @@ async fn dial_failure(transport1: Transport, transport2: Transport, dial_address
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => config1.with_quic(config),
-        #[cfg(feature = "webscocket")]
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (ping_config2, _ping_event_stream2) = PingConfig::default();
     let config2 = ConfigBuilder::new()
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => config2.with_quic(config),
-        #[cfg(feature = "webscocket")]
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -384,15 +366,7 @@ async fn connection_timeout(transport: Transport, address: Multiaddr) {
     let litep2p_config = ConfigBuilder::new()
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config);
-
-    let litep2p_config = match transport {
-        Transport::Tcp(config) => litep2p_config.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => litep2p_config.with_quic(config),
-        #[cfg(feature = "webscocket")]
-        Transport::WebSocket(config) => litep2p_config.with_websocket(config),
-    }
-    .build();
+    let litep2p_config = add_transport(litep2p_config, transport).build();
 
     let mut litep2p = Litep2p::new(litep2p_config).unwrap();
 
@@ -475,15 +449,7 @@ async fn dial_self(transport: Transport) {
     let litep2p_config = ConfigBuilder::new()
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config);
-
-    let litep2p_config = match transport {
-        Transport::Tcp(config) => litep2p_config.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => litep2p_config.with_quic(config),
-        #[cfg(feature = "webscocket")]
-        Transport::WebSocket(config) => litep2p_config.with_websocket(config),
-    }
-    .build();
+    let litep2p_config = add_transport(litep2p_config, transport).build();
 
     let mut litep2p = Litep2p::new(litep2p_config).unwrap();
     let address = litep2p.listen_addresses().next().unwrap().clone();
@@ -602,14 +568,7 @@ async fn keep_alive_timeout(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => config1.with_quic(config),
-        #[cfg(feature = "websocket")]
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
     let mut litep2p1 = Litep2p::new(config1).unwrap();
 
     let (ping_config2, mut ping_event_stream2) = PingConfig::default();
@@ -617,14 +576,7 @@ async fn keep_alive_timeout(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => config2.with_quic(config),
-        #[cfg(feature = "websocket")]
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
 
     let address1 = litep2p1.listen_addresses().next().unwrap().clone();
@@ -1476,28 +1428,14 @@ async fn simultaneous_dial_then_redial(transport1: Transport, transport2: Transp
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => config1.with_quic(config),
-        #[cfg(feature = "websocket")]
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (ping_config2, _ping_event_stream2) = PingConfig::default();
     let config2 = ConfigBuilder::new()
         .with_keypair(Keypair::generate())
         .with_libp2p_ping(ping_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        #[cfg(feature = "quic")]
-        Transport::Quic(config) => config2.with_quic(config),
-        #[cfg(feature = "webscocket")]
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -37,7 +37,7 @@ use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use tokio::net::TcpListener;
-#[cfg(fetaure = "quic")]
+#[cfg(feature = "quic")]
 use tokio::net::UdpSocket;
 
 #[cfg(test)]

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -21,27 +21,33 @@
 use litep2p::{
     config::ConfigBuilder,
     crypto::ed25519::Keypair,
-    error::{AddressError, Error},
+    error::Error,
     protocol::libp2p::ping::{Config as PingConfig, PingEvent},
-    transport::{
-        quic::config::Config as QuicConfig, tcp::config::Config as TcpConfig,
-        websocket::config::Config as WebSocketConfig,
-    },
+    transport::tcp::config::Config as TcpConfig,
     Litep2p, Litep2pEvent, PeerId,
 };
+
+#[cfg(feature = "websocket")]
+use litep2p::transport::websocket::config::Config as WebSocketConfig;
+#[cfg(feature = "quic")]
+use litep2p::{error::AddressError, transport::quic::config::Config as QuicConfig};
 
 use futures::{Stream, StreamExt};
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
-use tokio::net::{TcpListener, UdpSocket};
+use tokio::net::TcpListener;
+#[cfg(fetaure = "quic")]
+use tokio::net::UdpSocket;
 
 #[cfg(test)]
 mod protocol_dial_invalid_address;
 
 enum Transport {
     Tcp(TcpConfig),
+    #[cfg(feature = "quic")]
     Quic(QuicConfig),
+    #[cfg(feature = "websocket")]
     WebSocket(WebSocketConfig),
 }
 
@@ -60,6 +66,7 @@ async fn two_litep2ps_work_tcp() {
     .await
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn two_litep2ps_work_quic() {
     two_litep2ps_work(
@@ -69,6 +76,7 @@ async fn two_litep2ps_work_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn two_litep2ps_work_websocket() {
     two_litep2ps_work(
@@ -96,7 +104,9 @@ async fn two_litep2ps_work(transport1: Transport, transport2: Transport) {
 
     let config1 = match transport1 {
         Transport::Tcp(config) => config1.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config1.with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => config1.with_websocket(config),
     }
     .build();
@@ -108,7 +118,9 @@ async fn two_litep2ps_work(transport1: Transport, transport2: Transport) {
 
     let config2 = match transport2 {
         Transport::Tcp(config) => config2.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config2.with_quic(config),
+        #[cfg(feature = "webscoekt")]
         Transport::WebSocket(config) => config2.with_websocket(config),
     }
     .build();
@@ -151,6 +163,7 @@ async fn dial_failure_tcp() {
     .await
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn dial_failure_quic() {
     dial_failure(
@@ -166,6 +179,7 @@ async fn dial_failure_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn dial_failure_websocket() {
     dial_failure(
@@ -199,7 +213,9 @@ async fn dial_failure(transport1: Transport, transport2: Transport, dial_address
 
     let config1 = match transport1 {
         Transport::Tcp(config) => config1.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config1.with_quic(config),
+        #[cfg(feature = "webscocket")]
         Transport::WebSocket(config) => config1.with_websocket(config),
     }
     .build();
@@ -211,7 +227,9 @@ async fn dial_failure(transport1: Transport, transport2: Transport, dial_address
 
     let config2 = match transport2 {
         Transport::Tcp(config) => config2.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config2.with_quic(config),
+        #[cfg(feature = "webscocket")]
         Transport::WebSocket(config) => config2.with_websocket(config),
     }
     .build();
@@ -316,6 +334,7 @@ async fn connection_timeout_tcp() {
     .await
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn connection_timeout_quic() {
     // create udp socket but don't respond to any inbound datagrams
@@ -332,6 +351,7 @@ async fn connection_timeout_quic() {
     connection_timeout(Transport::Quic(Default::default()), address).await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn connection_timeout_websocket() {
     // create tcp listener but don't accept any inbound connections
@@ -367,7 +387,9 @@ async fn connection_timeout(transport: Transport, address: Multiaddr) {
 
     let litep2p_config = match transport {
         Transport::Tcp(config) => litep2p_config.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => litep2p_config.with_quic(config),
+        #[cfg(feature = "webscocket")]
         Transport::WebSocket(config) => litep2p_config.with_websocket(config),
     }
     .build();
@@ -389,6 +411,7 @@ async fn connection_timeout(transport: Transport, address: Multiaddr) {
     assert!(std::matches!(error, Error::Timeout));
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn dial_quic_peer_id_missing() {
     let _ = tracing_subscriber::fmt()
@@ -427,11 +450,13 @@ async fn dial_self_tcp() {
     .await
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn dial_self_quic() {
     dial_self(Transport::Quic(Default::default())).await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn dial_self_websocket() {
     dial_self(Transport::WebSocket(WebSocketConfig {
@@ -453,7 +478,9 @@ async fn dial_self(transport: Transport) {
 
     let litep2p_config = match transport {
         Transport::Tcp(config) => litep2p_config.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => litep2p_config.with_quic(config),
+        #[cfg(feature = "webscocket")]
         Transport::WebSocket(config) => litep2p_config.with_websocket(config),
     }
     .build();
@@ -469,7 +496,36 @@ async fn dial_self(transport: Transport) {
 }
 
 #[tokio::test]
-async fn attempt_to_dial_using_unsupported_transport() {
+async fn attempt_to_dial_using_unsupported_transport_tcp() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let (ping_config, _ping_event_stream) = PingConfig::default();
+    let config = ConfigBuilder::new()
+        .with_keypair(Keypair::generate())
+        .with_tcp(Default::default())
+        .with_libp2p_ping(ping_config)
+        .build();
+
+    let mut litep2p = Litep2p::new(config).unwrap();
+    let address = Multiaddr::empty()
+        .with(Protocol::from(std::net::Ipv4Addr::new(127, 0, 0, 1)))
+        .with(Protocol::Tcp(8888))
+        .with(Protocol::Ws(std::borrow::Cow::Borrowed("/")))
+        .with(Protocol::P2p(
+            Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
+        ));
+
+    assert!(std::matches!(
+        litep2p.dial_address(address.clone()).await,
+        Err(Error::TransportNotSupported(_))
+    ));
+}
+
+#[cfg(feature = "quic")]
+#[tokio::test]
+async fn attempt_to_dial_using_unsupported_transport_quic() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init();
@@ -510,6 +566,7 @@ async fn keep_alive_timeout_tcp() {
     .await
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn keep_alive_timeout_quic() {
     keep_alive_timeout(
@@ -519,6 +576,7 @@ async fn keep_alive_timeout_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn keep_alive_timeout_websocket() {
     keep_alive_timeout(
@@ -546,7 +604,9 @@ async fn keep_alive_timeout(transport1: Transport, transport2: Transport) {
 
     let config1 = match transport1 {
         Transport::Tcp(config) => config1.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config1.with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => config1.with_websocket(config),
     }
     .build();
@@ -559,7 +619,9 @@ async fn keep_alive_timeout(transport1: Transport, transport2: Transport) {
 
     let config2 = match transport2 {
         Transport::Tcp(config) => config2.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config2.with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => config2.with_websocket(config),
     }
     .build();
@@ -654,6 +716,7 @@ async fn simultaneous_dial_tcp() {
     }
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn simultaneous_dial_quic() {
     let _ = tracing_subscriber::fmt()
@@ -706,6 +769,7 @@ async fn simultaneous_dial_quic() {
     }
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn simultaneous_dial_ipv6_quic() {
     let _ = tracing_subscriber::fmt()
@@ -758,6 +822,7 @@ async fn simultaneous_dial_ipv6_quic() {
     }
 }
 
+#[cfg(feature = "webscocket")]
 #[tokio::test]
 async fn websocket_over_ipv6() {
     let _ = tracing_subscriber::fmt()
@@ -871,6 +936,7 @@ async fn tcp_dns_resolution() {
     }
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn websocket_dns_resolution() {
     let _ = tracing_subscriber::fmt()
@@ -955,6 +1021,7 @@ async fn multiple_listen_addresses_tcp() {
     .await
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn multiple_listen_addresses_quic() {
     multiple_listen_addresses(
@@ -977,6 +1044,7 @@ async fn multiple_listen_addresses_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn multiple_listen_addresses_websocket() {
     multiple_listen_addresses(
@@ -1009,7 +1077,9 @@ async fn make_dummy_litep2p(
 
     let litep2p_config = match transport {
         Transport::Tcp(config) => litep2p_config.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => litep2p_config.with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => litep2p_config.with_websocket(config),
     }
     .build();
@@ -1081,6 +1151,7 @@ async fn port_in_use_tcp() {
     .unwrap();
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn port_in_use_websocket() {
     let _ = tracing_subscriber::fmt()
@@ -1247,6 +1318,7 @@ async fn unspecified_listen_address_tcp() {
     }
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn unspecified_listen_address_websocket() {
     let _ = tracing_subscriber::fmt()
@@ -1368,6 +1440,7 @@ async fn simultaneous_dial_then_redial_tcp() {
     .await
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn simultaneous_dial_then_redial_websocket() {
     simultaneous_dial_then_redial(
@@ -1383,6 +1456,7 @@ async fn simultaneous_dial_then_redial_websocket() {
     .await
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn simultaneous_dial_then_redial_quic() {
     simultaneous_dial_then_redial(
@@ -1404,7 +1478,9 @@ async fn simultaneous_dial_then_redial(transport1: Transport, transport2: Transp
 
     let config1 = match transport1 {
         Transport::Tcp(config) => config1.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config1.with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => config1.with_websocket(config),
     }
     .build();
@@ -1416,7 +1492,9 @@ async fn simultaneous_dial_then_redial(transport1: Transport, transport2: Transp
 
     let config2 = match transport2 {
         Transport::Tcp(config) => config2.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config2.with_quic(config),
+        #[cfg(feature = "webscocket")]
         Transport::WebSocket(config) => config2.with_websocket(config),
     }
     .build();

--- a/tests/protocol/identify.rs
+++ b/tests/protocol/identify.rs
@@ -26,32 +26,10 @@ use litep2p::{
         identify::{Config, IdentifyEvent},
         ping::Config as PingConfig,
     },
-    transport::tcp::config::Config as TcpConfig,
     Litep2p, Litep2pEvent,
 };
 
-#[cfg(feature = "quic")]
-use litep2p::transport::quic::config::Config as QuicConfig;
-#[cfg(feature = "websocket")]
-use litep2p::transport::websocket::config::Config as WebSocketConfig;
-
-enum Transport {
-    Tcp(TcpConfig),
-    #[cfg(feature = "quic")]
-    Quic(QuicConfig),
-    #[cfg(feature = "websocket")]
-    WebSocket(WebSocketConfig),
-}
-
-fn add_transport(config: ConfigBuilder, transport: Transport) -> ConfigBuilder {
-    match transport {
-        Transport::Tcp(transport) => config.with_tcp(transport),
-        #[cfg(feature = "quic")]
-        Transport::Quic(transport) => config.with_quic(transport),
-        #[cfg(feature = "websocket")]
-        Transport::WebSocket(transport) => config.with_websocket(transport),
-    }
-}
+use crate::common::{add_transport, Transport};
 
 #[tokio::test]
 async fn identify_supported_tcp() {

--- a/tests/protocol/identify.rs
+++ b/tests/protocol/identify.rs
@@ -26,16 +26,20 @@ use litep2p::{
         identify::{Config, IdentifyEvent},
         ping::Config as PingConfig,
     },
-    transport::{
-        quic::config::Config as QuicConfig, tcp::config::Config as TcpConfig,
-        websocket::config::Config as WebSocketConfig,
-    },
+    transport::tcp::config::Config as TcpConfig,
     Litep2p, Litep2pEvent,
 };
 
+#[cfg(feature = "quic")]
+use litep2p::transport::quic::config::Config as QuicConfig;
+#[cfg(feature = "websocket")]
+use litep2p::transport::websocket::config::Config as WebSocketConfig;
+
 enum Transport {
-    Quic(QuicConfig),
     Tcp(TcpConfig),
+    #[cfg(feature = "quic")]
+    Quic(QuicConfig),
+    #[cfg(feature = "websocket")]
     WebSocket(WebSocketConfig),
 }
 
@@ -48,6 +52,7 @@ async fn identify_supported_tcp() {
     .await
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn identify_supported_quic() {
     identify_supported(
@@ -57,6 +62,7 @@ async fn identify_supported_quic() {
     .await
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn identify_supported_websocket() {
     identify_supported(
@@ -82,7 +88,9 @@ async fn identify_supported(transport1: Transport, transport2: Transport) {
 
     let config1 = match transport1 {
         Transport::Tcp(config) => config_builder.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config_builder.with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => config_builder.with_websocket(config),
     }
     .build();
@@ -98,7 +106,9 @@ async fn identify_supported(transport1: Transport, transport2: Transport) {
 
     let config2 = match transport2 {
         Transport::Tcp(config) => config_builder.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config_builder.with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => config_builder.with_websocket(config),
     }
     .build();
@@ -180,6 +190,7 @@ async fn identify_not_supported_tcp() {
     .await
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn identify_not_supported_quic() {
     identify_not_supported(
@@ -189,6 +200,7 @@ async fn identify_not_supported_quic() {
     .await
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn identify_not_supported_websocket() {
     identify_not_supported(
@@ -206,7 +218,9 @@ async fn identify_not_supported(transport1: Transport, transport2: Transport) {
     let (ping_config, _event_stream) = PingConfig::default();
     let config1 = match transport1 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_keypair(Keypair::generate())
@@ -221,7 +235,9 @@ async fn identify_not_supported(transport1: Transport, transport2: Transport) {
 
     let config2 = match transport2 {
         Transport::Tcp(config) => config_builder.with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config_builder.with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => config_builder.with_websocket(config),
     }
     .build();

--- a/tests/protocol/notification.rs
+++ b/tests/protocol/notification.rs
@@ -841,7 +841,7 @@ async fn set_new_handshake(transport1: Transport, transport2: Transport) {
 
     let config1 = match transport1 {
         Transport::Tcp(config) => config1.with_tcp(config),
-        #[cfg(feature = "websocket")]
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => config1.with_quic(config),
         #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => config1.with_websocket(config),

--- a/tests/protocol/notification.rs
+++ b/tests/protocol/notification.rs
@@ -41,9 +41,9 @@ use futures::StreamExt;
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
 
-#[cfg(any(feature = "quic", feature = "websocket"))]
-use std::net::Ipv6Addr;
-use std::{net::Ipv4Addr, task::Poll, time::Duration};
+#[cfg(feature = "quic")]
+use std::net::Ipv4Addr;
+use std::{net::Ipv6Addr, task::Poll, time::Duration};
 
 enum Transport {
     Tcp(TcpConfig),
@@ -3445,11 +3445,11 @@ async fn dial_failure(transport1: Transport, transport2: Transport) {
 
     let known_address = match &transport2 {
         Transport::Tcp(_) => Multiaddr::empty()
-            .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
+            .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
             .with(Protocol::Tcp(5)),
         #[cfg(feature = "quic")]
         Transport::Quic(_) => Multiaddr::empty()
-            .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
+            .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Udp(5))
             .with(Protocol::QuicV1),
         #[cfg(feature = "websocket")]

--- a/tests/protocol/notification.rs
+++ b/tests/protocol/notification.rs
@@ -31,8 +31,6 @@ use litep2p::{
     Litep2p, Litep2pEvent, PeerId,
 };
 
-#[cfg(feature = "quic")]
-use litep2p::transport::quic::config::Config as QuicConfig;
 #[cfg(feature = "websocket")]
 use litep2p::transport::websocket::config::Config as WebSocketConfig;
 
@@ -45,23 +43,7 @@ use multihash::Multihash;
 use std::net::Ipv4Addr;
 use std::{net::Ipv6Addr, task::Poll, time::Duration};
 
-enum Transport {
-    Tcp(TcpConfig),
-    #[cfg(feature = "quic")]
-    Quic(QuicConfig),
-    #[cfg(feature = "websocket")]
-    WebSocket(WebSocketConfig),
-}
-
-fn add_transport(config: Litep2pConfigBuilder, transport: Transport) -> Litep2pConfigBuilder {
-    match transport {
-        Transport::Tcp(transport) => config.with_tcp(transport),
-        #[cfg(feature = "quic")]
-        Transport::Quic(transport) => config.with_quic(transport),
-        #[cfg(feature = "websocket")]
-        Transport::WebSocket(transport) => config.with_websocket(transport),
-    }
-}
+use crate::common::{add_transport, Transport};
 
 async fn connect_peers(litep2p1: &mut Litep2p, litep2p2: &mut Litep2p) {
     let address = litep2p2.listen_addresses().next().unwrap().clone();

--- a/tests/protocol/ping.rs
+++ b/tests/protocol/ping.rs
@@ -56,7 +56,7 @@ async fn ping_supported_tcp() {
     .await;
 }
 
-#[cfg(feature = "webscocket")]
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn ping_supported_websocket() {
     ping_supported(

--- a/tests/protocol/ping.rs
+++ b/tests/protocol/ping.rs
@@ -20,18 +20,20 @@
 
 use futures::StreamExt;
 use litep2p::{
-    config::ConfigBuilder,
-    protocol::libp2p::ping::ConfigBuilder as PingConfigBuilder,
-    transport::{
-        quic::config::Config as QuicConfig, tcp::config::Config as TcpConfig,
-        websocket::config::Config as WebSocketConfig,
-    },
-    Litep2p,
+    config::ConfigBuilder, protocol::libp2p::ping::ConfigBuilder as PingConfigBuilder,
+    transport::tcp::config::Config as TcpConfig, Litep2p,
 };
+
+#[cfg(feature = "quic")]
+use litep2p::transport::quic::config::Config as QuicConfig;
+#[cfg(feature = "websocket")]
+use litep2p::transport::websocket::config::Config as WebSocketConfig;
 
 enum Transport {
     Tcp(TcpConfig),
+    #[cfg(feature = "quic")]
     Quic(QuicConfig),
+    #[cfg(feature = "webscocket")]
     WebSocket(WebSocketConfig),
 }
 
@@ -44,6 +46,7 @@ async fn ping_supported_tcp() {
     .await;
 }
 
+#[cfg(feature = "webscocket")]
 #[tokio::test]
 async fn ping_supported_websocket() {
     ping_supported(
@@ -53,6 +56,7 @@ async fn ping_supported_websocket() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn ping_supported_quic() {
     ping_supported(
@@ -71,7 +75,9 @@ async fn ping_supported(transport1: Transport, transport2: Transport) {
         PingConfigBuilder::new().with_max_failure(3usize).build();
     let config1 = match transport1 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "webscocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_libp2p_ping(ping_config1)
@@ -80,7 +86,9 @@ async fn ping_supported(transport1: Transport, transport2: Transport) {
     let (ping_config2, mut ping_event_stream2) = PingConfigBuilder::new().build();
     let config2 = match transport2 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "webscocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_libp2p_ping(ping_config2)

--- a/tests/protocol/ping.rs
+++ b/tests/protocol/ping.rs
@@ -20,32 +20,10 @@
 
 use futures::StreamExt;
 use litep2p::{
-    config::ConfigBuilder, protocol::libp2p::ping::ConfigBuilder as PingConfigBuilder,
-    transport::tcp::config::Config as TcpConfig, Litep2p,
+    config::ConfigBuilder, protocol::libp2p::ping::ConfigBuilder as PingConfigBuilder, Litep2p,
 };
 
-#[cfg(feature = "quic")]
-use litep2p::transport::quic::config::Config as QuicConfig;
-#[cfg(feature = "websocket")]
-use litep2p::transport::websocket::config::Config as WebSocketConfig;
-
-enum Transport {
-    Tcp(TcpConfig),
-    #[cfg(feature = "quic")]
-    Quic(QuicConfig),
-    #[cfg(feature = "websocket")]
-    WebSocket(WebSocketConfig),
-}
-
-fn add_transport(config: ConfigBuilder, transport: Transport) -> ConfigBuilder {
-    match transport {
-        Transport::Tcp(transport) => config.with_tcp(transport),
-        #[cfg(feature = "quic")]
-        Transport::Quic(transport) => config.with_quic(transport),
-        #[cfg(feature = "websocket")]
-        Transport::WebSocket(transport) => config.with_websocket(transport),
-    }
-}
+use crate::common::{add_transport, Transport};
 
 #[tokio::test]
 async fn ping_supported_tcp() {

--- a/tests/protocol/request_response.rs
+++ b/tests/protocol/request_response.rs
@@ -25,13 +25,15 @@ use litep2p::{
         Config as RequestResponseConfig, ConfigBuilder, DialOptions, RequestResponseError,
         RequestResponseEvent,
     },
-    transport::{
-        quic::config::Config as QuicConfig, tcp::config::Config as TcpConfig,
-        websocket::config::Config as WebSocketConfig,
-    },
+    transport::tcp::config::Config as TcpConfig,
     types::{protocol::ProtocolName, RequestId},
     Litep2p, Litep2pEvent, PeerId,
 };
+
+#[cfg(feature = "quic")]
+use litep2p::transport::quic::config::Config as QuicConfig;
+#[cfg(feature = "websocket")]
+use litep2p::transport::websocket::config::Config as WebSocketConfig;
 
 use futures::{channel, StreamExt};
 use multiaddr::{Multiaddr, Protocol};
@@ -40,17 +42,31 @@ use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use tokio::time::sleep;
 
+#[cfg(feature = "quic")]
+use std::net::Ipv4Addr;
 use std::{
     collections::{HashMap, HashSet},
-    net::{Ipv4Addr, Ipv6Addr},
+    net::Ipv6Addr,
     task::Poll,
     time::Duration,
 };
 
 enum Transport {
     Tcp(TcpConfig),
+    #[cfg(feature = "quic")]
     Quic(QuicConfig),
+    #[cfg(feature = "websocket")]
     WebSocket(WebSocketConfig),
+}
+
+fn add_transport(config: Litep2pConfigBuilder, transport: Transport) -> Litep2pConfigBuilder {
+    match transport {
+        Transport::Tcp(transport) => config.with_tcp(transport),
+        #[cfg(feature = "quic")]
+        Transport::Quic(transport) => config.with_quic(transport),
+        #[cfg(feature = "websocket")]
+        Transport::WebSocket(transport) => config.with_websocket(transport),
+    }
 }
 
 async fn connect_peers(litep2p1: &mut Litep2p, litep2p2: &mut Litep2p) {
@@ -100,6 +116,7 @@ async fn send_request_receive_response_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn send_request_receive_response_quic() {
     send_request_receive_response(
@@ -109,6 +126,7 @@ async fn send_request_receive_response_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn send_request_receive_response_websocket() {
     send_request_receive_response(
@@ -140,12 +158,7 @@ async fn send_request_receive_response(transport1: Transport, transport2: Transp
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1"),
@@ -158,12 +171,7 @@ async fn send_request_receive_response(transport1: Transport, transport2: Transp
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -225,6 +233,7 @@ async fn reject_request_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn reject_request_quic() {
     reject_request(
@@ -234,6 +243,7 @@ async fn reject_request_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn reject_request_websocket() {
     reject_request(
@@ -266,12 +276,7 @@ async fn reject_request(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1"),
@@ -284,12 +289,7 @@ async fn reject_request(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -352,6 +352,7 @@ async fn multiple_simultaneous_requests_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn multiple_simultaneous_requests_quic() {
     multiple_simultaneous_requests(
@@ -361,6 +362,7 @@ async fn multiple_simultaneous_requests_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn multiple_simultaneous_requests_websocket() {
     multiple_simultaneous_requests(
@@ -393,12 +395,7 @@ async fn multiple_simultaneous_requests(transport1: Transport, transport2: Trans
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1"),
@@ -411,12 +408,7 @@ async fn multiple_simultaneous_requests(transport1: Transport, transport2: Trans
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -516,6 +508,7 @@ async fn request_timeout_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn request_timeout_quic() {
     request_timeout(
@@ -525,6 +518,7 @@ async fn request_timeout_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn request_timeout_websocket() {
     request_timeout(
@@ -557,12 +551,7 @@ async fn request_timeout(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, _handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1"),
@@ -575,12 +564,7 @@ async fn request_timeout(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -632,6 +616,7 @@ async fn protocol_not_supported_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn protocol_not_supported_quic() {
     protocol_not_supported(
@@ -641,6 +626,7 @@ async fn protocol_not_supported_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn protocol_not_supported_websocket() {
     protocol_not_supported(
@@ -673,12 +659,7 @@ async fn protocol_not_supported(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, _handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/2"),
@@ -691,12 +672,7 @@ async fn protocol_not_supported(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -746,6 +722,7 @@ async fn connection_close_while_request_is_pending_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn connection_close_while_request_is_pending_quic() {
     connection_close_while_request_is_pending(
@@ -755,6 +732,7 @@ async fn connection_close_while_request_is_pending_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn connection_close_while_request_is_pending_websocket() {
     connection_close_while_request_is_pending(
@@ -786,12 +764,7 @@ async fn connection_close_while_request_is_pending(transport1: Transport, transp
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1"),
@@ -804,12 +777,7 @@ async fn connection_close_while_request_is_pending(transport1: Transport, transp
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -859,6 +827,7 @@ async fn request_too_big_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn request_too_big_quic() {
     request_too_big(
@@ -868,6 +837,7 @@ async fn request_too_big_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn request_too_big_websocket() {
     request_too_big(
@@ -899,12 +869,7 @@ async fn request_too_big(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, _handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1"),
@@ -917,12 +882,7 @@ async fn request_too_big(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -968,6 +928,7 @@ async fn response_too_big_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn response_too_big_quic() {
     response_too_big(
@@ -977,6 +938,7 @@ async fn response_too_big_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn response_too_big_websocket() {
     response_too_big(
@@ -1008,12 +970,7 @@ async fn response_too_big(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1"),
@@ -1026,12 +983,7 @@ async fn response_too_big(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -1206,6 +1158,7 @@ async fn dialer_fallback_protocol_works_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn dialer_fallback_protocol_works_quic() {
     dialer_fallback_protocol_works(
@@ -1215,6 +1168,7 @@ async fn dialer_fallback_protocol_works_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn dialer_fallback_protocol_works_websocket() {
     dialer_fallback_protocol_works(
@@ -1245,12 +1199,7 @@ async fn dialer_fallback_protocol_works(transport1: Transport, transport2: Trans
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1"),
@@ -1263,12 +1212,7 @@ async fn dialer_fallback_protocol_works(transport1: Transport, transport2: Trans
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -1330,6 +1274,7 @@ async fn listener_fallback_protocol_works_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn listener_fallback_protocol_works_quic() {
     listener_fallback_protocol_works(
@@ -1339,6 +1284,7 @@ async fn listener_fallback_protocol_works_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn listener_fallback_protocol_works_websocket() {
     listener_fallback_protocol_works(
@@ -1370,12 +1316,7 @@ async fn listener_fallback_protocol_works(transport1: Transport, transport2: Tra
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1/improved"),
@@ -1388,12 +1329,7 @@ async fn listener_fallback_protocol_works(transport1: Transport, transport2: Tra
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -1455,6 +1391,7 @@ async fn dial_peer_when_sending_request_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn dial_peer_when_sending_request_quic() {
     dial_peer_when_sending_request(
@@ -1464,6 +1401,7 @@ async fn dial_peer_when_sending_request_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn dial_peer_when_sending_request_websocket() {
     dial_peer_when_sending_request(
@@ -1495,12 +1433,7 @@ async fn dial_peer_when_sending_request(transport1: Transport, transport2: Trans
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1/improved"),
@@ -1513,12 +1446,7 @@ async fn dial_peer_when_sending_request(transport1: Transport, transport2: Trans
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -1580,6 +1508,7 @@ async fn dial_peer_but_no_known_address_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn dial_peer_but_no_known_address_quic() {
     dial_peer_but_no_known_address(
@@ -1589,6 +1518,7 @@ async fn dial_peer_but_no_known_address_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn dial_peer_but_no_known_address_websocket() {
     dial_peer_but_no_known_address(
@@ -1620,12 +1550,7 @@ async fn dial_peer_but_no_known_address(transport1: Transport, transport2: Trans
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, _handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1/improved"),
@@ -1638,12 +1563,7 @@ async fn dial_peer_but_no_known_address(transport1: Transport, transport2: Trans
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -1687,6 +1607,7 @@ async fn cancel_request_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn cancel_request_quic() {
     cancel_request(
@@ -1696,6 +1617,7 @@ async fn cancel_request_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn cancel_request_websocket() {
     cancel_request(
@@ -1727,12 +1649,7 @@ async fn cancel_request(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/1"),
@@ -1745,12 +1662,7 @@ async fn cancel_request(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -1812,6 +1724,7 @@ async fn substream_open_failure_reported_once_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn substream_open_failure_reported_once_quic() {
     substream_open_failure_reported_once(
@@ -1821,6 +1734,7 @@ async fn substream_open_failure_reported_once_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn substream_open_failure_reported_once_websocket() {
     substream_open_failure_reported_once(
@@ -1852,12 +1766,7 @@ async fn substream_open_failure_reported_once(transport1: Transport, transport2:
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, _handle2) = RequestResponseConfig::new(
         ProtocolName::from("/protocol/2"),
@@ -1870,12 +1779,7 @@ async fn substream_open_failure_reported_once(transport1: Transport, transport2:
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -1937,6 +1841,7 @@ async fn excess_inbound_request_rejected_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn excess_inbound_request_rejected_quic() {
     excess_inbound_request_rejected(
@@ -1946,6 +1851,7 @@ async fn excess_inbound_request_rejected_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn excess_inbound_request_rejected_websocket() {
     excess_inbound_request_rejected(
@@ -1974,12 +1880,7 @@ async fn excess_inbound_request_rejected(transport1: Transport, transport2: Tran
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, _handle2) = ConfigBuilder::new(ProtocolName::from("/protocol/1"))
         .with_max_size(1024)
@@ -1990,12 +1891,7 @@ async fn excess_inbound_request_rejected(transport1: Transport, transport2: Tran
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -2058,6 +1954,7 @@ async fn feedback_received_for_succesful_response_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn feedback_received_for_succesful_response_quic() {
     feedback_received_for_succesful_response(
@@ -2067,6 +1964,7 @@ async fn feedback_received_for_succesful_response_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn feedback_received_for_succesful_response_websocket() {
     feedback_received_for_succesful_response(
@@ -2095,12 +1993,7 @@ async fn feedback_received_for_succesful_response(transport1: Transport, transpo
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = ConfigBuilder::new(ProtocolName::from("/protocol/1"))
         .with_max_size(1024)
@@ -2110,12 +2003,7 @@ async fn feedback_received_for_succesful_response(transport1: Transport, transpo
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -2179,6 +2067,7 @@ async fn feedback_received_for_succesful_response(transport1: Transport, transpo
 //     .await;
 // }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn feedback_not_received_for_failed_response_quic() {
     feedback_not_received_for_failed_response(
@@ -2203,6 +2092,7 @@ async fn feedback_not_received_for_failed_response_quic() {
 //     .await;
 // }
 
+#[cfg(feature = "quic")]
 async fn feedback_not_received_for_failed_response(transport1: Transport, transport2: Transport) {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -2216,12 +2106,7 @@ async fn feedback_not_received_for_failed_response(transport1: Transport, transp
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = ConfigBuilder::new(ProtocolName::from("/protocol/1"))
         .with_max_size(1024)
@@ -2231,12 +2116,7 @@ async fn feedback_not_received_for_failed_response(transport1: Transport, transp
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -2289,6 +2169,7 @@ async fn custom_timeout_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn custom_timeout_quic() {
     custom_timeout(
@@ -2298,6 +2179,7 @@ async fn custom_timeout_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn custom_timeout_websocket() {
     custom_timeout(
@@ -2321,12 +2203,7 @@ async fn custom_timeout(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, _handle2) = ConfigBuilder::new(ProtocolName::from("/protocol/1"))
         .with_max_size(1024)
@@ -2336,12 +2213,7 @@ async fn custom_timeout(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -2383,11 +2255,13 @@ async fn outbound_request_for_unconnected_peer_tcp() {
     outbound_request_for_unconnected_peer(Transport::Tcp(Default::default())).await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn outbound_request_for_unconnected_peer_quic() {
     outbound_request_for_unconnected_peer(Transport::Quic(Default::default())).await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn outbound_request_for_unconnected_peer_websocket() {
     outbound_request_for_unconnected_peer(Transport::WebSocket(Default::default())).await;
@@ -2406,12 +2280,7 @@ async fn outbound_request_for_unconnected_peer(transport1: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     tokio::spawn(async move {
         let mut litep2p1 = Litep2p::new(config1).unwrap();
@@ -2440,11 +2309,13 @@ async fn dial_failure_tcp() {
     dial_failure(Transport::Tcp(Default::default())).await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn dial_failure_quic() {
     dial_failure(Transport::Quic(Default::default())).await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn dial_failure_websocket() {
     dial_failure(Transport::WebSocket(Default::default())).await;
@@ -2469,11 +2340,13 @@ async fn dial_failure(transport: Transport) {
             .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
             .with(Protocol::Tcp(5))
             .with(Protocol::P2p(Multihash::from(peer))),
+        #[cfg(feature = "quic")]
         Transport::Quic(_) => Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Udp(5))
             .with(Protocol::QuicV1)
             .with(Protocol::P2p(Multihash::from(peer))),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(_) => Multiaddr::empty()
             .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
             .with(Protocol::Tcp(5))
@@ -2481,12 +2354,7 @@ async fn dial_failure(transport: Transport) {
             .with(Protocol::P2p(Multihash::from(peer))),
     };
 
-    let config = match transport {
-        Transport::Tcp(config) => litep2p_config.with_tcp(config),
-        Transport::Quic(config) => litep2p_config.with_quic(config),
-        Transport::WebSocket(config) => litep2p_config.with_websocket(config),
-    }
-    .build();
+    let config = add_transport(litep2p_config, transport).build();
 
     let mut litep2p = Litep2p::new(config).unwrap();
     litep2p.add_known_address(peer, vec![known_address].into_iter());
@@ -2514,6 +2382,7 @@ async fn large_response_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn large_response_quic() {
     large_response(
@@ -2523,6 +2392,7 @@ async fn large_response_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn large_response_websocket() {
     large_response(
@@ -2546,12 +2416,7 @@ async fn large_response(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = ConfigBuilder::new(ProtocolName::from("/protocol/1"))
         .with_max_size(16 * 1024 * 1024)
@@ -2561,12 +2426,7 @@ async fn large_response(transport1: Transport, transport2: Transport) {
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -2624,6 +2484,7 @@ async fn binary_incompatible_fallback_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn binary_incompatible_fallback_quic() {
     binary_incompatible_fallback(
@@ -2633,6 +2494,7 @@ async fn binary_incompatible_fallback_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn binary_incompatible_fallback_websocket() {
     binary_incompatible_fallback(
@@ -2657,12 +2519,7 @@ async fn binary_incompatible_fallback(transport1: Transport, transport2: Transpo
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = ConfigBuilder::new(ProtocolName::from("/protocol/1"))
         .with_max_size(16 * 1024 * 1024)
@@ -2672,12 +2529,7 @@ async fn binary_incompatible_fallback(transport1: Transport, transport2: Transpo
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -2737,6 +2589,7 @@ async fn binary_incompatible_fallback_inbound_request_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn binary_incompatible_fallback_inbound_request_quic() {
     binary_incompatible_fallback_inbound_request(
@@ -2746,6 +2599,7 @@ async fn binary_incompatible_fallback_inbound_request_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn binary_incompatible_fallback_inbound_request_websocket() {
     binary_incompatible_fallback_inbound_request(
@@ -2773,12 +2627,7 @@ async fn binary_incompatible_fallback_inbound_request(
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) = ConfigBuilder::new(ProtocolName::from("/protocol/1"))
         .with_max_size(16 * 1024 * 1024)
@@ -2788,12 +2637,7 @@ async fn binary_incompatible_fallback_inbound_request(
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -2848,6 +2692,7 @@ async fn binary_incompatible_fallback_two_fallback_protocols_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn binary_incompatible_fallback_two_fallback_protocols_quic() {
     binary_incompatible_fallback_two_fallback_protocols(
@@ -2857,6 +2702,7 @@ async fn binary_incompatible_fallback_two_fallback_protocols_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn binary_incompatible_fallback_two_fallback_protocols_websocket() {
     binary_incompatible_fallback_two_fallback_protocols(
@@ -2888,12 +2734,7 @@ async fn binary_incompatible_fallback_two_fallback_protocols(
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) =
         ConfigBuilder::new(ProtocolName::from("/genesis/protocol/1"))
@@ -2905,12 +2746,7 @@ async fn binary_incompatible_fallback_two_fallback_protocols(
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -2970,6 +2806,7 @@ async fn binary_incompatible_fallback_two_fallback_protocols_inbound_request_tcp
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn binary_incompatible_fallback_two_fallback_protocols_inbound_request_quic() {
     binary_incompatible_fallback_two_fallback_protocols_inbound_request(
@@ -2979,6 +2816,7 @@ async fn binary_incompatible_fallback_two_fallback_protocols_inbound_request_qui
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn binary_incompatible_fallback_two_fallback_protocols_inbound_request_websocket() {
     binary_incompatible_fallback_two_fallback_protocols_inbound_request(
@@ -3010,12 +2848,7 @@ async fn binary_incompatible_fallback_two_fallback_protocols_inbound_request(
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) =
         ConfigBuilder::new(ProtocolName::from("/genesis/protocol/1"))
@@ -3027,12 +2860,7 @@ async fn binary_incompatible_fallback_two_fallback_protocols_inbound_request(
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
@@ -3087,6 +2915,7 @@ async fn binary_incompatible_fallback_compatible_nodes_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn binary_incompatible_fallback_compatible_nodes_quic() {
     binary_incompatible_fallback_compatible_nodes(
@@ -3096,6 +2925,7 @@ async fn binary_incompatible_fallback_compatible_nodes_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn binary_incompatible_fallback_compatible_nodes_websocket() {
     binary_incompatible_fallback_compatible_nodes(
@@ -3127,12 +2957,7 @@ async fn binary_incompatible_fallback_compatible_nodes(
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config1);
 
-    let config1 = match transport1 {
-        Transport::Tcp(config) => config1.with_tcp(config),
-        Transport::Quic(config) => config1.with_quic(config),
-        Transport::WebSocket(config) => config1.with_websocket(config),
-    }
-    .build();
+    let config1 = add_transport(config1, transport1).build();
 
     let (req_resp_config2, mut handle2) =
         ConfigBuilder::new(ProtocolName::from("/genesis/protocol/2"))
@@ -3148,12 +2973,7 @@ async fn binary_incompatible_fallback_compatible_nodes(
         .with_keypair(Keypair::generate())
         .with_request_response_protocol(req_resp_config2);
 
-    let config2 = match transport2 {
-        Transport::Tcp(config) => config2.with_tcp(config),
-        Transport::Quic(config) => config2.with_quic(config),
-        Transport::WebSocket(config) => config2.with_websocket(config),
-    }
-    .build();
+    let config2 = add_transport(config2, transport2).build();
 
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();

--- a/tests/protocol/request_response.rs
+++ b/tests/protocol/request_response.rs
@@ -30,8 +30,6 @@ use litep2p::{
     Litep2p, Litep2pEvent, PeerId,
 };
 
-#[cfg(feature = "quic")]
-use litep2p::transport::quic::config::Config as QuicConfig;
 #[cfg(feature = "websocket")]
 use litep2p::transport::websocket::config::Config as WebSocketConfig;
 
@@ -51,23 +49,7 @@ use std::{
     time::Duration,
 };
 
-enum Transport {
-    Tcp(TcpConfig),
-    #[cfg(feature = "quic")]
-    Quic(QuicConfig),
-    #[cfg(feature = "websocket")]
-    WebSocket(WebSocketConfig),
-}
-
-fn add_transport(config: Litep2pConfigBuilder, transport: Transport) -> Litep2pConfigBuilder {
-    match transport {
-        Transport::Tcp(transport) => config.with_tcp(transport),
-        #[cfg(feature = "quic")]
-        Transport::Quic(transport) => config.with_quic(transport),
-        #[cfg(feature = "websocket")]
-        Transport::WebSocket(transport) => config.with_websocket(transport),
-    }
-}
+use crate::common::{add_transport, Transport};
 
 async fn connect_peers(litep2p1: &mut Litep2p, litep2p2: &mut Litep2p) {
     let address = litep2p2.listen_addresses().next().unwrap().clone();

--- a/tests/substream.rs
+++ b/tests/substream.rs
@@ -23,13 +23,15 @@ use litep2p::{
     config::ConfigBuilder,
     protocol::{Direction, TransportEvent, TransportService, UserProtocol},
     substream::{Substream, SubstreamSet},
-    transport::{
-        quic::config::Config as QuicConfig, tcp::config::Config as TcpConfig,
-        websocket::config::Config as WebSocketConfig,
-    },
+    transport::tcp::config::Config as TcpConfig,
     types::{protocol::ProtocolName, SubstreamId},
     Error, Litep2p, Litep2pEvent, PeerId,
 };
+
+#[cfg(feature = "quic")]
+use litep2p::transport::quic::config::Config as QuicConfig;
+#[cfg(feature = "websocket")]
+use litep2p::transport::websocket::config::Config as WebSocketConfig;
 
 use bytes::Bytes;
 use futures::{Sink, SinkExt, StreamExt};
@@ -50,7 +52,9 @@ use std::{
 
 enum Transport {
     Tcp(TcpConfig),
+    #[cfg(feature = "quic")]
     Quic(QuicConfig),
+    #[cfg(feature = "websocket")]
     WebSocket(WebSocketConfig),
 }
 
@@ -243,6 +247,7 @@ async fn too_big_identity_payload_framed_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn too_big_identity_payload_framed_quic() {
     too_big_identity_payload_framed(
@@ -252,6 +257,7 @@ async fn too_big_identity_payload_framed_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn too_big_identity_payload_framed_websocket() {
     too_big_identity_payload_framed(
@@ -270,7 +276,9 @@ async fn too_big_identity_payload_framed(transport1: Transport, transport2: Tran
     let (custom_protocol1, tx1) = CustomProtocol::new(ProtocolCodec::Identity(10usize));
     let config1 = match transport1 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol1))
@@ -279,7 +287,9 @@ async fn too_big_identity_payload_framed(transport1: Transport, transport2: Tran
     let (custom_protocol2, _tx2) = CustomProtocol::new(ProtocolCodec::Identity(10usize));
     let config2 = match transport2 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "wesocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol2))
@@ -328,6 +338,7 @@ async fn too_big_identity_payload_sink_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn too_big_identity_payload_sink_quic() {
     too_big_identity_payload_sink(
@@ -337,6 +348,7 @@ async fn too_big_identity_payload_sink_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn too_big_identity_payload_sink_websocket() {
     too_big_identity_payload_sink(
@@ -355,7 +367,9 @@ async fn too_big_identity_payload_sink(transport1: Transport, transport2: Transp
     let (custom_protocol1, tx1) = CustomProtocol::new(ProtocolCodec::Identity(10usize));
     let config1 = match transport1 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol1))
@@ -364,7 +378,9 @@ async fn too_big_identity_payload_sink(transport1: Transport, transport2: Transp
     let (custom_protocol2, _tx2) = CustomProtocol::new(ProtocolCodec::Identity(10usize));
     let config2 = match transport2 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "webscocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol2))
@@ -415,6 +431,7 @@ async fn correct_payload_size_sink_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn correct_payload_size_sink_quic() {
     correct_payload_size_sink(
@@ -424,6 +441,7 @@ async fn correct_payload_size_sink_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn correct_payload_size_sink_websocket() {
     correct_payload_size_sink(
@@ -442,7 +460,9 @@ async fn correct_payload_size_sink(transport1: Transport, transport2: Transport)
     let (custom_protocol1, tx1) = CustomProtocol::new(ProtocolCodec::Identity(10usize));
     let config1 = match transport1 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol1))
@@ -451,7 +471,9 @@ async fn correct_payload_size_sink(transport1: Transport, transport2: Transport)
     let (custom_protocol2, _tx2) = CustomProtocol::new(ProtocolCodec::Identity(10usize));
     let config2 = match transport2 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol2))
@@ -499,6 +521,7 @@ async fn correct_payload_size_async_write_tcp() {
     .await;
 }
 
+#[cfg(feature = "quic")]
 #[tokio::test]
 async fn correct_payload_size_async_write_quic() {
     correct_payload_size_async_write(
@@ -508,6 +531,7 @@ async fn correct_payload_size_async_write_quic() {
     .await;
 }
 
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn correct_payload_size_async_write_websocket() {
     correct_payload_size_async_write(
@@ -526,7 +550,9 @@ async fn correct_payload_size_async_write(transport1: Transport, transport2: Tra
     let (custom_protocol1, tx1) = CustomProtocol::new(ProtocolCodec::Identity(10usize));
     let config1 = match transport1 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol1))
@@ -535,7 +561,9 @@ async fn correct_payload_size_async_write(transport1: Transport, transport2: Tra
     let (custom_protocol2, _tx2) = CustomProtocol::new(ProtocolCodec::Identity(10usize));
     let config2 = match transport2 {
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
+        #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol2))

--- a/tests/substream.rs
+++ b/tests/substream.rs
@@ -289,7 +289,7 @@ async fn too_big_identity_payload_framed(transport1: Transport, transport2: Tran
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
         #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
-        #[cfg(feature = "wesocket")]
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol2))
@@ -380,7 +380,7 @@ async fn too_big_identity_payload_sink(transport1: Transport, transport2: Transp
         Transport::Tcp(config) => ConfigBuilder::new().with_tcp(config),
         #[cfg(feature = "quic")]
         Transport::Quic(config) => ConfigBuilder::new().with_quic(config),
-        #[cfg(feature = "webscocket")]
+        #[cfg(feature = "websocket")]
         Transport::WebSocket(config) => ConfigBuilder::new().with_websocket(config),
     }
     .with_user_protocol(Box::new(custom_protocol2))

--- a/tests/webrtc.rs
+++ b/tests/webrtc.rs
@@ -18,6 +18,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#![cfg(feature = "webrtc")]
+
 use futures::StreamExt;
 use litep2p::{
     config::ConfigBuilder as Litep2pConfigBuilder,


### PR DESCRIPTION
Put extra transports behind feature flags to make some dependencies optional.

While at it, also made sure no warnings are emitted on the recent rust version.

Resolves https://github.com/paritytech/litep2p/issues/161.