### PR TITLE
substream: Use write_all instead of manually writing bytes   

### DIFF
--- a/src/substream/mod.rs
+++ b/src/substream/mod.rs
@@ -375,6 +375,7 @@ impl Substream {
         io.flush().await.map_err(From::from)
     }
 
+    /// Send unsigned varint payload to remote peer.
     async fn send_unsigned_varint_payload<T: AsyncWrite + Unpin>(
         io: &mut T,
         bytes: Bytes,

--- a/src/substream/mod.rs
+++ b/src/substream/mod.rs
@@ -407,7 +407,7 @@ impl Substream {
                     check_size!(max_size, bytes.len());
 
                     // Write the length of the frame.
-                    let mut buffer = [0u8; 10];
+                    let mut buffer = unsigned_varint::encode::usize_buffer();
                     let encoded_len =
                         unsigned_varint::encode::usize(bytes.len(), &mut buffer).len();
                     substream.write_all(&buffer[..encoded_len]).await?;
@@ -426,7 +426,7 @@ impl Substream {
                 ProtocolCodec::UnsignedVarint(max_size) => {
                     check_size!(max_size, bytes.len());
 
-                    let mut buffer = [0u8; 10];
+                    let mut buffer = unsigned_varint::encode::usize_buffer();
                     let len = unsigned_varint::encode::usize(bytes.len(), &mut buffer);
                     let mut offset = 0;
 
@@ -450,7 +450,7 @@ impl Substream {
                 ProtocolCodec::UnsignedVarint(max_size) => {
                     check_size!(max_size, bytes.len());
 
-                    let mut buffer = [0u8; 10];
+                    let mut buffer = unsigned_varint::encode::usize_buffer();
                     let len = unsigned_varint::encode::usize(bytes.len(), &mut buffer);
                     let len = BytesMut::from(len);
 
@@ -465,7 +465,7 @@ impl Substream {
                 ProtocolCodec::UnsignedVarint(max_size) => {
                     check_size!(max_size, bytes.len());
 
-                    let mut buffer = [0u8; 10];
+                    let mut buffer = unsigned_varint::encode::usize_buffer();
                     let len = unsigned_varint::encode::usize(bytes.len(), &mut buffer);
                     let mut offset = 0;
 
@@ -718,7 +718,7 @@ impl Sink<Bytes> for Substream {
                 check_size!(max_size, item.len());
 
                 let len = {
-                    let mut buffer = [0u8; 10];
+                    let mut buffer = unsigned_varint::encode::usize_buffer();
                     let len = unsigned_varint::encode::usize(item.len(), &mut buffer);
                     BytesMut::from(len)
                 };

--- a/src/substream/mod.rs
+++ b/src/substream/mod.rs
@@ -369,7 +369,10 @@ impl Substream {
 
         io.write_all(&payload)
             .await
-            .map_err(|_| Error::SubstreamError(SubstreamError::ConnectionClosed))
+            .map_err(|_| Error::SubstreamError(SubstreamError::ConnectionClosed))?;
+
+        // Flush the stream.
+        io.flush().await.map_err(From::from)
     }
 
     async fn send_unsigned_varint_payload<T: AsyncWrite + Unpin>(


### PR DESCRIPTION
This PR refactors the substream writing to replace the `while remaining { write(byte) }` with the `write_all` method.
- introduce a dedicated function that is shared between substream implementation that handles the varint payload
- replace hardcoded buffer [0; 10] with the encoded buffer of `usize` from the unsigned_varint crate
- flush the identity protocol similar to the varint protocol after successfully writing data

This was driven by the fact that the identity protocol (ie plain bytes without length prefix) uses write_all; and the higher level functions never use that partially written information. I expect the performance improvement to be negligible, however this helps with code maintenance and consistency. 

cc @paritytech/networking 