### PR TITLE
kad: Add support for provider records to `MemoryStore`

### DIFF
--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -144,6 +144,8 @@ impl MemoryStore {
     /// Try to add a provider for `key`. If there are already `max_providers_per_key` for
     /// this `key`, the new provider is only inserted if its closer to `key` than
     /// the furthest already inserted provider. The furthest provider is then discarded.
+    ///
+    /// Returns `true` if the provider was added, `false` otherwise.
     pub fn put_provider(&mut self, provider_record: ProviderRecord) -> bool {
         // Make sure we have no more than `max_provider_addresses`.
         let provider_record = {

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -21,9 +21,12 @@
 //! Memory store implementation for Kademlia.
 
 #![allow(unused)]
-use crate::protocol::libp2p::kademlia::record::{Key, Record};
+use crate::protocol::libp2p::kademlia::record::{Key, ProviderRecord, Record};
 
-use std::collections::{hash_map::Entry, HashMap};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    num::NonZeroUsize,
+};
 
 /// Logging target for the file.
 const LOG_TARGET: &str = "litep2p::ipfs::kademlia::store";
@@ -35,6 +38,8 @@ pub enum MemoryStoreEvent {}
 pub struct MemoryStore {
     /// Records.
     records: HashMap<Key, Record>,
+    /// Provider records.
+    provider_keys: HashMap<Key, Vec<ProviderRecord>>,
     /// Configuration.
     config: MemoryStoreConfig,
 }
@@ -44,6 +49,7 @@ impl MemoryStore {
     pub fn new() -> Self {
         Self {
             records: HashMap::new(),
+            provider_keys: HashMap::new(),
             config: MemoryStoreConfig::default(),
         }
     }
@@ -52,6 +58,7 @@ impl MemoryStore {
     pub fn with_config(config: MemoryStoreConfig) -> Self {
         Self {
             records: HashMap::new(),
+            provider_keys: HashMap::new(),
             config,
         }
     }
@@ -115,6 +122,86 @@ impl MemoryStore {
         }
     }
 
+    /// Try to get providers from local store for `key`.
+    ///
+    /// Returns a non-empty list of providers, if any.
+    pub fn get_providers(&mut self, key: &Key) -> Option<&Vec<ProviderRecord>> {
+        let drop = self.provider_keys.get_mut(key).map_or(false, |providers| {
+            let now = std::time::Instant::now();
+            providers.retain(|p| !p.is_expired(now));
+
+            providers.is_empty()
+        });
+
+        if drop {
+            self.provider_keys.remove(key);
+            None
+        } else {
+            self.provider_keys.get(key)
+        }
+    }
+
+    /// Try to add a provider for `key`. If there are already `max_providers_per_key` for
+    /// this `key`, the new provider is only inserted if its closer to `key` than
+    /// the furthest already inserted provider. The furthest provider is then discarded.
+    pub fn put_provider(&mut self, provider_record: ProviderRecord) -> bool {
+        // Make sure we have no more than `max_provider_addresses`.
+        let provider_record = {
+            let mut record = provider_record;
+            record.addresses.truncate(self.config.max_provider_addresses.into());
+            record
+        };
+
+        let can_insert_new_key =
+            self.provider_keys.len() < usize::from(self.config.max_provider_keys);
+
+        match self.provider_keys.entry(provider_record.key.clone()) {
+            Entry::Vacant(entry) =>
+                if can_insert_new_key {
+                    entry.insert(vec![provider_record]);
+
+                    true
+                } else {
+                    false
+                },
+            Entry::Occupied(mut entry) => {
+                let mut providers = entry.get_mut();
+
+                // Providers under every key are sorted by distance, with equal distances meaning
+                // peer IDs are equal.
+                let provider_position =
+                    providers.binary_search_by(|p| p.distance().cmp(&provider_record.distance()));
+
+                match provider_position {
+                    Ok(i) => {
+                        // Update the provider in place.
+                        let existing_provider =
+                            providers.get_mut(i).expect("index was found in the vector; qed");
+                        *existing_provider = provider_record;
+
+                        true
+                    }
+                    Err(i) => {
+                        // `Err(i)` contains the insertion point.
+                        if i == usize::from(self.config.max_providers_per_key) {
+                            // The provider won't be inserted, as it's further than all existing
+                            // providers and we don't have space left.
+                            false
+                        } else {
+                            if providers.len() == usize::from(self.config.max_providers_per_key) {
+                                providers.pop();
+                            }
+
+                            providers.insert(i, provider_record);
+
+                            true
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /// Poll next event from the store.
     async fn next_event() -> Option<MemoryStoreEvent> {
         None
@@ -127,6 +214,16 @@ pub struct MemoryStoreConfig {
 
     /// Maximum size of a record in bytes.
     pub max_record_size_bytes: usize,
+
+    /// Maximum number of provider keys this node stores.
+    pub max_provider_keys: NonZeroUsize,
+
+    /// Maximum number of cached addresses per provider.
+    pub max_provider_addresses: NonZeroUsize,
+
+    /// Maximum number of providers per key. Only providers with peer IDs closest to the key are
+    /// kept.
+    pub max_providers_per_key: NonZeroUsize,
 }
 
 impl Default for MemoryStoreConfig {
@@ -134,16 +231,26 @@ impl Default for MemoryStoreConfig {
         Self {
             max_records: 1024,
             max_record_size_bytes: 65 * 1024,
+            max_provider_keys: NonZeroUsize::new(1024).expect("1024 > 0"),
+            max_provider_addresses: NonZeroUsize::new(30).expect("30 > 0"),
+            max_providers_per_key: NonZeroUsize::new(20).expect("20 > 0"),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time;
+
     use super::*;
+    use crate::PeerId;
+    use multiaddr::{
+        multiaddr,
+        Protocol::{Ip4, Tcp},
+    };
 
     #[test]
-    fn test_memory_store() {
+    fn put_get_record() {
         let mut store = MemoryStore::new();
         let key = Key::from(vec![1, 2, 3]);
         let record = Record::new(key.clone(), vec![4, 5, 6]);
@@ -153,10 +260,11 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_store_length() {
+    fn max_records() {
         let mut store = MemoryStore::with_config(MemoryStoreConfig {
             max_records: 1,
             max_record_size_bytes: 1024,
+            ..Default::default()
         });
 
         let key1 = Key::from(vec![1, 2, 3]);
@@ -172,7 +280,7 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_store_remove_old_records() {
+    fn expired_record_removed() {
         let mut store = MemoryStore::new();
         let key = Key::from(vec![1, 2, 3]);
         let record = Record {
@@ -189,7 +297,7 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_store_replace_new_records() {
+    fn new_record_overwrites() {
         let mut store = MemoryStore::new();
         let key = Key::from(vec![1, 2, 3]);
         let record1 = Record {
@@ -213,10 +321,11 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_store_max_record_size() {
+    fn max_record_size() {
         let mut store = MemoryStore::with_config(MemoryStoreConfig {
             max_records: 1024,
             max_record_size_bytes: 2,
+            ..Default::default()
         });
 
         let key = Key::from(vec![1, 2, 3]);
@@ -227,5 +336,110 @@ mod tests {
         let record = Record::new(key.clone(), vec![4]);
         store.put(record.clone());
         assert_eq!(store.get(&key), Some(&record));
+    }
+
+    #[test]
+    fn put_get_provider() {
+        let mut store = MemoryStore::new();
+        let provider = ProviderRecord {
+            key: Key::from(vec![1, 2, 3]),
+            provider: PeerId::random(),
+            addresses: vec![multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10000u16))],
+            expires: std::time::Instant::now() + std::time::Duration::from_secs(3600),
+        };
+
+        store.put_provider(provider.clone());
+        assert_eq!(store.get_providers(&provider.key).unwrap(), &vec![provider]);
+    }
+
+    #[test]
+    fn multiple_providers_per_key() {
+        let mut store = MemoryStore::new();
+        let key = Key::from(vec![1, 2, 3]);
+        let provider1 = ProviderRecord {
+            key: key.clone(),
+            provider: PeerId::random(),
+            addresses: vec![multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10000u16))],
+            expires: std::time::Instant::now() + std::time::Duration::from_secs(3600),
+        };
+        let provider2 = ProviderRecord {
+            key: key.clone(),
+            provider: PeerId::random(),
+            addresses: vec![multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10000u16))],
+            expires: std::time::Instant::now() + std::time::Duration::from_secs(3600),
+        };
+
+        store.put_provider(provider1.clone());
+        store.put_provider(provider2.clone());
+
+        let got_providers = store.get_providers(&key).unwrap();
+        assert_eq!(got_providers.len(), 2);
+        assert!(got_providers.contains(&provider1));
+        assert!(got_providers.contains(&provider2));
+    }
+
+    #[test]
+    fn providers_sorted_by_distance() {
+        let mut store = MemoryStore::new();
+        let key = Key::from(vec![1, 2, 3]);
+        let providers = (0..10)
+            .map(|_| ProviderRecord {
+                key: key.clone(),
+                provider: PeerId::random(),
+                addresses: vec![multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10000u16))],
+                expires: std::time::Instant::now() + std::time::Duration::from_secs(3600),
+            })
+            .collect::<Vec<_>>();
+
+        providers.iter().for_each(|p| {
+            store.put_provider(p.clone());
+        });
+
+        let sorted_providers = {
+            let mut providers = providers;
+            providers.sort_unstable_by_key(ProviderRecord::distance);
+            providers
+        };
+
+        assert_eq!(store.get_providers(&key).unwrap(), &sorted_providers);
+    }
+
+    #[test]
+    fn max_providers_per_key() {
+        let mut store = MemoryStore::with_config(MemoryStoreConfig {
+            max_providers_per_key: NonZeroUsize::new(10).unwrap(),
+            ..Default::default()
+        });
+        let key = Key::from(vec![1, 2, 3]);
+        let providers = (0..20)
+            .map(|_| ProviderRecord {
+                key: key.clone(),
+                provider: PeerId::random(),
+                addresses: vec![multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10000u16))],
+                expires: std::time::Instant::now() + std::time::Duration::from_secs(3600),
+            })
+            .collect::<Vec<_>>();
+
+        providers.iter().for_each(|p| {
+            store.put_provider(p.clone());
+        });
+        assert_eq!(store.get_providers(&key).unwrap().len(), 10);
+    }
+
+    #[test]
+    fn provider_record_expires() {
+        let mut store = MemoryStore::new();
+        let provider = ProviderRecord {
+            key: Key::from(vec![1, 2, 3]),
+            provider: PeerId::random(),
+            addresses: vec![multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10500u16))],
+            expires: std::time::Instant::now() - std::time::Duration::from_secs(5),
+        };
+
+        // Provider record is already expired.
+        assert!(provider.is_expired(std::time::Instant::now()));
+
+        store.put_provider(provider.clone());
+        assert_eq!(store.get_providers(&provider.key), None);
     }
 }

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -72,7 +72,6 @@ impl MemoryStore {
 
         if is_expired {
             self.records.remove(key);
-
             None
         } else {
             self.records.get(key)
@@ -136,6 +135,7 @@ impl MemoryStore {
 
         if drop {
             self.provider_keys.remove(key);
+
             None
         } else {
             self.provider_keys.get(key)

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -255,8 +255,6 @@ impl Default for MemoryStoreConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::time;
-
     use super::*;
     use crate::PeerId;
     use multiaddr::{

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -183,9 +183,7 @@ impl MemoryStore {
                 match provider_position {
                     Ok(i) => {
                         // Update the provider in place.
-                        let existing_provider =
-                            providers.get_mut(i).expect("index was found in the vector; qed");
-                        *existing_provider = provider_record;
+                        providers[i] = provider_record;
 
                         true
                     }

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -72,6 +72,7 @@ impl MemoryStore {
 
         if is_expired {
             self.records.remove(key);
+
             None
         } else {
             self.records.get(key)

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -148,12 +148,11 @@ impl MemoryStore {
         // Make sure we have no more than `max_provider_addresses`.
         let provider_record = {
             let mut record = provider_record;
-            record.addresses.truncate(self.config.max_provider_addresses.into());
+            record.addresses.truncate(self.config.max_provider_addresses);
             record
         };
 
-        let can_insert_new_key =
-            self.provider_keys.len() < usize::from(self.config.max_provider_keys);
+        let can_insert_new_key = self.provider_keys.len() < self.config.max_provider_keys;
 
         match self.provider_keys.entry(provider_record.key.clone()) {
             Entry::Vacant(entry) =>
@@ -183,7 +182,7 @@ impl MemoryStore {
                     }
                     Err(i) => {
                         // `Err(i)` contains the insertion point.
-                        if i == usize::from(self.config.max_providers_per_key) {
+                        if i == self.config.max_providers_per_key {
                             // The provider won't be inserted, as it's further than all existing
                             // providers and we don't have space left.
                             false
@@ -216,14 +215,14 @@ pub struct MemoryStoreConfig {
     pub max_record_size_bytes: usize,
 
     /// Maximum number of provider keys this node stores.
-    pub max_provider_keys: NonZeroUsize,
+    pub max_provider_keys: usize,
 
     /// Maximum number of cached addresses per provider.
-    pub max_provider_addresses: NonZeroUsize,
+    pub max_provider_addresses: usize,
 
     /// Maximum number of providers per key. Only providers with peer IDs closest to the key are
     /// kept.
-    pub max_providers_per_key: NonZeroUsize,
+    pub max_providers_per_key: usize,
 }
 
 impl Default for MemoryStoreConfig {
@@ -231,9 +230,9 @@ impl Default for MemoryStoreConfig {
         Self {
             max_records: 1024,
             max_record_size_bytes: 65 * 1024,
-            max_provider_keys: NonZeroUsize::new(1024).expect("1024 > 0"),
-            max_provider_addresses: NonZeroUsize::new(30).expect("30 > 0"),
-            max_providers_per_key: NonZeroUsize::new(20).expect("20 > 0"),
+            max_provider_keys: 1024,
+            max_provider_addresses: 30,
+            max_providers_per_key: 20,
         }
     }
 }
@@ -407,7 +406,7 @@ mod tests {
     #[test]
     fn max_providers_per_key() {
         let mut store = MemoryStore::with_config(MemoryStoreConfig {
-            max_providers_per_key: NonZeroUsize::new(10).unwrap(),
+            max_providers_per_key: 10,
             ..Default::default()
         });
         let key = Key::from(vec![1, 2, 3]);
@@ -429,7 +428,7 @@ mod tests {
     #[test]
     fn closest_providers_kept() {
         let mut store = MemoryStore::with_config(MemoryStoreConfig {
-            max_providers_per_key: NonZeroUsize::new(10).unwrap(),
+            max_providers_per_key: 10,
             ..Default::default()
         });
         let key = Key::from(vec![1, 2, 3]);
@@ -501,7 +500,7 @@ mod tests {
     #[test]
     fn max_addresses_per_provider() {
         let mut store = MemoryStore::with_config(MemoryStoreConfig {
-            max_provider_addresses: NonZeroUsize::new(2).unwrap(),
+            max_provider_addresses: 2,
             ..Default::default()
         });
         let key = Key::from(vec![1, 2, 3]);
@@ -529,7 +528,7 @@ mod tests {
     #[test]
     fn max_provider_keys() {
         let mut store = MemoryStore::with_config(MemoryStoreConfig {
-            max_provider_keys: NonZeroUsize::new(2).unwrap(),
+            max_provider_keys: 2,
             ..Default::default()
         });
 

--- a/src/protocol/libp2p/kademlia/types.rs
+++ b/src/protocol/libp2p/kademlia/types.rs
@@ -139,7 +139,7 @@ impl<T: Clone> Hash for Key<T> {
 }
 
 /// The raw bytes of a key in the DHT keyspace.
-#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct KeyBytes(GenericArray<u8, U32>);
 
 impl KeyBytes {

--- a/src/protocol/libp2p/kademlia/types.rs
+++ b/src/protocol/libp2p/kademlia/types.rs
@@ -139,7 +139,7 @@ impl<T: Clone> Hash for Key<T> {
 }
 
 /// The raw bytes of a key in the DHT keyspace.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct KeyBytes(GenericArray<u8, U32>);
 
 impl KeyBytes {


### PR DESCRIPTION
Resolves https://github.com/paritytech/litep2p/issues/195.