### PR TITLE
Fix TCP, WebSocket, QUIC leaking connection IDs in `reject()`

### DIFF
--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -285,7 +285,6 @@ impl Transport for QuicTransport {
     }
 
     fn reject(&mut self, connection_id: ConnectionId) -> crate::Result<()> {
-        self.canceled.insert(connection_id);
         self.pending_open
             .remove(&connection_id)
             .map_or(Err(Error::ConnectionDoesntExist(connection_id)), |_| Ok(()))

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -310,7 +310,6 @@ impl Transport for TcpTransport {
     }
 
     fn reject(&mut self, connection_id: ConnectionId) -> crate::Result<()> {
-        self.canceled.insert(connection_id);
         self.pending_open
             .remove(&connection_id)
             .map_or(Err(Error::ConnectionDoesntExist(connection_id)), |_| Ok(()))

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -379,7 +379,6 @@ impl Transport for WebSocketTransport {
     }
 
     fn reject(&mut self, connection_id: ConnectionId) -> crate::Result<()> {
-        self.canceled.insert(connection_id);
         self.pending_open
             .remove(&connection_id)
             .map_or(Err(Error::ConnectionDoesntExist(connection_id)), |_| Ok(()))


### PR DESCRIPTION
Resolves https://github.com/paritytech/litep2p/issues/197.