### PR TITLE
kad: Remove unused serde cfg

### DIFF
--- a/src/protocol/libp2p/kademlia/record.rs
+++ b/src/protocol/libp2p/kademlia/record.rs
@@ -32,7 +32,6 @@ use multihash::Multihash;
 use std::{borrow::Borrow, time::Instant};
 
 /// The (opaque) key of a record.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Key(Bytes);
 


### PR DESCRIPTION
Remove unused serde feature flag.
Litep2p does not expose the `serde` feature flag.
This is most likely copied from libp2p when porting kademlia. 