### PR TITLE
crypto/noise: Generate keypair only for Curve25519

### DIFF
--- a/src/crypto/noise/protocol.rs
+++ b/src/crypto/noise/protocol.rs
@@ -75,8 +75,12 @@ impl snow::resolvers::CryptoResolver for Resolver {
         Some(Box::new(Rng(rand::rngs::StdRng::from_entropy())))
     }
 
-    fn resolve_dh(&self, _: &snow::params::DHChoice) -> Option<Box<dyn snow::types::Dh>> {
-        Some(Box::new(Keypair::<x25519_spec::X25519Spec>::default()))
+    fn resolve_dh(&self, choice: &snow::params::DHChoice) -> Option<Box<dyn snow::types::Dh>> {
+        if let snow::params::DHChoice::Curve25519 = choice {
+            Some(Box::new(Keypair::<x25519_spec::X25519Spec>::default()))
+        } else {
+            None
+        }
     }
 
     fn resolve_hash(


### PR DESCRIPTION
This PR ensures that a keypair is only generated for `Curve25519`. This behavior is similar how libp2p creates keypairs. 

cc @paritytech/networking 