### PR TITLE
transport: Implement `TransportService::local_peer_id()`

### DIFF
--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -167,8 +167,8 @@ pub(crate) struct Kademlia {
 impl Kademlia {
     /// Create new [`Kademlia`].
     pub(crate) fn new(mut service: TransportService, config: Config) -> Self {
-        let local_peer_id = service.local_peer_id;
-        let local_key = Key::from(service.local_peer_id);
+        let local_peer_id = service.local_peer_id();
+        let local_key = Key::from(service.local_peer_id());
         let mut routing_table = RoutingTable::new(local_key.clone());
 
         for (peer, addresses) in config.known_peers {
@@ -357,7 +357,7 @@ impl Kademlia {
     /// the mode was set to manual.
     async fn update_routing_table(&mut self, peers: &[KademliaPeer]) {
         let peers: Vec<_> =
-            peers.iter().filter(|peer| peer.peer != self.service.local_peer_id).collect();
+            peers.iter().filter(|peer| peer.peer != self.service.local_peer_id()).collect();
 
         // inform user about the routing table update, regardless of what the routing table update
         // mode is
@@ -889,7 +889,7 @@ impl Kademlia {
 
                             // Put the record to the specified peers.
                             let peers = peers.into_iter().filter_map(|peer| {
-                                if peer == self.service.local_peer_id {
+                                if peer == self.service.local_peer_id() {
                                     return None;
                                 }
 

--- a/src/protocol/transport_service.rs
+++ b/src/protocol/transport_service.rs
@@ -102,7 +102,7 @@ impl ConnectionContext {
 #[derive(Debug)]
 pub struct TransportService {
     /// Local peer ID.
-    pub(crate) local_peer_id: PeerId,
+    local_peer_id: PeerId,
 
     /// Protocol.
     protocol: ProtocolName,
@@ -361,6 +361,11 @@ impl TransportService {
         }
 
         connection.primary.force_close()
+    }
+
+    /// Get local peer ID.
+    pub fn local_peer_id(&self) -> PeerId {
+        self.local_peer_id
     }
 }
 


### PR DESCRIPTION
Previously `local_peer_id` was declared `pub(crate)` which made it inaccessible to protocols implemented with `UserProtocol`

Implement getter for local peer ID, allowing all protocols having access to `TransportService` to query the local peer ID