### PR TITLE
[ci] Change CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: parity-default
     timeout-minutes: 15
     needs: [set-image]
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: arc-runners-litep2p
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [set-image]
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# ${{ vars.CI_UNIFIED_IMAGE }} is defined in the repository variables
+# common variable is defined in the workflow
+# repo env variable doesn't work for PR from forks
 env:
   CI_IMAGE: "paritytech/ci-unified:bullseye-1.75.0-2024-01-22-v20240222"
 


### PR DESCRIPTION
PR changes runner for the `test` job in the process of runners unification. More details can be found here https://github.com/paritytech/ci_cd/issues/1039