### PR TITLE
req-resp: Refactor to move functionality to dedicated methods

### DIFF
--- a/src/protocol/request_response/handle.rs
+++ b/src/protocol/request_response/handle.rs
@@ -115,6 +115,7 @@ impl From<SubstreamError> for RejectReason {
 }
 
 /// Request-response events.
+#[derive(Debug)]
 pub(super) enum InnerRequestResponseEvent {
     /// Request received from remote
     RequestReceived {

--- a/src/protocol/request_response/mod.rs
+++ b/src/protocol/request_response/mod.rs
@@ -871,7 +871,7 @@ impl RequestResponseProtocol {
     }
 
     /// Cancel outbound request.
-    async fn on_cancel_request(&mut self, request_id: RequestId) -> crate::Result<()> {
+    fn on_cancel_request(&mut self, request_id: RequestId) -> crate::Result<()> {
         tracing::trace!(target: LOG_TARGET, protocol = %self.protocol, ?request_id, "cancel outbound request");
 
         match self.pending_outbound_cancels.remove(&request_id) {
@@ -962,7 +962,7 @@ impl RequestResponseProtocol {
                 }
             }
             RequestResponseCommand::CancelRequest { request_id } => {
-                if let Err(error) = self.on_cancel_request(request_id).await {
+                if let Err(error) = self.on_cancel_request(request_id) {
                     tracing::debug!(
                         target: LOG_TARGET,
                         protocol = %self.protocol,

--- a/src/protocol/request_response/mod.rs
+++ b/src/protocol/request_response/mod.rs
@@ -955,17 +955,6 @@ impl RequestResponseProtocol {
                     }
                 }
             }
-            RequestResponseCommand::CancelRequest { request_id } => {
-                if let Err(error) = self.on_cancel_request(request_id) {
-                    tracing::debug!(
-                        target: LOG_TARGET,
-                        protocol = %self.protocol,
-                        ?request_id,
-                        ?error,
-                        "failed to cancel reqeuest",
-                    );
-                }
-            }
             RequestResponseCommand::SendRequestWithFallback {
                 peer,
                 request_id,
@@ -995,6 +984,17 @@ impl RequestResponseProtocol {
                             "failed to report request failure",
                         );
                     }
+                }
+            }
+            RequestResponseCommand::CancelRequest { request_id } => {
+                if let Err(error) = self.on_cancel_request(request_id) {
+                    tracing::debug!(
+                        target: LOG_TARGET,
+                        protocol = %self.protocol,
+                        ?request_id,
+                        ?error,
+                        "failed to cancel reqeuest",
+                    );
                 }
             }
         }

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -155,7 +155,7 @@ async fn cancel_unknown_request() {
 
     let request_id = RequestId::from(1337usize);
     assert!(!protocol.pending_outbound_cancels.contains_key(&request_id));
-    assert!(protocol.on_cancel_request(request_id).await.is_ok());
+    assert!(protocol.on_cancel_request(request_id).is_ok());
 }
 
 #[tokio::test]

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -278,15 +278,17 @@ async fn request_failure_reported_once() {
     // initiate outbound request
     //
     // since the peer wasn't properly registered, opening substream to them will fail
-    protocol
+    let request_id = RequestId::from(1337usize);
+    let error = protocol
         .on_send_request(
             peer,
-            RequestId::from(1337usize),
+            request_id,
             vec![1, 2, 3, 4],
             DialOptions::Reject,
             None,
         )
-        .unwrap();
+        .unwrap_err();
+    protocol.report_request_failure(peer, request_id, error).await.unwrap();
 
     match handle.next().await {
         Some(RequestResponseEvent::RequestFailed {

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -286,7 +286,6 @@ async fn request_failure_reported_once() {
             DialOptions::Reject,
             None,
         )
-        .await
         .unwrap();
 
     match handle.next().await {


### PR DESCRIPTION
This PR refactors the `RequstResponse::run()` method to move away from writing code in `loop { tokio::select! }`.
Instead, the functionality is moved to dedicated functions.

While at it, have remove the `async` from functions that were plain sync and added comments to make the polling a bit clearer.

cc @paritytech/networking 