### PR TITLE
kad: Fix substream opening and dialing race

### DIFF
--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -233,6 +233,14 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
         // If we cannot make progress, return the final result.
         // A query failed when we are not able to identify one single peer.
         if self.is_done() {
+            tracing::trace!(
+                target: LOG_TARGET,
+                query = ?self.config.query,
+                pending = self.pending.len(),
+                candidates = self.candidates.len(),
+                "query finished"
+            );
+
             return if self.responses.is_empty() {
                 Some(QueryAction::QueryFailed {
                     query: self.config.query,


### PR DESCRIPTION

This PR makes the substream opening and dialing of query commands more robust.

In the past, the logic of a query action would:
- T0; try to open a substream
- T1; try to dial the peer

There is a race between the moment when a substream is opened and when the peer is dialed (T0 and T1), where the peer could connect to us. The race manifested after extensively running `FindNode` commands via [subp2p-explorer bench-cli](https://github.com/lexnv/subp2p-explorer/tree/main/bench-cli)

To mitigate this race, retry to open the substream on recoverable errors from dialing (ie Error::PeerAlreadyConnected).

cc @paritytech/networking 
