### PR TITLE
errors: Add `DialError` error and `ListDialFailures` event for better error reporting

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -100,7 +100,7 @@ impl TryFrom<keys_proto::PublicKey> for PublicKey {
         if key_type == keys_proto::KeyType::Ed25519 {
             Ok(ed25519::PublicKey::try_from_bytes(&pubkey.data).map(PublicKey::Ed25519)?)
         } else {
-            Err(ParseError::UnsupportedKeyType(key_type as i32))
+            Err(ParseError::UnknownKeyType(key_type as i32))
         }
     }
 }

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -789,7 +789,7 @@ mod tests {
     #[test]
     fn invalid_peer_id_schema() {
         match parse_peer_id(&vec![1, 2, 3, 4]).unwrap_err() {
-            crate::Error::ParseError(_) => {}
+            NegotiationError::ParseError(_) => {}
             _ => panic!("invalid error"),
         }
     }

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -114,7 +114,7 @@ impl NoiseContext {
         };
 
         let mut payload = Vec::with_capacity(noise_payload.encoded_len());
-        noise_payload.encode(&mut payload).map_err(|err| ParseError::from(err))?;
+        noise_payload.encode(&mut payload).map_err(ParseError::from)?;
 
         Ok(Self {
             noise: NoiseState::Handshake(noise),

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -176,7 +176,7 @@ impl NoiseContext {
         let NoiseState::Handshake(ref mut noise) = self.noise else {
             tracing::error!(target: LOG_TARGET, "invalid state to read the second handshake message");
             debug_assert!(false);
-            return Err(NegotiationError::StateMissmatch);
+            return Err(NegotiationError::StateMismatch);
         };
 
         let res = noise.read_message(reply, &mut buffer)?;
@@ -199,7 +199,7 @@ impl NoiseContext {
                 let NoiseState::Handshake(ref mut noise) = self.noise else {
                     tracing::error!(target: LOG_TARGET, "invalid state to read the first handshake message");
                     debug_assert!(false);
-                    return Err(NegotiationError::StateMissmatch);
+                    return Err(NegotiationError::StateMismatch);
                 };
 
                 let mut buffer = vec![0u8; 256];
@@ -225,7 +225,7 @@ impl NoiseContext {
         let NoiseState::Handshake(ref mut noise) = self.noise else {
             tracing::error!(target: LOG_TARGET, "invalid state to read the first handshake message");
             debug_assert!(false);
-            return Err(NegotiationError::StateMissmatch);
+            return Err(NegotiationError::StateMismatch);
         };
 
         let mut buffer = vec![0u8; 2048];
@@ -257,7 +257,7 @@ impl NoiseContext {
         let NoiseState::Handshake(ref mut noise) = self.noise else {
             tracing::error!(target: LOG_TARGET, "invalid state to read handshake message");
             debug_assert!(false);
-            return Err(NegotiationError::StateMissmatch);
+            return Err(NegotiationError::StateMismatch);
         };
 
         let nread = noise.read_message(&message, &mut out)?;
@@ -284,7 +284,7 @@ impl NoiseContext {
     fn into_transport(self) -> Result<NoiseContext, NegotiationError> {
         let transport = match self.noise {
             NoiseState::Handshake(noise) => noise.into_transport_mode()?,
-            NoiseState::Transport(_) => return Err(NegotiationError::StateMissmatch),
+            NoiseState::Transport(_) => return Err(NegotiationError::StateMismatch),
         };
 
         Ok(NoiseContext {

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -24,7 +24,7 @@
 use crate::{
     config::Role,
     crypto::{ed25519::Keypair, PublicKey},
-    error::{NegotiationError, ParseError},
+    error::NegotiationError,
     PeerId,
 };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -297,7 +297,7 @@ pub enum DnsError {
     ///
     /// For example, DNSv4 was expected but DNSv6 was provided.
     #[error("DNS type is different from the provided IP address")]
-    MismatchDnsVersion,
+    IpVersionMismatch,
 }
 
 impl From<MultihashGeneric<64>> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,8 +146,8 @@ pub enum AddressError {
     #[error("Address not available")]
     AddressNotAvailable,
     /// The provided address contains an invalid multihash.
-    #[error("Invalid multihash: `{0:?}`")]
-    InvalidMultihash(Multihash),
+    #[error("Multihash does not contain a valid peer ID : `{0:?}`")]
+    InvalidPeerId(Multihash),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -299,7 +299,7 @@ pub enum DnsError {
 
 impl From<MultihashGeneric<64>> for Error {
     fn from(hash: MultihashGeneric<64>) -> Self {
-        Error::AddressError(AddressError::InvalidMultihash(hash))
+        Error::AddressError(AddressError::InvalidPeerId(hash))
     }
 }
 
@@ -365,7 +365,7 @@ impl From<ParseError> for Error {
 
 impl From<MultihashGeneric<64>> for AddressError {
     fn from(hash: MultihashGeneric<64>) -> Self {
-        AddressError::InvalidMultihash(hash)
+        AddressError::InvalidPeerId(hash)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -203,6 +203,11 @@ pub enum NegotiationError {
     StateMissmatch,
     #[error("Peer ID mismatch: expected `{0}`, got `{1}`")]
     PeerIdMismatch(PeerId, PeerId),
+
+    #[cfg(feature = "quic")]
+    #[error("Failed to negotiate QUIC: `{0}`")]
+    Quinn(quinn::ConnectionError),
+
     // TODO: Convert tokio_tungstenite::accept_async into `NegotiationError` for some cases (ie
     // ConnectionClosed).
     #[error("Other error occurred: `{0}`")]
@@ -247,6 +252,21 @@ pub enum DialError {
     #[cfg(feature = "websocket")]
     #[error("WebSocket error: `{0}`")]
     WebSocket(#[from] tokio_tungstenite::tungstenite::error::Error),
+
+    #[cfg(feature = "quic")]
+    #[error("QUIC error: `{0}`")]
+    Quic(#[from] QuicError),
+}
+
+#[cfg(feature = "quic")]
+#[derive(Debug, thiserror::Error)]
+pub enum QuicError {
+    #[error("Invalid certificate")]
+    InvalidCertificate,
+    #[error("Failed to negotiate QUIC: `{0}`")]
+    ConnectionError(#[from] quinn::ConnectionError),
+    #[error("Failed to connect to peer: `{0}`")]
+    ConnectError(#[from] quinn::ConnectError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -291,7 +291,7 @@ pub enum QuicError {
 #[derive(Debug, thiserror::Error)]
 pub enum DnsError {
     /// The DNS resolution failed to resolve the provided URL.
-    #[error("Dns failed to resolve url `{0}`")]
+    #[error("DNS failed to resolve url `{0}`")]
     ResolveError(String),
     /// The DNS expected a different IP address version.
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -165,6 +165,7 @@ pub enum ParseError {
     /// This error can happen when:
     ///  - The received number of bytes is not equal to the expected number of bytes (32 bytes).
     ///  - The bytes are not a valid Ed25519 public key.
+    ///  - Length of the public key is not represented by 2 bytes (WebRTC specific).
     #[error("Invalid public key")]
     InvalidPublicKey,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -428,18 +428,6 @@ mod tests {
 
     #[tokio::test]
     async fn try_from_errors() {
-        tracing::trace!("{:?}", NotificationError::InvalidState);
-        tracing::trace!("{:?}", DialError::AlreadyConnected);
-        tracing::trace!(
-            "{:?}",
-            SubstreamError::YamuxError(crate::yamux::ConnectionError::Closed)
-        );
-        tracing::trace!("{:?}", AddressError::PeerIdMissing);
-        tracing::trace!(
-            "{:?}",
-            ParseError::InvalidMultihash(Multihash::from(PeerId::random()))
-        );
-
         let (tx, rx) = channel(1);
         drop(rx);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -265,7 +265,7 @@ pub enum DialError {
     ///
     /// The address provided may be valid, however it failed to resolve to a concrete IP address.
     /// This error may be recoverable.
-    #[error("Dns lookup error for `{0}`")]
+    #[error("DNS lookup error for `{0}`")]
     DnsError(#[from] DnsError),
     /// An error occurred during the negotiation process.
     #[error("Negotiation error: `{0}`")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -149,10 +149,20 @@ pub enum ParseError {
     ProstDecodeError(prost::DecodeError),
     #[error("Failed to encode protobuf message: `{0:?}`")]
     ProstEncodeError(prost::EncodeError),
+    /// The protobuf message contains an unexpected key type.
+    ///
+    /// This error can happen when:
+    ///  - The provided key type is not recognized.
+    ///  - The provided key type is recognized but not supported.
     #[error("Unknown key type from protobuf message: `{0}`")]
     UnknownKeyType(i32),
-    #[error("Unsupported key type from protobuf message: `{0}`")]
-    UnsupportedKeyType(i32),
+    /// The public key bytes are invalid and cannot be parsed.
+    ///
+    /// This error can happen when:
+    ///  - The received number of bytes is not equal to the expected number of bytes (32 bytes).
+    ///  - The bytes are not a valid Ed25519 public key.
+    #[error("Invalid public key")]
+    InvalidPublicKey,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -171,8 +181,6 @@ pub enum SubstreamError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum NegotiationError {
-    #[error("Dial error: `{0}`")]
-    DialError(#[from] DialError),
     #[error("multistream-select error: `{0:?}`")]
     MultistreamSelectError(crate::multistream_select::NegotiationError),
     #[error("multistream-select error: `{0:?}`")]
@@ -213,6 +221,8 @@ pub enum DialError {
     AddressError(#[from] AddressError),
     #[error("Dns lookup error for `{0}`")]
     DnsError(#[from] DnsError),
+    #[error("Negotiation error: `{0}`")]
+    NegotiationError(#[from] NegotiationError),
     #[error("I/O error: `{0}`")]
     IoError(ErrorKind),
     #[error("Tried to dial self")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -134,7 +134,7 @@ pub enum AddressError {
     ///
     /// For example, this can happen when the address used the UDP protocol but
     /// the handling transport only allows TCP connections.
-    #[error("Invalid protocol")]
+    #[error("Invalid address for protocol")]
     InvalidProtocol,
     /// The provided address is not a valid URL.
     #[error("Invalid URL")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -152,9 +152,6 @@ pub enum AddressError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
-    /// Cannot parse the multihash from the provided bytes.
-    #[error("Invalid multihash: `{0:?}`")]
-    InvalidMultihash(Multihash),
     /// The provided probuf message cannot be decoded.
     #[error("Failed to decode protobuf message: `{0:?}`")]
     ProstDecodeError(#[from] prost::DecodeError),
@@ -302,7 +299,7 @@ pub enum DnsError {
 
 impl From<MultihashGeneric<64>> for Error {
     fn from(hash: MultihashGeneric<64>) -> Self {
-        Error::ParseError(ParseError::InvalidMultihash(hash))
+        Error::AddressError(AddressError::InvalidMultihash(hash))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -168,6 +168,11 @@ pub enum ParseError {
     ///  - Length of the public key is not represented by 2 bytes (WebRTC specific).
     #[error("Invalid public key")]
     InvalidPublicKey,
+    /// The provided date has an invalid format.
+    ///
+    /// This error is protocol specific.
+    #[error("Invalid data")]
+    InvalidData,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -200,8 +205,10 @@ pub enum NegotiationError {
     ParseError(ParseError),
     #[error("I/O error: `{0}`")]
     IoError(ErrorKind),
-    #[error("Expected a different noise state")]
+    #[error("Expected a different state")]
     StateMissmatch,
+    #[error("Protocol not supported")]
+    ProtocolNotSupported(String),
     #[error("Peer ID mismatch: expected `{0}`, got `{1}`")]
     PeerIdMismatch(PeerId, PeerId),
 
@@ -377,6 +384,18 @@ impl From<io::Error> for NegotiationError {
 impl From<ParseError> for NegotiationError {
     fn from(error: ParseError) -> Self {
         NegotiationError::ParseError(error)
+    }
+}
+
+impl From<ParseError> for SubstreamError {
+    fn from(error: ParseError) -> Self {
+        SubstreamError::NegotiationError(NegotiationError::ParseError(error))
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(error: ParseError) -> Self {
+        Error::ParseError(error)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -220,7 +220,7 @@ pub enum NegotiationError {
     IoError(ErrorKind),
     /// Expected a different state during the negotiation process.
     #[error("Expected a different state")]
-    StateMissmatch,
+    StateMismatch,
     /// The noise handshake provided a different peer ID than the one expected in the dialing
     /// address.
     #[error("Peer ID mismatch: expected `{0}`, got `{1}`")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -399,13 +399,6 @@ impl From<quinn::ConnectError> for DialError {
     }
 }
 
-#[cfg(feature = "websocket")]
-impl From<tokio_tungstenite::tungstenite::error::Error> for DialError {
-    fn from(error: tokio_tungstenite::tungstenite::error::Error) -> Self {
-        DialError::NegotiationError(NegotiationError::WebSocket(error))
-    }
-}
-
 impl From<ConnectionLimitsError> for Error {
     fn from(error: ConnectionLimitsError) -> Self {
         Error::ConnectionLimit(error)

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,7 +139,7 @@ pub enum AddressError {
     /// The provided address is not a valid URL.
     #[error("Invalid URL")]
     InvalidUrl,
-    /// The provided address is not a valid multiaddress.
+    /// The provided address does not include a peer ID.
     #[error("`PeerId` missing from the address")]
     PeerIdMissing,
     /// No address is available for the provided peer ID.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,8 @@ pub enum Litep2pEvent {
     },
 
     /// Failed to dial peer.
+    ///
+    /// This error can originate from dialing a single peer address.
     DialFailure {
         /// Address of the peer.
         address: Multiaddr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ use crate::transport::webrtc::WebRtcTransport;
 #[cfg(feature = "websocket")]
 use crate::transport::websocket::WebSocketTransport;
 
+use error::DialError;
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
 use transport::Endpoint;
@@ -117,7 +118,15 @@ pub enum Litep2pEvent {
         address: Multiaddr,
 
         /// Dial error.
-        error: Error,
+        error: DialError,
+    },
+
+    /// A list of multiple dial failures.
+    ListDialFailures {
+        /// List of errors.
+        ///
+        /// Depending on the transport, the address might be different for each error.
+        errors: Vec<(Multiaddr, DialError)>,
     },
 }
 
@@ -479,6 +488,10 @@ impl Litep2p {
                     }),
                 TransportEvent::DialFailure { address, error, .. } =>
                     return Some(Litep2pEvent::DialFailure { address, error }),
+
+                TransportEvent::OpenFailure { errors, .. } => {
+                    return Some(Litep2pEvent::ListDialFailures { errors });
+                }
                 _ => {}
             }
         }

--- a/src/multistream_select/dialer_select.rs
+++ b/src/multistream_select/dialer_select.rs
@@ -818,9 +818,7 @@ mod tests {
             DialerState::propose(ProtocolName::from("/13371338/proto/1"), vec![]).unwrap();
 
         match dialer_state.register_response(bytes.freeze().to_vec()) {
-            Err(Error::NegotiationError(error::NegotiationError::MultistreamSelectError(
-                NegotiationError::Failed,
-            ))) => {}
+            Err(error::NegotiationError::MultistreamSelectError(NegotiationError::Failed)) => {}
             event => panic!("invalid event: {event:?}"),
         }
     }
@@ -839,9 +837,7 @@ mod tests {
             DialerState::propose(ProtocolName::from("/13371338/proto/1"), vec![]).unwrap();
 
         match dialer_state.register_response(bytes.freeze().to_vec()) {
-            Err(Error::NegotiationError(error::NegotiationError::MultistreamSelectError(
-                NegotiationError::Failed,
-            ))) => {}
+            Err(error::NegotiationError::MultistreamSelectError(NegotiationError::Failed)) => {}
             event => panic!("invalid event: {event:?}"),
         }
     }

--- a/src/multistream_select/dialer_select.rs
+++ b/src/multistream_select/dialer_select.rs
@@ -370,7 +370,7 @@ impl DialerState {
         loop {
             match (&self.state, protocol_iter.next()) {
                 (HandshakeState::WaitingResponse, None) =>
-                    return Err(crate::error::NegotiationError::StateMissmatch),
+                    return Err(crate::error::NegotiationError::StateMismatch),
                 (HandshakeState::WaitingResponse, Some(protocol)) => {
                     let header = Protocol::try_from(&b"/multistream/1.0.0"[..])
                         .expect("valid multitstream-select header");

--- a/src/multistream_select/negotiated.rs
+++ b/src/multistream_select/negotiated.rs
@@ -350,19 +350,15 @@ where
 }
 
 /// Error that can happen when negotiating a protocol with the remote.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum NegotiationError {
     /// A protocol error occurred during the negotiation.
-    ProtocolError(ProtocolError),
+    #[error("A protocol error occurred during the negotiation: `{0:?}`")]
+    ProtocolError(#[from] ProtocolError),
 
     /// Protocol negotiation failed because no protocol could be agreed upon.
+    #[error("Protocol negotiation failed.")]
     Failed,
-}
-
-impl From<ProtocolError> for NegotiationError {
-    fn from(err: ProtocolError) -> NegotiationError {
-        NegotiationError::ProtocolError(err)
-    }
 }
 
 impl From<io::Error> for NegotiationError {
@@ -377,24 +373,5 @@ impl From<NegotiationError> for io::Error {
             return e.into();
         }
         io::Error::new(io::ErrorKind::Other, err)
-    }
-}
-
-impl Error for NegotiationError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            NegotiationError::ProtocolError(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl fmt::Display for NegotiationError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            NegotiationError::ProtocolError(p) =>
-                fmt.write_fmt(format_args!("Protocol error: {p}")),
-            NegotiationError::Failed => fmt.write_str("Protocol negotiation failed."),
-        }
     }
 }

--- a/src/multistream_select/protocol.rs
+++ b/src/multistream_select/protocol.rs
@@ -426,7 +426,7 @@ where
 pub enum ProtocolError {
     /// I/O error.
     #[error("I/O error: `{0}`")]
-    IoError(io::Error),
+    IoError(#[from] io::Error),
 
     /// Received an invalid message from the remote.
     #[error("Received an invalid message from the remote.")]
@@ -443,12 +443,6 @@ pub enum ProtocolError {
     /// The protocol is not supported.
     #[error("The protocol is not supported.")]
     ProtocolNotSupported,
-}
-
-impl From<io::Error> for ProtocolError {
-    fn from(err: io::Error) -> ProtocolError {
-        ProtocolError::IoError(err)
-    }
 }
 
 impl From<ProtocolError> for io::Error {

--- a/src/multistream_select/protocol.rs
+++ b/src/multistream_select/protocol.rs
@@ -422,21 +422,26 @@ where
 }
 
 /// A protocol error.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ProtocolError {
     /// I/O error.
+    #[error("I/O error: `{0}`")]
     IoError(io::Error),
 
     /// Received an invalid message from the remote.
+    #[error("Received an invalid message from the remote.")]
     InvalidMessage,
 
     /// A protocol (name) is invalid.
+    #[error("A protocol (name) is invalid.")]
     InvalidProtocol,
 
     /// Too many protocols have been returned by the remote.
+    #[error("Too many protocols have been returned by the remote.")]
     TooManyProtocols,
 
     /// The protocol is not supported.
+    #[error("The protocol is not supported.")]
     ProtocolNotSupported,
 }
 
@@ -458,26 +463,5 @@ impl From<ProtocolError> for io::Error {
 impl From<uvi::decode::Error> for ProtocolError {
     fn from(err: uvi::decode::Error) -> ProtocolError {
         Self::from(io::Error::new(io::ErrorKind::InvalidData, err.to_string()))
-    }
-}
-
-impl Error for ProtocolError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match *self {
-            ProtocolError::IoError(ref err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl fmt::Display for ProtocolError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            ProtocolError::IoError(e) => write!(fmt, "I/O error: {e}"),
-            ProtocolError::InvalidMessage => write!(fmt, "Received an invalid message."),
-            ProtocolError::InvalidProtocol => write!(fmt, "A protocol (name) is invalid."),
-            ProtocolError::TooManyProtocols => write!(fmt, "Too many protocols received."),
-            ProtocolError::ProtocolNotSupported => write!(fmt, "The protocol is not supported."),
-        }
     }
 }

--- a/src/multistream_select/protocol.rs
+++ b/src/multistream_select/protocol.rs
@@ -435,6 +435,9 @@ pub enum ProtocolError {
 
     /// Too many protocols have been returned by the remote.
     TooManyProtocols,
+
+    /// The protocol is not supported.
+    ProtocolNotSupported,
 }
 
 impl From<io::Error> for ProtocolError {
@@ -474,6 +477,7 @@ impl fmt::Display for ProtocolError {
             ProtocolError::InvalidMessage => write!(fmt, "Received an invalid message."),
             ProtocolError::InvalidProtocol => write!(fmt, "A protocol (name) is invalid."),
             ProtocolError::TooManyProtocols => write!(fmt, "Too many protocols received."),
+            ProtocolError::ProtocolNotSupported => write!(fmt, "The protocol is not supported."),
         }
     }
 }

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -21,7 +21,7 @@
 //! [`/ipfs/kad/1.0.0`](https://github.com/libp2p/specs/blob/master/kad-dht/README.md) implementation.
 
 use crate::{
-    error::Error,
+    error::{Error, SubstreamError},
     protocol::{
         libp2p::kademlia::{
             bucket::KBucketEntry,
@@ -492,7 +492,11 @@ impl Kademlia {
     }
 
     /// Failed to open substream to remote peer.
-    async fn on_substream_open_failure(&mut self, substream_id: SubstreamId, error: Error) {
+    async fn on_substream_open_failure(
+        &mut self,
+        substream_id: SubstreamId,
+        error: SubstreamError,
+    ) {
         tracing::trace!(
             target: LOG_TARGET,
             ?substream_id,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     codec::ProtocolCodec,
-    error::Error,
+    error::{Error, SubstreamError},
     substream::Substream,
     transport::Endpoint,
     types::{protocol::ProtocolName, SubstreamId},
@@ -125,7 +125,7 @@ pub enum TransportEvent {
         substream: SubstreamId,
 
         /// Error that occurred when the substream was being opened.
-        error: Error,
+        error: SubstreamError,
     },
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     codec::ProtocolCodec,
-    error::{Error, SubstreamError},
+    error::SubstreamError,
     substream::Substream,
     transport::Endpoint,
     types::{protocol::ProtocolName, SubstreamId},

--- a/src/protocol/notification/mod.rs
+++ b/src/protocol/notification/mod.rs
@@ -21,7 +21,7 @@
 //! Notification protocol implementation.
 
 use crate::{
-    error::Error,
+    error::{Error, SubstreamError},
     executor::Executor,
     protocol::{
         self,
@@ -813,7 +813,11 @@ impl NotificationProtocol {
     ///
     /// If the substream was initiated by the local node, it must be reported that the substream
     /// failed to open. Otherwise the peer state can silently be converted to `Closed`.
-    async fn on_substream_open_failure(&mut self, substream_id: SubstreamId, error: Error) {
+    async fn on_substream_open_failure(
+        &mut self,
+        substream_id: SubstreamId,
+        error: SubstreamError,
+    ) {
         tracing::debug!(
             target: LOG_TARGET,
             protocol = %self.protocol,

--- a/src/protocol/notification/tests/notification.rs
+++ b/src/protocol/notification/tests/notification.rs
@@ -31,7 +31,7 @@ use crate::{
             ConnectionState, InboundState, NotificationProtocol, OutboundState, PeerContext,
             PeerState, ValidationResult,
         },
-        InnerTransportEvent, ProtocolCommand,
+        InnerTransportEvent, ProtocolCommand, SubstreamError,
     },
     substream::Substream,
     transport::Endpoint,
@@ -225,7 +225,9 @@ async fn substream_open_failure_for_unknown_substream() {
 
     let (mut notif, _handle, _sender, _tx) = make_notification_protocol();
 
-    notif.on_substream_open_failure(SubstreamId::new(), Error::Unknown).await;
+    notif
+        .on_substream_open_failure(SubstreamId::new(), SubstreamError::ConnectionClosed)
+        .await;
 }
 
 #[tokio::test]
@@ -313,7 +315,9 @@ async fn substream_open_failure_for_unknown_peer() {
     let substream_id = SubstreamId::from(1337usize);
 
     notif.pending_outbound.insert(substream_id, peer);
-    notif.on_substream_open_failure(substream_id, Error::Unknown).await;
+    notif
+        .on_substream_open_failure(substream_id, SubstreamError::ConnectionClosed)
+        .await;
 }
 
 #[tokio::test]
@@ -895,7 +899,10 @@ async fn open_failure_reported_once() {
     notif.pending_outbound.insert(SubstreamId::from(1337usize), peer);
 
     notif
-        .on_substream_open_failure(SubstreamId::from(1337usize), Error::Unknown)
+        .on_substream_open_failure(
+            SubstreamId::from(1337usize),
+            SubstreamError::ConnectionClosed,
+        )
         .await;
 
     match handle.next().await {

--- a/src/protocol/protocol_set.rs
+++ b/src/protocol/protocol_set.rs
@@ -20,7 +20,7 @@
 
 use crate::{
     codec::ProtocolCodec,
-    error::Error,
+    error::{Error, SubstreamError},
     protocol::{
         connection::{ConnectionHandle, Permit},
         Direction, TransportEvent,
@@ -131,7 +131,7 @@ pub enum InnerTransportEvent {
         substream: SubstreamId,
 
         /// Error that occurred when the substream was being opened.
-        error: Error,
+        error: SubstreamError,
     },
 }
 
@@ -312,7 +312,7 @@ impl ProtocolSet {
         &mut self,
         protocol: ProtocolName,
         substream: SubstreamId,
-        error: Error,
+        error: SubstreamError,
     ) -> crate::Result<()> {
         tracing::debug!(
             target: LOG_TARGET,

--- a/src/protocol/protocol_set.rs
+++ b/src/protocol/protocol_set.rs
@@ -20,7 +20,10 @@
 
 use crate::{
     codec::ProtocolCodec,
-    error::{Error, SubstreamError},
+    error::{Error, NegotiationError, SubstreamError},
+    multistream_select::{
+        NegotiationError as MultiStreamNegotiationError, ProtocolError as MultiStreamProtocolError,
+    },
     protocol::{
         connection::{ConnectionHandle, Permit},
         Direction, TransportEvent,
@@ -274,7 +277,7 @@ impl ProtocolSet {
         protocol: ProtocolName,
         direction: Direction,
         substream: Substream,
-    ) -> crate::Result<()> {
+    ) -> Result<(), SubstreamError> {
         tracing::debug!(target: LOG_TARGET, %protocol, ?peer, ?direction, "substream opened");
 
         let (protocol, fallback) = match self.fallback_names.get(&protocol) {
@@ -282,19 +285,28 @@ impl ProtocolSet {
             None => (protocol, None),
         };
 
-        self.protocols
-            .get_mut(&protocol)
-            .ok_or(Error::ProtocolNotSupported(protocol.to_string()))?
+        let Some(protocol_context) = self.protocols.get(&protocol) else {
+            return Err(NegotiationError::MultistreamSelectError(
+                MultiStreamNegotiationError::ProtocolError(
+                    MultiStreamProtocolError::ProtocolNotSupported,
+                ),
+            )
+            .into());
+        };
+
+        let event = InnerTransportEvent::SubstreamOpened {
+            peer,
+            protocol: protocol.clone(),
+            fallback,
+            direction,
+            substream,
+        };
+
+        protocol_context
             .tx
-            .send(InnerTransportEvent::SubstreamOpened {
-                peer,
-                protocol: protocol.clone(),
-                fallback,
-                direction,
-                substream,
-            })
+            .send(event)
             .await
-            .map_err(From::from)
+            .map_err(|_| SubstreamError::ConnectionClosed)
     }
 
     /// Get codec used by the protocol.

--- a/src/protocol/request_response/mod.rs
+++ b/src/protocol/request_response/mod.rs
@@ -21,7 +21,7 @@
 //! Request-response protocol implementation.
 
 use crate::{
-    error::{Error, NegotiationError},
+    error::{Error, NegotiationError, SubstreamError},
     multistream_select::NegotiationError::Failed as MultistreamFailed,
     protocol::{
         request_response::handle::{InnerRequestResponseEvent, RequestResponseCommand},
@@ -623,7 +623,7 @@ impl RequestResponseProtocol {
     async fn on_substream_open_failure(
         &mut self,
         substream: SubstreamId,
-        error: Error,
+        error: SubstreamError,
     ) -> crate::Result<()> {
         let Some(RequestContext {
             request_id, peer, ..
@@ -660,7 +660,7 @@ impl RequestResponseProtocol {
                 peer,
                 request_id,
                 error: match error {
-                    Error::NegotiationError(NegotiationError::MultistreamSelectError(
+                    SubstreamError::NegotiationError(NegotiationError::MultistreamSelectError(
                         MultistreamFailed,
                     )) => RequestResponseError::UnsupportedProtocol,
                     _ => RequestResponseError::Rejected,

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -26,7 +26,7 @@ use crate::{
             ConfigBuilder, DialOptions, RequestResponseError, RequestResponseEvent,
             RequestResponseHandle, RequestResponseProtocol,
         },
-        InnerTransportEvent, TransportService,
+        InnerTransportEvent, SubstreamError, TransportService,
     },
     substream::Substream,
     transport::manager::{limits::ConnectionLimitsConfig, TransportManager},
@@ -134,7 +134,10 @@ async fn unknown_substream_open_failure() {
     let (mut protocol, _handle, _manager, _tx) = protocol();
 
     match protocol
-        .on_substream_open_failure(SubstreamId::from(1338usize), Error::Unknown)
+        .on_substream_open_failure(
+            SubstreamId::from(1338usize),
+            SubstreamError::ConnectionClosed,
+        )
         .await
     {
         Err(Error::InvalidState) => {}

--- a/src/transport/common/listener.rs
+++ b/src/transport/common/listener.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     error::{AddressError, DnsError},
-    Error, PeerId,
+    PeerId,
 };
 
 use futures::Stream;

--- a/src/transport/common/listener.rs
+++ b/src/transport/common/listener.rs
@@ -430,10 +430,8 @@ fn multiaddr_to_socket_address(
     }
 
     let maybe_peer = match iter.next() {
-        Some(Protocol::P2p(multihash)) => Some(
-            PeerId::from_multihash(multihash)
-                .map_err(|hash| AddressError::InvalidMultihash(hash))?,
-        ),
+        Some(Protocol::P2p(multihash)) =>
+            Some(PeerId::from_multihash(multihash).map_err(AddressError::InvalidMultihash)?),
         None => None,
         protocol => {
             tracing::error!(

--- a/src/transport/common/listener.rs
+++ b/src/transport/common/listener.rs
@@ -431,7 +431,7 @@ fn multiaddr_to_socket_address(
 
     let maybe_peer = match iter.next() {
         Some(Protocol::P2p(multihash)) =>
-            Some(PeerId::from_multihash(multihash).map_err(AddressError::InvalidMultihash)?),
+            Some(PeerId::from_multihash(multihash).map_err(AddressError::InvalidPeerId)?),
         None => None,
         protocol => {
             tracing::error!(

--- a/src/transport/common/listener.rs
+++ b/src/transport/common/listener.rs
@@ -112,7 +112,7 @@ impl AddressType {
                 "Multiaddr DNS type does not match IP version `{}`",
                 url
             );
-            return Err(DnsError::MismatchDnsVersion);
+            return Err(DnsError::IpVersionMismatch);
         };
 
         Ok(SocketAddr::new(ip, port))

--- a/src/transport/dummy.rs
+++ b/src/transport/dummy.rs
@@ -104,7 +104,7 @@ impl Transport for DummyTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{transport::Endpoint, Error, PeerId};
+    use crate::{error::DialError, transport::Endpoint, PeerId};
     use futures::StreamExt;
 
     #[tokio::test]
@@ -114,7 +114,7 @@ mod tests {
         transport.inject_event(TransportEvent::DialFailure {
             connection_id: ConnectionId::from(1338usize),
             address: Multiaddr::empty(),
-            error: Error::Unknown,
+            error: DialError::Timeout,
         });
 
         let peer = PeerId::random();

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -1772,6 +1772,7 @@ mod tests {
         crypto::ed25519::Keypair, executor::DefaultExecutor, transport::dummy::DummyTransport,
     };
     use std::{
+        borrow::Cow,
         net::{Ipv4Addr, Ipv6Addr},
         sync::Arc,
     };
@@ -4068,5 +4069,111 @@ mod tests {
             assert!(!peer_context.addresses.contains(&dial_address));
             assert!(!peer_context.addresses.contains(&second_address));
         }
+    }
+
+    #[tokio::test]
+    async fn opening_errors_are_reported() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+
+        let (mut manager, _handle) = TransportManager::new(
+            Keypair::generate(),
+            HashSet::new(),
+            BandwidthSink::new(),
+            8usize,
+            ConnectionLimitsConfig::default(),
+        );
+        let peer = PeerId::random();
+        let connection_id = ConnectionId::from(0);
+
+        // Setup TCP transport.
+        let dial_address_tcp = Multiaddr::empty()
+            .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
+            .with(Protocol::Tcp(8888))
+            .with(Protocol::P2p(
+                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
+            ));
+        let transport = Box::new({
+            let mut transport = DummyTransport::new();
+            transport.inject_event(TransportEvent::OpenFailure {
+                connection_id,
+                errors: vec![(dial_address_tcp.clone(), DialError::Timeout)],
+            });
+            transport
+        });
+        manager.register_transport(SupportedTransport::Tcp, transport);
+        manager.add_known_address(
+            peer,
+            vec![Multiaddr::empty()
+                .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 5)))
+                .with(Protocol::Tcp(8888))
+                .with(Protocol::P2p(Multihash::from(peer)))]
+            .into_iter(),
+        );
+
+        // Setup WebSockets transport.
+        let dial_address_ws = Multiaddr::empty()
+            .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
+            .with(Protocol::Tcp(8889))
+            .with(Protocol::Ws(Cow::Borrowed("/")))
+            .with(Protocol::P2p(
+                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
+            ));
+
+        let transport = Box::new({
+            let mut transport = DummyTransport::new();
+            transport.inject_event(TransportEvent::OpenFailure {
+                connection_id,
+                errors: vec![(dial_address_ws.clone(), DialError::Timeout)],
+            });
+            transport
+        });
+        manager.register_transport(SupportedTransport::WebSocket, transport);
+        manager.add_known_address(
+            peer,
+            vec![Multiaddr::empty()
+                .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 5)))
+                .with(Protocol::Tcp(8889))
+                .with(Protocol::Ws(Cow::Borrowed("/")))
+                .with(Protocol::P2p(
+                    Multihash::from_bytes(&peer.to_bytes()).unwrap(),
+                ))]
+            .into_iter(),
+        );
+
+        // Dial the peer on both transports.
+        assert!(manager.dial(peer).await.is_ok());
+        assert!(!manager.pending_connections.is_empty());
+
+        {
+            let peers = manager.peers.read();
+
+            match peers.get(&peer) {
+                Some(PeerContext {
+                    state: PeerState::Opening { .. },
+                    ..
+                }) => {}
+                state => panic!("invalid state for peer: {state:?}"),
+            }
+        }
+
+        match manager.next().await.unwrap() {
+            TransportEvent::OpenFailure {
+                connection_id,
+                errors,
+            } => {
+                assert_eq!(connection_id, ConnectionId::from(0));
+                assert_eq!(errors.len(), 2);
+                let tcp = errors.iter().find(|(addr, _)| addr == &dial_address_tcp).unwrap();
+                assert!(std::matches!(tcp.1, DialError::Timeout));
+
+                let ws = errors.iter().find(|(addr, _)| addr == &dial_address_ws).unwrap();
+                assert!(std::matches!(ws.1, DialError::Timeout));
+            }
+            event => panic!("invalid event: {event:?}"),
+        }
+        assert!(manager.pending_connections.is_empty());
+        assert!(manager.opening_errors.is_empty());
     }
 }

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -1724,7 +1724,7 @@ impl TransportManager {
                                         "open failure, but not the last transport",
                                     );
 
-                                    self.opening_errors.entry(connection_id).or_insert(Default::default()).extend(errors);
+                                    self.opening_errors.entry(connection_id).or_default().extend(errors);
                                 }
                             }
                         },

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -20,7 +20,7 @@
 
 //! Transport protocol implementations provided by [`Litep2p`](`crate::Litep2p`).
 
-use crate::{transport::manager::TransportHandle, types::ConnectionId, Error, PeerId};
+use crate::{error::DialError, transport::manager::TransportHandle, types::ConnectionId, PeerId};
 
 use futures::Stream;
 use multiaddr::Multiaddr;
@@ -156,13 +156,16 @@ pub(crate) enum TransportEvent {
         address: Multiaddr,
 
         /// Error.
-        error: Error,
+        error: DialError,
     },
 
     /// Open failure for an unnegotiated set of connections.
     OpenFailure {
         /// Connection ID.
         connection_id: ConnectionId,
+
+        /// Errors.
+        errors: Vec<(Multiaddr, DialError)>,
     },
 }
 

--- a/src/transport/quic/connection.rs
+++ b/src/transport/quic/connection.rs
@@ -145,7 +145,7 @@ impl QuicConnection {
             Role::Dialer => dialer_select_proto(stream, protocols, Version::V1).await,
             Role::Listener => listener_select_proto(stream, protocols).await,
         }
-        .map_err(|error| NegotiationError::MultistreamSelectError(error))?;
+        .map_err(NegotiationError::MultistreamSelectError)?;
 
         tracing::trace!(target: LOG_TARGET, ?protocol, "protocol negotiated");
 

--- a/src/transport/quic/connection.rs
+++ b/src/transport/quic/connection.rs
@@ -164,7 +164,7 @@ impl QuicConnection {
 
         let stream = match handle.open_bi().await {
             Ok((send_stream, recv_stream)) => NegotiatingSubstream::new(send_stream, recv_stream),
-            Err(error) => return Err(NegotiationError::Quinn(error).into()),
+            Err(error) => return Err(NegotiationError::Quic(error.into()).into()),
         };
 
         // TODO: protocols don't change after they've been initialized so this should be done only

--- a/src/transport/quic/listener.rs
+++ b/src/transport/quic/listener.rs
@@ -270,12 +270,10 @@ mod tests {
         let crypto_config =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
         let client_config = ClientConfig::new(crypto_config);
-        let client = Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0))
-            .map_err(|error| Error::Other(error.to_string()))
-            .unwrap();
+        let client =
+            Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)).unwrap();
         let connection = client
             .connect_with(client_config, format!("[::1]:{port}").parse().unwrap(), "l")
-            .map_err(|error| Error::Other(error.to_string()))
             .unwrap();
 
         let (res1, res2) = tokio::join!(
@@ -320,31 +318,27 @@ mod tests {
         let crypto_config1 =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
         let client_config1 = ClientConfig::new(crypto_config1);
-        let client1 = Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0))
-            .map_err(|error| Error::Other(error.to_string()))
-            .unwrap();
+        let client1 =
+            Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)).unwrap();
         let connection1 = client1
             .connect_with(
                 client_config1,
                 format!("[::1]:{port1}").parse().unwrap(),
                 "l",
             )
-            .map_err(|error| Error::Other(error.to_string()))
             .unwrap();
 
         let crypto_config2 =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
         let client_config2 = ClientConfig::new(crypto_config2);
-        let client2 = Endpoint::client(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
-            .map_err(|error| Error::Other(error.to_string()))
-            .unwrap();
+        let client2 =
+            Endpoint::client(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)).unwrap();
         let connection2 = client2
             .connect_with(
                 client_config2,
                 format!("127.0.0.1:{port2}").parse().unwrap(),
                 "l",
             )
-            .map_err(|error| Error::Other(error.to_string()))
             .unwrap();
 
         tokio::spawn(async move {
@@ -393,31 +387,27 @@ mod tests {
         let crypto_config1 =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
         let client_config1 = ClientConfig::new(crypto_config1);
-        let client1 = Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0))
-            .map_err(|error| Error::Other(error.to_string()))
-            .unwrap();
+        let client1 =
+            Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)).unwrap();
         let connection1 = client1
             .connect_with(
                 client_config1,
                 format!("[::1]:{port}").parse().unwrap(),
                 "l",
             )
-            .map_err(|error| Error::Other(error.to_string()))
             .unwrap();
 
         let crypto_config2 =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
         let client_config2 = ClientConfig::new(crypto_config2);
-        let client2 = Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0))
-            .map_err(|error| Error::Other(error.to_string()))
-            .unwrap();
+        let client2 =
+            Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)).unwrap();
         let connection2 = client2
             .connect_with(
                 client_config2,
                 format!("[::1]:{port}").parse().unwrap(),
                 "l",
             )
-            .map_err(|error| Error::Other(error.to_string()))
             .unwrap();
 
         tokio::spawn(async move {

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -24,7 +24,7 @@
 
 use crate::{
     crypto::tls::make_client_config,
-    error::{AddressError, DialError, Error, QuicError},
+    error::{AddressError, DialError, Error, NegotiationError, QuicError},
     transport::{
         manager::TransportHandle,
         quic::{config::Config as QuicConfig, connection::QuicConnection, listener::QuicListener},

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -356,7 +356,7 @@ impl Transport for QuicTransport {
 
                 let future = async move {
                     let (socket_address, peer) = QuicListener::get_socket_address(&address)
-                        .map_err(|err| DialError::AddressError(err))?;
+                        .map_err(DialError::AddressError)?;
                     let peer =
                         peer.ok_or_else(|| DialError::AddressError(AddressError::PeerIdMissing))?;
 

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -24,7 +24,7 @@
 
 use crate::{
     crypto::tls::make_client_config,
-    error::{AddressError, DialError, Error, NegotiationError, QuicError},
+    error::{AddressError, DialError, Error, QuicError},
     transport::{
         manager::TransportHandle,
         quic::{config::Config as QuicConfig, connection::QuicConnection, listener::QuicListener},

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -24,7 +24,7 @@
 
 use crate::{
     crypto::tls::make_client_config,
-    error::{AddressError, Error},
+    error::{AddressError, DialError, Error, QuicError},
     transport::{
         manager::TransportHandle,
         quic::{config::Config as QuicConfig, connection::QuicConnection, listener::QuicListener},
@@ -84,15 +84,22 @@ pub(crate) struct QuicTransport {
     pending_inbound_connections: HashMap<ConnectionId, Connecting>,
 
     /// Pending connections.
-    pending_connections:
-        FuturesUnordered<BoxFuture<'static, (ConnectionId, Result<NegotiatedConnection, Error>)>>,
+    pending_connections: FuturesUnordered<
+        BoxFuture<'static, (ConnectionId, Result<NegotiatedConnection, DialError>)>,
+    >,
 
     /// Negotiated connections waiting for validation.
     pending_open: HashMap<ConnectionId, (NegotiatedConnection, Litep2pEndpoint)>,
 
     /// Pending raw, unnegotiated connections.
     pending_raw_connections: FuturesUnordered<
-        BoxFuture<'static, Result<(ConnectionId, Multiaddr, NegotiatedConnection), ConnectionId>>,
+        BoxFuture<
+            'static,
+            Result<
+                (ConnectionId, Multiaddr, NegotiatedConnection),
+                (ConnectionId, Vec<(Multiaddr, DialError)>),
+            >,
+        >,
     >,
 
     /// Opened raw connection, waiting for approval/rejection from `TransportManager`.
@@ -118,11 +125,14 @@ impl QuicTransport {
         self.pending_connections.push(Box::pin(async move {
             let connection = match connection.await {
                 Ok(connection) => connection,
-                Err(error) => return (connection_id, Err(error.into())),
+                Err(error) => return (connection_id, Err(DialError::Quic(error.into()))),
             };
 
             let Some(peer) = Self::extract_peer_id(&connection) else {
-                return (connection_id, Err(Error::InvalidCertificate));
+                return (
+                    connection_id,
+                    Err(DialError::Quic(QuicError::InvalidCertificate)),
+                );
             };
 
             (connection_id, Ok(NegotiatedConnection { peer, connection }))
@@ -133,7 +143,7 @@ impl QuicTransport {
     fn on_connection_established(
         &mut self,
         connection_id: ConnectionId,
-        result: crate::Result<NegotiatedConnection>,
+        result: Result<NegotiatedConnection, DialError>,
     ) -> Option<TransportEvent> {
         tracing::debug!(target: LOG_TARGET, ?connection_id, success = result.is_ok(), "connection established");
 
@@ -257,14 +267,18 @@ impl Transport for QuicTransport {
         );
 
         self.pending_dials.insert(connection_id, address);
+
         self.pending_connections.push(Box::pin(async move {
             let connection = match connection.await {
                 Ok(connection) => connection,
-                Err(error) => return (connection_id, Err(error.into())),
+                Err(error) => return (connection_id, Err(DialError::Quic(error.into()))),
             };
 
             let Some(peer) = Self::extract_peer_id(&connection) else {
-                return (connection_id, Err(Error::InvalidCertificate));
+                return (
+                    connection_id,
+                    Err(DialError::Quic(QuicError::InvalidCertificate)),
+                );
             };
 
             (connection_id, Ok(NegotiatedConnection { peer, connection }))
@@ -332,21 +346,19 @@ impl Transport for QuicTransport {
         connection_id: ConnectionId,
         addresses: Vec<Multiaddr>,
     ) -> crate::Result<()> {
+        let num_addresses = addresses.len();
         let mut futures: FuturesUnordered<_> = addresses
             .into_iter()
             .map(|address| {
                 let keypair = self.context.keypair.clone();
                 let connection_open_timeout = self.config.connection_open_timeout;
+                let addr = address.clone();
 
-                async move {
-                    let Ok((socket_address, Some(peer))) =
-                        QuicListener::get_socket_address(&address)
-                    else {
-                        return (
-                            connection_id,
-                            Err(Error::AddressError(AddressError::PeerIdMissing)),
-                        );
-                    };
+                let future = async move {
+                    let (socket_address, peer) = QuicListener::get_socket_address(&address)
+                        .map_err(|err| DialError::AddressError(err))?;
+                    let peer =
+                        peer.ok_or_else(|| DialError::AddressError(AddressError::PeerIdMissing))?;
 
                     let crypto_config =
                         Arc::new(make_client_config(&keypair, Some(peer)).expect("to succeed"));
@@ -362,59 +374,55 @@ impl Transport for QuicTransport {
                             SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
                         Some(Protocol::Ip4(_)) =>
                             SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
-                        _ =>
-                            return (
-                                connection_id,
-                                Err(Error::AddressError(AddressError::InvalidProtocol)),
-                            ),
+                        _ => return Err(AddressError::InvalidProtocol.into()),
                     };
 
                     let client = match Endpoint::client(client_listen_address) {
                         Ok(client) => client,
                         Err(error) => {
-                            return (connection_id, Err(Error::Other(error.to_string())));
+                            return Err(DialError::IoError(error.kind()));
                         }
                     };
                     let connection = match client.connect_with(client_config, socket_address, "l") {
                         Ok(connection) => connection,
-                        Err(error) => {
-                            return (connection_id, Err(Error::Other(error.to_string())));
-                        }
+                        Err(error) => return Err(DialError::Quic(error.into())),
                     };
 
                     let connection = match connection.await {
                         Ok(connection) => connection,
-                        Err(error) => return (connection_id, Err(error.into())),
+                        Err(error) => return Err(DialError::Quic(error.into())),
                     };
 
                     let Some(peer) = Self::extract_peer_id(&connection) else {
-                        return (connection_id, Err(Error::InvalidCertificate));
+                        return Err(DialError::Quic(QuicError::InvalidCertificate));
                     };
 
-                    (
-                        connection_id,
-                        Ok((address, NegotiatedConnection { peer, connection })),
-                    )
-                }
+                    Ok(NegotiatedConnection { peer, connection })
+                };
+
+                async move { future.await.map(|ok| (addr.clone(), ok)).map_err(|err| (addr, err)) }
             })
             .collect();
 
         self.pending_raw_connections.push(Box::pin(async move {
-            while let Some(result) = futures.next().await {
-                let (connection_id, result) = result;
+            let mut errors = Vec::with_capacity(num_addresses);
 
+            while let Some(result) = futures.next().await {
                 match result {
                     Ok((address, connection)) => return Ok((connection_id, address, connection)),
-                    Err(error) => tracing::debug!(
-                        target: LOG_TARGET,
-                        ?connection_id,
-                        ?error,
-                        "failed to open connection",
-                    ),
+                    Err(error) => {
+                        tracing::debug!(
+                            target: LOG_TARGET,
+                            ?connection_id,
+                            ?error,
+                            "failed to open connection",
+                        );
+                        errors.push(error)
+                    }
                 }
             }
 
-            Err(connection_id)
+            Err((connection_id, errors))
         }));
 
         Ok(())
@@ -478,9 +486,12 @@ impl Stream for QuicTransport {
                         }));
                     }
                 }
-                Err(connection_id) =>
+                Err((connection_id, errors)) =>
                     if !self.canceled.remove(&connection_id) {
-                        return Poll::Ready(Some(TransportEvent::OpenFailure { connection_id }));
+                        return Poll::Ready(Some(TransportEvent::OpenFailure {
+                            connection_id,
+                            errors,
+                        }));
                     },
             }
         }

--- a/src/transport/tcp/connection.rs
+++ b/src/transport/tcp/connection.rs
@@ -718,11 +718,11 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::NegotiationError(NegotiationError::MultistreamSelectError(
+            Err(NegotiationError::MultistreamSelectError(
                 crate::multistream_select::NegotiationError::ProtocolError(
                     crate::multistream_select::ProtocolError::InvalidMessage,
                 ),
-            ))) => {}
+            )) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
@@ -760,11 +760,11 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::NegotiationError(NegotiationError::MultistreamSelectError(
+            Err(NegotiationError::MultistreamSelectError(
                 crate::multistream_select::NegotiationError::ProtocolError(
                     crate::multistream_select::ProtocolError::InvalidMessage,
                 ),
-            ))) => {}
+            )) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
@@ -813,9 +813,9 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::NegotiationError(NegotiationError::MultistreamSelectError(
+            Err(NegotiationError::MultistreamSelectError(
                 crate::multistream_select::NegotiationError::Failed,
-            ))) => {}
+            )) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
@@ -857,9 +857,9 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::NegotiationError(NegotiationError::MultistreamSelectError(
+            Err(NegotiationError::MultistreamSelectError(
                 crate::multistream_select::NegotiationError::Failed,
-            ))) => {}
+            )) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
@@ -904,7 +904,7 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::Timeout) => {}
+            Err(NegotiationError::Timeout) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
@@ -955,7 +955,7 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::Timeout) => {}
+            Err(NegotiationError::Timeout) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
@@ -1001,7 +1001,7 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::Timeout) => {}
+            Err(NegotiationError::Timeout) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
@@ -1041,7 +1041,7 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::Timeout) => {}
+            Err(NegotiationError::Timeout) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
@@ -1096,9 +1096,9 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::NegotiationError(NegotiationError::MultistreamSelectError(
+            Err(NegotiationError::MultistreamSelectError(
                 crate::multistream_select::NegotiationError::Failed,
-            ))) => {}
+            )) => {}
             Err(error) => panic!("{error:?}"),
         }
     }
@@ -1156,9 +1156,9 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::NegotiationError(NegotiationError::MultistreamSelectError(
+            Err(NegotiationError::MultistreamSelectError(
                 crate::multistream_select::NegotiationError::Failed,
-            ))) => {}
+            )) => {}
             Err(error) => panic!("{error:?}"),
         }
     }
@@ -1209,7 +1209,7 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::Timeout) => {}
+            Err(NegotiationError::Timeout) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
@@ -1266,7 +1266,7 @@ mod tests {
         .await
         {
             Ok(_) => panic!("connection was supposed to fail"),
-            Err(Error::Timeout) => {}
+            Err(NegotiationError::Timeout) => {}
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }

--- a/src/transport/tcp/connection.rs
+++ b/src/transport/tcp/connection.rs
@@ -249,7 +249,7 @@ impl TcpConnection {
         {
             Err(_) => {
                 tracing::trace!(target: LOG_TARGET, ?connection_id, "connection timed out during negotiation");
-                Err(Error::Timeout)
+                Err(NegotiationError::Timeout)
             }
             Ok(result) => result,
         }
@@ -522,7 +522,7 @@ impl TcpConnection {
                                 Ok(Err(error)) => Err(ConnectionError::FailedToNegotiate {
                                     protocol: None,
                                     substream_id: None,
-                                    error,
+                                    error: SubstreamError::NegotiationError(error),
                                 }),
                                 Err(_) => Err(ConnectionError::Timeout {
                                     protocol: None,

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -917,7 +917,7 @@ mod tests {
 
         assert!(!transport.pending_dials.is_empty());
         transport.pending_connections.push(Box::pin(async move {
-            Err((ConnectionId::from(0usize), Error::Unknown))
+            Err((ConnectionId::from(0usize), DialError::Timeout))
         }));
 
         assert!(std::matches!(

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -569,7 +569,7 @@ impl Stream for TcpTransport {
                         return Poll::Ready(Some(TransportEvent::DialFailure {
                             connection_id,
                             address,
-                            error: error.into(),
+                            error,
                         }));
                     }
                 }

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -572,8 +572,7 @@ impl Stream for TcpTransport {
                             error,
                         }));
                     } else {
-                        tracing::debug!(target: LOG_TARGET, ?error, ?connection_id, "Pending dial for connection ID not found");
-                        debug_assert!(false);
+                        tracing::debug!(target: LOG_TARGET, ?error, ?connection_id, "Pending inbound connection failed");
                     }
                 }
             }

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -571,6 +571,9 @@ impl Stream for TcpTransport {
                             address,
                             error,
                         }));
+                    } else {
+                        tracing::debug!(target: LOG_TARGET, ?error, ?connection_id, "Pending dial for connection ID not found");
+                        debug_assert!(false);
                     }
                 }
             }

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -381,8 +381,11 @@ impl WebRtcConnection {
             "handle opening outbound substream",
         );
 
-        let rtc_message = WebRtcMessage::decode(&data)?;
-        let message = rtc_message.payload.ok_or(ParseError::InvalidData)?;
+        let rtc_message = WebRtcMessage::decode(&data)
+            .map_err(|err| SubstreamError::NegotiationError(err.into()))?;
+        let message = rtc_message.payload.ok_or(SubstreamError::NegotiationError(
+            ParseError::InvalidData.into(),
+        ))?;
 
         let HandshakeResult::Succeeded(protocol) = dialer_state.register_response(message)? else {
             tracing::trace!(

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{
-    error::Error,
+    error::{Error, ParseError, SubstreamError},
     multistream_select::{listener_negotiate, DialerState, HandshakeResult, ListenerSelectResult},
     protocol::{Direction, Permit, ProtocolCommand, ProtocolSet},
     substream::Substream,
@@ -349,6 +349,7 @@ impl WebRtcConnection {
             .report_substream_open(self.peer, protocol.clone(), Direction::Inbound, substream)
             .await
             .map(|_| (substream_id, handle, permit))
+            .map_err(Into::into)
     }
 
     /// Handle data received to an opening outbound channel.
@@ -372,7 +373,7 @@ impl WebRtcConnection {
         data: Vec<u8>,
         mut dialer_state: DialerState,
         context: ChannelContext,
-    ) -> crate::Result<Option<(SubstreamId, SubstreamHandle, Permit)>> {
+    ) -> Result<Option<(SubstreamId, SubstreamHandle, Permit)>, SubstreamError> {
         tracing::trace!(
             target: LOG_TARGET,
             peer = ?self.peer,
@@ -380,7 +381,9 @@ impl WebRtcConnection {
             "handle opening outbound substream",
         );
 
-        let message = WebRtcMessage::decode(&data)?.payload.ok_or(Error::InvalidData)?;
+        let rtc_message = WebRtcMessage::decode(&data)?;
+        let message = rtc_message.payload.ok_or(ParseError::InvalidData)?;
+
         let HandshakeResult::Succeeded(protocol) = dialer_state.register_response(message)? else {
             tracing::trace!(
                 target: LOG_TARGET,

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -202,7 +202,7 @@ impl WebSocketConnection {
             Role::Dialer => dialer_select_proto(stream, protocols, Version::V1).await,
             Role::Listener => listener_select_proto(stream, protocols).await,
         }
-        .map_err(|error| NegotiationError::MultistreamSelectError(error))?;
+        .map_err(NegotiationError::MultistreamSelectError)?;
 
         tracing::trace!(target: LOG_TARGET, ?protocol, "protocol negotiated");
 
@@ -258,7 +258,7 @@ impl WebSocketConnection {
         Self::negotiate_connection(
             tokio_tungstenite::accept_async(stream)
                 .await
-                .map_err(|err| NegotiationError::Other(err.to_string()))?,
+                .map_err(NegotiationError::WebSocket)?,
             None,
             Role::Listener,
             address,

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -317,8 +317,8 @@ impl WebSocketConnection {
             }
         }
 
-        tracing::trace!(target: LOG_TARGET, "noise handshake done");
         let stream: NoiseSocket<BufferedStream<_>> = stream;
+        tracing::trace!(target: LOG_TARGET, "noise handshake done");
 
         // negotiate `yamux`
         let (stream, _) = Self::negotiate_protocol(stream, &role, vec!["/yamux/1.0.0"]).await?;

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -614,8 +614,7 @@ impl Stream for WebSocketTransport {
                             error,
                         }));
                     } else {
-                        tracing::debug!(target: LOG_TARGET, ?error, ?connection_id, "Pending dial for connection ID not found");
-                        debug_assert!(false);
+                        tracing::debug!(target: LOG_TARGET, ?error, ?connection_id, "Pending inbound connection failed");
                     }
                 }
             }

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -610,6 +610,9 @@ impl Stream for WebSocketTransport {
                             address,
                             error,
                         }));
+                    } else {
+                        tracing::debug!(target: LOG_TARGET, ?error, ?connection_id, "Pending dial for connection ID not found");
+                        debug_assert!(false);
                     }
                 }
             }

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -266,7 +266,7 @@ impl WebSocketTransport {
                 address,
                 tokio_tungstenite::client_async_tls(url, stream)
                     .await
-                    .map_err(|err| NegotiationError::WebSocket(err))?
+                    .map_err(NegotiationError::WebSocket)?
                     .0,
             ))
         };

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -33,7 +33,7 @@ use crate::{
         Transport, TransportBuilder, TransportEvent,
     },
     types::ConnectionId,
-    PeerId,
+    DialError, PeerId,
 };
 
 use futures::{future::BoxFuture, stream::FuturesUnordered, Stream, StreamExt};
@@ -59,24 +59,6 @@ mod stream;
 mod substream;
 
 pub mod config;
-
-#[derive(Debug)]
-pub(super) struct WebSocketError {
-    /// Error.
-    error: Error,
-
-    /// Connection ID.
-    connection_id: Option<ConnectionId>,
-}
-
-impl WebSocketError {
-    pub fn new(error: Error, connection_id: Option<ConnectionId>) -> Self {
-        Self {
-            error,
-            connection_id,
-        }
-    }
-}
 
 /// Logging target for the file.
 const LOG_TARGET: &str = "litep2p::websocket";
@@ -110,8 +92,9 @@ pub(crate) struct WebSocketTransport {
     pending_inbound_connections: HashMap<ConnectionId, PendingInboundConnection>,
 
     /// Pending connections.
-    pending_connections:
-        FuturesUnordered<BoxFuture<'static, Result<NegotiatedConnection, WebSocketError>>>,
+    pending_connections: FuturesUnordered<
+        BoxFuture<'static, Result<NegotiatedConnection, (ConnectionId, DialError)>>,
+    >,
 
     /// Pending raw, unnegotiated connections.
     pending_raw_connections: FuturesUnordered<
@@ -123,7 +106,7 @@ pub(crate) struct WebSocketTransport {
                     Multiaddr,
                     WebSocketStream<MaybeTlsStream<TcpStream>>,
                 ),
-                ConnectionId,
+                (ConnectionId, Vec<(Multiaddr, DialError)>),
             >,
         >,
     >,
@@ -168,11 +151,11 @@ impl WebSocketTransport {
                     max_write_buffer_size,
                 )
                 .await
-                .map_err(|error| WebSocketError::new(error, None))
+                .map_err(|error| (connection_id, error.into()))
             })
             .await
             {
-                Err(_) => Err(WebSocketError::new(Error::Timeout, None)),
+                Err(_) => Err((connection_id, DialError::Timeout)),
                 Ok(Err(error)) => Err(error),
                 Ok(Ok(result)) => Ok(result),
             }
@@ -180,31 +163,31 @@ impl WebSocketTransport {
     }
 
     /// Convert `Multiaddr` into `url::Url`
-    fn multiaddr_into_url(address: Multiaddr) -> crate::Result<(Url, PeerId)> {
+    fn multiaddr_into_url(address: Multiaddr) -> Result<(Url, PeerId), AddressError> {
         let mut protocol_stack = address.iter();
 
         let dial_address = match protocol_stack
             .next()
-            .ok_or_else(|| Error::TransportNotSupported(address.clone()))?
+            .ok_or_else(|| AddressError::TransportNotSupported(address.clone()))?
         {
             Protocol::Ip4(address) => address.to_string(),
             Protocol::Ip6(address) => format!("[{address}]"),
             Protocol::Dns(address) | Protocol::Dns4(address) | Protocol::Dns6(address) =>
                 address.to_string(),
 
-            _ => return Err(Error::TransportNotSupported(address)),
+            _ => return Err(AddressError::TransportNotSupported(address)),
         };
 
         let url = match protocol_stack
             .next()
-            .ok_or_else(|| Error::TransportNotSupported(address.clone()))?
+            .ok_or_else(|| AddressError::TransportNotSupported(address.clone()))?
         {
             Protocol::Tcp(port) => match protocol_stack.next() {
                 Some(Protocol::Ws(_)) => format!("ws://{dial_address}:{port}/"),
                 Some(Protocol::Wss(_)) => format!("wss://{dial_address}:{port}/"),
-                _ => return Err(Error::TransportNotSupported(address.clone())),
+                _ => return Err(AddressError::TransportNotSupported(address.clone())),
             },
-            _ => return Err(Error::TransportNotSupported(address)),
+            _ => return Err(AddressError::TransportNotSupported(address)),
         };
 
         let peer = match protocol_stack.next() {
@@ -215,13 +198,15 @@ impl WebSocketTransport {
                     ?protocol,
                     "invalid protocol, expected `Protocol::Ws`/`Protocol::Wss`",
                 );
-                return Err(Error::AddressError(AddressError::PeerIdMissing));
+                return Err(AddressError::PeerIdMissing);
             }
         };
 
         tracing::trace!(target: LOG_TARGET, ?url, "parse address");
 
-        url::Url::parse(&url).map(|url| (url, peer)).map_err(|_| Error::InvalidData)
+        url::Url::parse(&url)
+            .map(|url| (url, peer))
+            .map_err(|_| AddressError::InvalidUrl)
     }
 
     /// Dial remote peer over `address`.
@@ -230,14 +215,14 @@ impl WebSocketTransport {
         dial_addresses: DialAddresses,
         connection_open_timeout: Duration,
         nodelay: bool,
-    ) -> crate::Result<(Multiaddr, WebSocketStream<MaybeTlsStream<TcpStream>>)> {
+    ) -> Result<(Multiaddr, WebSocketStream<MaybeTlsStream<TcpStream>>), DialError> {
         let (url, _) = Self::multiaddr_into_url(address.clone())?;
 
         let (socket_address, _) = WebSocketAddress::multiaddr_to_socket_address(&address)?;
         let remote_address =
             match tokio::time::timeout(connection_open_timeout, socket_address.lookup_ip()).await {
-                Err(_) => return Err(Error::Timeout),
-                Ok(Err(error)) => return Err(error),
+                Err(_) => return Err(DialError::Timeout),
+                Ok(Err(error)) => return Err(error.into()),
                 Ok(Ok(address)) => address,
             };
 
@@ -274,17 +259,13 @@ impl WebSocketTransport {
                 Ok(()) => {}
                 Err(error) if error.raw_os_error() == Some(libc::EINPROGRESS) => {}
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
-                Err(error) => return Err(Error::Other(error.to_string())),
+                Err(err) => return Err(DialError::IoError(err.kind())),
             }
 
-            let stream = TcpStream::try_from(Into::<std::net::TcpStream>::into(socket))
-                .map_err(|error| Error::Other(error.to_string()))?;
-            stream.writable().await.map_err(|error| Error::Other(error.to_string()))?;
-
-            if let Some(error) =
-                stream.take_error().map_err(|error| Error::Other(error.to_string()))?
-            {
-                return Err(Error::Other(error.to_string()));
+            let stream = TcpStream::try_from(Into::<std::net::TcpStream>::into(socket))?;
+            stream.writable().await?;
+            if let Some(e) = stream.take_error()? {
+                return Err(DialError::IoError(e.kind()));
             }
 
             Ok((
@@ -294,7 +275,7 @@ impl WebSocketTransport {
         };
 
         match tokio::time::timeout(connection_open_timeout, future).await {
-            Err(_) => Err(Error::Timeout),
+            Err(_) => Err(DialError::Timeout),
             Ok(Err(error)) => Err(error),
             Ok(Ok((address, stream))) => Ok((address, stream)),
         }
@@ -366,7 +347,7 @@ impl Transport for WebSocketTransport {
                 nodelay,
             )
             .await
-            .map_err(|error| WebSocketError::new(error, Some(connection_id)))?;
+            .map_err(|error| (connection_id, error))?;
 
             WebSocketConnection::open_connection(
                 connection_id,
@@ -380,12 +361,12 @@ impl Transport for WebSocketTransport {
                 max_write_buffer_size,
             )
             .await
-            .map_err(|error| WebSocketError::new(error, Some(connection_id)))
+            .map_err(|error| (connection_id, error.into()))
         };
 
         self.pending_connections.push(Box::pin(async move {
             match tokio::time::timeout(connection_open_timeout, future).await {
-                Err(_) => Err(WebSocketError::new(Error::Timeout, Some(connection_id))),
+                Err(_) => Err((connection_id, DialError::Timeout)),
                 Ok(Err(error)) => Err(error),
                 Ok(Ok(result)) => Ok(result),
             }
@@ -459,6 +440,7 @@ impl Transport for WebSocketTransport {
         connection_id: ConnectionId,
         addresses: Vec<Multiaddr>,
     ) -> crate::Result<()> {
+        let num_addresses = addresses.len();
         let mut futures: FuturesUnordered<_> = addresses
             .into_iter()
             .map(|address| {
@@ -468,30 +450,36 @@ impl Transport for WebSocketTransport {
 
                 async move {
                     WebSocketTransport::dial_peer(
-                        address,
+                        address.clone(),
                         dial_addresses,
                         connection_open_timeout,
                         nodelay,
                     )
                     .await
+                    .map_err(|error| (address, error))
                 }
             })
             .collect();
 
         self.pending_raw_connections.push(Box::pin(async move {
+            let mut errors = Vec::with_capacity(num_addresses);
+
             while let Some(result) = futures.next().await {
                 match result {
                     Ok((address, stream)) => return Ok((connection_id, address, stream)),
-                    Err(error) => tracing::debug!(
-                        target: LOG_TARGET,
-                        ?connection_id,
-                        ?error,
-                        "failed to open connection",
-                    ),
+                    Err(error) => {
+                        tracing::debug!(
+                            target: LOG_TARGET,
+                            ?connection_id,
+                            ?error,
+                            "failed to open connection",
+                        );
+                        errors.push(error)
+                    }
                 }
             }
 
-            Err(connection_id)
+            Err((connection_id, errors))
         }));
 
         Ok(())
@@ -536,11 +524,11 @@ impl Transport for WebSocketTransport {
                     max_write_buffer_size,
                 )
                 .await
-                .map_err(|error| WebSocketError::new(error, Some(connection_id)))
+                .map_err(|error| (connection_id, error.into()))
             })
             .await
             {
-                Err(_) => Err(WebSocketError::new(Error::Timeout, Some(connection_id))),
+                Err(_) => Err((connection_id, DialError::Timeout)),
                 Ok(Err(error)) => Err(error),
                 Ok(Ok(connection)) => Ok(connection),
             }
@@ -599,9 +587,12 @@ impl Stream for WebSocketTransport {
                         }));
                     }
                 }
-                Err(connection_id) =>
+                Err((connection_id, errors)) =>
                     if !self.canceled.remove(&connection_id) {
-                        return Poll::Ready(Some(TransportEvent::OpenFailure { connection_id }));
+                        return Poll::Ready(Some(TransportEvent::OpenFailure {
+                            connection_id,
+                            errors,
+                        }));
                     },
             }
         }
@@ -618,22 +609,15 @@ impl Stream for WebSocketTransport {
                         endpoint,
                     }));
                 }
-                Err(error) => match error.connection_id {
-                    Some(connection_id) => match self.pending_dials.remove(&connection_id) {
-                        Some(address) =>
-                            return Poll::Ready(Some(TransportEvent::DialFailure {
-                                connection_id,
-                                address,
-                                error: error.error,
-                            })),
-                        None => {
-                            tracing::debug!(target: LOG_TARGET, ?error, "failed to establish connection")
-                        }
-                    },
-                    None => {
-                        tracing::debug!(target: LOG_TARGET, ?error, "failed to establish connection")
+                Err((connection_id, error)) => {
+                    if let Some(address) = self.pending_dials.remove(&connection_id) {
+                        return Poll::Ready(Some(TransportEvent::DialFailure {
+                            connection_id,
+                            address,
+                            error,
+                        }));
                     }
-                },
+                }
             }
         }
 

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -22,7 +22,7 @@
 
 use crate::{
     config::Role,
-    error::{AddressError, Error},
+    error::{AddressError, Error, NegotiationError},
     transport::{
         common::listener::{DialAddresses, GetSocketAddr, SocketListener, WebSocketAddress},
         manager::TransportHandle,
@@ -264,7 +264,10 @@ impl WebSocketTransport {
 
             Ok((
                 address,
-                tokio_tungstenite::client_async_tls(url, stream).await?.0,
+                tokio_tungstenite::client_async_tls(url, stream)
+                    .await
+                    .map_err(|err| NegotiationError::WebSocket(err))?
+                    .0,
             ))
         };
 

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -21,7 +21,7 @@
 use litep2p::{
     config::ConfigBuilder,
     crypto::ed25519::Keypair,
-    error::Error,
+    error::{DialError, Error, NegotiationError},
     protocol::libp2p::ping::{Config as PingConfig, PingEvent},
     transport::tcp::config::Config as TcpConfig,
     Litep2p, Litep2pEvent, PeerId,
@@ -366,7 +366,14 @@ async fn connection_timeout(transport: Transport, address: Multiaddr) {
 
     assert_eq!(dial_address, address);
     println!("{error:?}");
-    assert!(std::matches!(error, Error::Timeout));
+    match error {
+        DialError::Timeout => {}
+        DialError::NegotiationError(NegotiationError::Timeout) => {}
+        DialError::Quic(litep2p::error::QuicError::ConnectionError(
+            quinn::ConnectionError::TimedOut,
+        )) => {}
+        _ => panic!("unexpected error {error:?}"),
+    }
 }
 
 #[cfg(feature = "quic")]

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -369,9 +369,6 @@ async fn connection_timeout(transport: Transport, address: Multiaddr) {
     match error {
         DialError::Timeout => {}
         DialError::NegotiationError(NegotiationError::Timeout) => {}
-        DialError::Quic(litep2p::error::QuicError::ConnectionError(
-            quinn::ConnectionError::TimedOut,
-        )) => {}
         _ => panic!("unexpected error {error:?}"),
     }
 }


### PR DESCRIPTION
The purpose of this PR is to pave the way for making the Identify protocol more robust, which is currently linked with the low number of peers and connective issues over a long period of time
- https://github.com/paritytech/polkadot-sdk/issues/4925

This PR adds a coherent `DialError` that exposes the minimal information users need to know about dial failures.
- https://github.com/paritytech/polkadot-sdk/issues/5239

A new litep2p event is added for reporting multiple dial errors that occur on different protocols back to the user:

```rust
    /// A list of multiple dial failures.
    ListDialFailures {
        /// List of errors.
        ///
        /// Depending on the transport, the address might be different for each error.
        errors: Vec<(Multiaddr, DialError)>,
    },
```

This event eases the debugging of substrate connectivity issues. At the same time, it can be used in a future PR to inform back to the Identify protocol which self-reported addresses of some peers are unreachable:
- https://github.com/paritytech/litep2p/issues/203

### Next Steps
- Add more tests
- Warp sync + sync full nodes since this is touching individual transports

### Future Work
- The overarching `litep2p::Error` needs a closer look and a refactoring:
  - https://github.com/paritytech/litep2p/issues/204
  - https://github.com/paritytech/litep2p/issues/128
  
- ConnectionError event for individual transports can be simplified:
  - https://github.com/paritytech/litep2p/issues/205
  
- I've observed some inconsistencies in handling TCP vs WebSocket connection timeouts. I believe that we can have another pass and share even more code between them:
  - https://github.com/paritytech/litep2p/issues/70
