### PR TITLE
substream-set: Poll substreams fairly with poll indexes

### DIFF
--- a/src/substream/mod.rs
+++ b/src/substream/mod.rs
@@ -841,21 +841,26 @@ where
 
         let len = inner.keys.len();
         for _ in 0..len {
-            let key = &inner.keys[inner.poll_index];
             inner.poll_index = (inner.poll_index + 1) % len;
+            let key = &inner.keys[inner.poll_index];
 
             let Some(mut substream) = inner.substreams.get_mut(key) else {
                 continue;
             };
 
             match Pin::new(&mut substream).poll_next(cx) {
-                Poll::Pending => continue,
-                Poll::Ready(Some(data)) => return Poll::Ready(Some((*key, data))),
-                Poll::Ready(None) =>
+                Poll::Pending => {
+                    continue;
+                }
+                Poll::Ready(Some(data)) => {
+                    return Poll::Ready(Some((*key, data)));
+                }
+                Poll::Ready(None) => {
                     return Poll::Ready(Some((
                         *key,
                         Err(Error::SubstreamError(SubstreamError::ConnectionClosed)),
-                    ))),
+                    )));
+                }
             }
         }
 


### PR DESCRIPTION
This PR refactors the substream-set (used by request-response protocols):
- the context waker is saved to before returning poll::pending
- a poll index and vec<keys> is introduced to provide more fairness during the polling of substreams
