### PR TITLE
kad: Providers part 3: publish provider records (start providing)

### DIFF
--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -130,6 +130,18 @@ pub(crate) enum KademliaCommand {
         query_id: QueryId,
     },
 
+    /// Register as a content provider for `key`.
+    StartProviding {
+        /// Provided key.
+        key: RecordKey,
+
+        /// Our external addresses to publish.
+        public_addresses: Vec<Multiaddr>,
+
+        /// Query ID for the query.
+        query_id: QueryId,
+    },
+
     /// Store record locally.
     StoreRecord {
         // Record.
@@ -175,7 +187,8 @@ pub enum KademliaEvent {
     },
 
     /// `PUT_VALUE` query succeeded.
-    PutRecordSucess {
+    // TODO: this is never emitted. Implement + add `AddProviderSuccess`.
+    PutRecordSuccess {
         /// Query ID.
         query_id: QueryId,
 
@@ -292,6 +305,27 @@ impl KademliaHandle {
             .send(KademliaCommand::GetRecord {
                 key,
                 quorum,
+                query_id,
+            })
+            .await;
+
+        query_id
+    }
+
+    /// Register as a content provider on the DHT.
+    ///
+    /// Register the local peer ID & its `public_addresses` as a provider for a given `key`.
+    pub async fn start_providing(
+        &mut self,
+        key: RecordKey,
+        public_addresses: Vec<Multiaddr>,
+    ) -> QueryId {
+        let query_id = self.next_query_id();
+        let _ = self
+            .cmd_tx
+            .send(KademliaCommand::StartProviding {
+                key,
+                public_addresses,
                 query_id,
             })
             .await;

--- a/src/protocol/libp2p/kademlia/message.rs
+++ b/src/protocol/libp2p/kademlia/message.rs
@@ -172,8 +172,7 @@ impl KademliaMessage {
     }
 
     /// Create `ADD_PROVIDER` message with `provider`.
-    #[allow(unused)]
-    pub fn add_provider(provider: ProviderRecord) -> Vec<u8> {
+    pub fn add_provider(provider: ProviderRecord) -> Bytes {
         let peer = KademliaPeer::new(
             provider.provider,
             provider.addresses,
@@ -187,10 +186,10 @@ impl KademliaMessage {
             ..Default::default()
         };
 
-        let mut buf = Vec::with_capacity(message.encoded_len());
+        let mut buf = BytesMut::with_capacity(message.encoded_len());
         message.encode(&mut buf).expect("Vec<u8> to provide needed capacity");
 
-        buf
+        buf.freeze()
     }
 
     /// Create `GET_PROVIDERS` request for `key`.

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -1031,7 +1031,7 @@ impl Kademlia {
 
                             let provider = ProviderRecord {
                                 key: key.clone(),
-                                provider: self.service.local_peer_id,
+                                provider: self.service.local_peer_id(),
                                 addresses: public_addresses,
                                 expires: Instant::now() + self.provider_ttl,
                             };

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -25,7 +25,7 @@ use crate::{
             find_node::{FindNodeConfig, FindNodeContext},
             get_record::{GetRecordConfig, GetRecordContext},
         },
-        record::{Key as RecordKey, Record},
+        record::{Key as RecordKey, ProviderRecord, Record},
         types::{KademliaPeer, Key},
         PeerRecord, Quorum,
     },
@@ -45,8 +45,6 @@ mod get_record;
 /// Logging target for the file.
 const LOG_TARGET: &str = "litep2p::ipfs::kademlia::query";
 
-// TODO: store record key instead of the actual record
-
 /// Type representing a query ID.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct QueryId(pub usize);
@@ -56,7 +54,7 @@ pub struct QueryId(pub usize);
 enum QueryType {
     /// `FIND_NODE` query.
     FindNode {
-        /// Context for the `FIND_NODE` query
+        /// Context for the `FIND_NODE` query.
         context: FindNodeContext<PeerId>,
     },
 
@@ -65,7 +63,7 @@ enum QueryType {
         /// Record that needs to be stored.
         record: Record,
 
-        /// Context for the `FIND_NODE` query
+        /// Context for the `FIND_NODE` query.
         context: FindNodeContext<RecordKey>,
     },
 
@@ -82,6 +80,15 @@ enum QueryType {
     GetRecord {
         /// Context for the `GET_VALUE` query.
         context: GetRecordContext,
+    },
+
+    /// `ADD_PROVIDER` query.
+    AddProvider {
+        /// Provider record that need to be stored.
+        provider: ProviderRecord,
+
+        /// Context for the `FIND_NODE` query.
+        context: FindNodeConfig<RecordKey>,
     },
 }
 
@@ -131,7 +138,6 @@ pub enum QueryAction {
         records: Vec<PeerRecord>,
     },
 
-    // TODO: remove
     /// Query succeeded.
     QuerySucceeded {
         /// ID of the query that succeeded.


### PR DESCRIPTION
Implement `ADD_PROVIDER` network request and execute `FIND_NODE` query to publish local provider to the target peers.

Builds upon https://github.com/paritytech/litep2p/pull/200 & https://github.com/paritytech/litep2p/pull/213.

Next PR in the series: https://github.com/paritytech/litep2p/pull/235.

### Follow-up
 - Make sure unit and integration tests do not reveal issues and merge together with other PRs in the series.