### PR TITLE
kad: Handle `ADD_PROVIDER` & `GET_PROVIDERS` network requests

### DIFF
--- a/src/protocol/libp2p/kademlia/message.rs
+++ b/src/protocol/libp2p/kademlia/message.rs
@@ -76,8 +76,8 @@ pub enum KademliaMessage {
 
     /// `GET_PROVIDERS` message.
     GetProviders {
-        /// Key.
-        key: RecordKey,
+        /// Key. `None` in response.
+        key: Option<RecordKey>,
 
         /// Peers closer to the key.
         peers: Vec<KademliaPeer>,
@@ -294,7 +294,7 @@ impl KademliaMessage {
                 }
                 // ADD_PROVIDER
                 2 => {
-                    let key = message.key.into(); // TODO: check for empty key.
+                    let key = (!message.key.is_empty()).then_some(message.key.into())?;
                     let providers = message
                         .provider_peers
                         .iter()
@@ -305,7 +305,7 @@ impl KademliaMessage {
                 }
                 // GET_PROVIDERS
                 3 => {
-                    let key = message.key.into(); // TODO: key is optional.
+                    let key = (!message.key.is_empty()).then_some(message.key.into());
                     let peers = message
                         .closer_peers
                         .iter()

--- a/src/protocol/libp2p/kademlia/message.rs
+++ b/src/protocol/libp2p/kademlia/message.rs
@@ -172,6 +172,7 @@ impl KademliaMessage {
     }
 
     /// Create `ADD_PROVIDER` message with `provider`.
+    #[allow(unused)]
     pub fn add_provider(provider: ProviderRecord) -> Vec<u8> {
         let peer = KademliaPeer::new(
             provider.provider,
@@ -193,6 +194,7 @@ impl KademliaMessage {
     }
 
     /// Create `GET_PROVIDERS` request for `key`.
+    #[allow(unused)]
     pub fn get_providers_request(key: RecordKey) -> Vec<u8> {
         let message = schema::kademlia::Message {
             key: key.to_vec(),

--- a/src/protocol/libp2p/kademlia/message.rs
+++ b/src/protocol/libp2p/kademlia/message.rs
@@ -20,9 +20,9 @@
 
 use crate::{
     protocol::libp2p::kademlia::{
-        record::{Key as RecordKey, Record},
+        record::{Key as RecordKey, ProviderRecord, Record},
         schema,
-        types::KademliaPeer,
+        types::{ConnectionType, KademliaPeer},
     },
     PeerId,
 };
@@ -171,10 +171,82 @@ impl KademliaMessage {
         buf
     }
 
+    /// Create `ADD_PROVIDER` message with `provider`.
+    pub fn add_provider(provider: ProviderRecord) -> Vec<u8> {
+        let peer = KademliaPeer::new(
+            provider.provider,
+            provider.addresses,
+            ConnectionType::CanConnect, // ignored by message recipient
+        );
+        let message = schema::kademlia::Message {
+            key: provider.key.clone().to_vec(),
+            cluster_level_raw: 10,
+            r#type: schema::kademlia::MessageType::AddProvider.into(),
+            provider_peers: std::iter::once((&peer).into()).collect(),
+            ..Default::default()
+        };
+
+        let mut buf = Vec::with_capacity(message.encoded_len());
+        message.encode(&mut buf).expect("Vec<u8> to provide needed capacity");
+
+        buf
+    }
+
+    /// Create `GET_PROVIDERS` request for `key`.
+    pub fn get_providers_request(key: RecordKey) -> Vec<u8> {
+        let message = schema::kademlia::Message {
+            key: key.to_vec(),
+            cluster_level_raw: 10,
+            r#type: schema::kademlia::MessageType::GetProviders.into(),
+            ..Default::default()
+        };
+
+        let mut buf = Vec::with_capacity(message.encoded_len());
+        message.encode(&mut buf).expect("Vec<u8> to provide needed capacity");
+
+        buf
+    }
+
+    /// Create `GET_PROVIDERS` response.
+    pub fn get_providers_response(
+        key: RecordKey,
+        providers: Vec<ProviderRecord>,
+        closer_peers: &[KademliaPeer],
+    ) -> Vec<u8> {
+        debug_assert!(providers.iter().all(|p| p.key == key));
+
+        let provider_peers = providers
+            .into_iter()
+            .map(|p| {
+                KademliaPeer::new(
+                    p.provider,
+                    p.addresses,
+                    ConnectionType::CanConnect, // ignored by recipient
+                )
+            })
+            .map(|p| (&p).into())
+            .collect();
+
+        let message = schema::kademlia::Message {
+            key: key.to_vec(),
+            cluster_level_raw: 10,
+            r#type: schema::kademlia::MessageType::GetProviders.into(),
+            closer_peers: closer_peers.iter().map(Into::into).collect(),
+            provider_peers,
+            ..Default::default()
+        };
+
+        let mut buf = Vec::with_capacity(message.encoded_len());
+        message.encode(&mut buf).expect("Vec<u8> to provide needed capacity");
+
+        buf
+    }
+
     /// Get [`KademliaMessage`] from bytes.
     pub fn from_bytes(bytes: BytesMut) -> Option<Self> {
         match schema::kademlia::Message::decode(bytes) {
             Ok(message) => match message.r#type {
+                // FIND_NODE
                 4 => {
                     let peers = message
                         .closer_peers
@@ -187,6 +259,7 @@ impl KademliaMessage {
                         peers,
                     })
                 }
+                // PUT_VALUE
                 0 => {
                     let record = message.record?;
 
@@ -194,6 +267,7 @@ impl KademliaMessage {
                         record: record_from_schema(record)?,
                     })
                 }
+                // GET_VALUE
                 1 => {
                     let key = match message.key.is_empty() {
                         true => message.record.as_ref().and_then(|record| {

--- a/src/protocol/libp2p/kademlia/message.rs
+++ b/src/protocol/libp2p/kademlia/message.rs
@@ -294,7 +294,7 @@ impl KademliaMessage {
                 }
                 // ADD_PROVIDER
                 2 => {
-                    let key = message.key.into();
+                    let key = message.key.into(); // TODO: check for empty key.
                     let providers = message
                         .provider_peers
                         .iter()
@@ -305,7 +305,7 @@ impl KademliaMessage {
                 }
                 // GET_PROVIDERS
                 3 => {
-                    let key = message.key.into();
+                    let key = message.key.into(); // TODO: key is optional.
                     let peers = message
                         .closer_peers
                         .iter()
@@ -323,8 +323,8 @@ impl KademliaMessage {
                         providers,
                     })
                 }
-                message => {
-                    tracing::warn!(target: LOG_TARGET, ?message, "unhandled message");
+                message_type => {
+                    tracing::warn!(target: LOG_TARGET, ?message_type, "unhandled message");
                     None
                 }
             },

--- a/src/protocol/libp2p/kademlia/message.rs
+++ b/src/protocol/libp2p/kademlia/message.rs
@@ -60,8 +60,30 @@ pub enum KademliaMessage {
         /// Record.
         record: Option<Record>,
 
-        /// Peers closest to key.
+        /// Peers closer to the key.
         peers: Vec<KademliaPeer>,
+    },
+
+    /// `ADD_PROVIDER` message.
+    AddProvider {
+        /// Key.
+        key: RecordKey,
+
+        /// Peers, providing the data for `key`. Must contain exactly one peer matching the sender
+        /// of the message.
+        providers: Vec<KademliaPeer>,
+    },
+
+    /// `GET_PROVIDERS` message.
+    GetProviders {
+        /// Key.
+        key: RecordKey,
+
+        /// Peers closer to the key.
+        peers: Vec<KademliaPeer>,
+
+        /// Peers, providing the data for `key`.
+        providers: Vec<KademliaPeer>,
     },
 }
 

--- a/src/protocol/libp2p/kademlia/message.rs
+++ b/src/protocol/libp2p/kademlia/message.rs
@@ -292,6 +292,37 @@ impl KademliaMessage {
                             .collect(),
                     })
                 }
+                // ADD_PROVIDER
+                2 => {
+                    let key = message.key.into();
+                    let providers = message
+                        .provider_peers
+                        .iter()
+                        .filter_map(|peer| KademliaPeer::try_from(peer).ok())
+                        .collect();
+
+                    Some(Self::AddProvider { key, providers })
+                }
+                // GET_PROVIDERS
+                3 => {
+                    let key = message.key.into();
+                    let peers = message
+                        .closer_peers
+                        .iter()
+                        .filter_map(|peer| KademliaPeer::try_from(peer).ok())
+                        .collect();
+                    let providers = message
+                        .provider_peers
+                        .iter()
+                        .filter_map(|peer| KademliaPeer::try_from(peer).ok())
+                        .collect();
+
+                    Some(Self::GetProviders {
+                        key,
+                        peers,
+                        providers,
+                    })
+                }
                 message => {
                     tracing::warn!(target: LOG_TARGET, ?message, "unhandled message");
                     None

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -175,8 +175,9 @@ impl MemoryStore {
             Entry::Occupied(mut entry) => {
                 let mut providers = entry.get_mut();
 
-                // Providers under every key are sorted by distance, with equal distances meaning
-                // peer IDs (more strictly, their hashes) are equal.
+                // Providers under every key are sorted by distance from the provided key, with
+                // equal distances meaning peer IDs (more strictly, their hashes)
+                // are equal.
                 let provider_position =
                     providers.binary_search_by(|p| p.distance().cmp(&provider_record.distance()));
 

--- a/src/protocol/libp2p/schema/kademlia.proto
+++ b/src/protocol/libp2p/schema/kademlia.proto
@@ -85,6 +85,6 @@ message Message {
 	repeated Peer closerPeers = 8;
 
 	// Used to return Providers
-	// GET_VALUE, ADD_PROVIDER, GET_PROVIDERS
+	// ADD_PROVIDER, GET_PROVIDERS
 	repeated Peer providerPeers = 9;
 }


### PR DESCRIPTION
This implements the `ADD_PROVIDER` & `GET_PROVIDER` Kademlia RPC without initiating the queries itself. This should already allow participating in the DHT with content providers and serve all network requests, but won't allow initiating queries (like getting the content provider & starting providing) locally.

Implements "server side" of https://github.com/paritytech/litep2p/issues/201.

### Next steps
- Initiate content provider queries in `litep2p`
- Once the client API for queries is exposed, add conformance tests with `libp2p`