### PR TITLE
transports: Fix missing Poll::Ready(None) event from listenener

### DIFF
--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -576,9 +576,9 @@ impl Stream for TcpTransport {
         let mut should_wake_up = false;
 
         while let Poll::Ready(Some(result)) = self.pending_raw_connections.poll_next_unpin(cx) {
-            should_wake_up |= true;
-
             tracing::trace!(target: LOG_TARGET, ?result, "raw connection result");
+
+            should_wake_up |= true;
 
             match result {
                 RawConnectionResult::Connected {

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -584,15 +584,8 @@ impl Stream for TcpTransport {
             };
         }
 
-        // Whenever we are receiving events by `Poll::Ready` and we choose to not propagate
-        // them to the higher levels, we should wake up the context to poll us again.
-        // Otherwise, the scheduler will not know that we are ready to be polled again.
-        let mut should_wake_up = false;
-
         while let Poll::Ready(Some(result)) = self.pending_raw_connections.poll_next_unpin(cx) {
             tracing::trace!(target: LOG_TARGET, ?result, "raw connection result");
-
-            should_wake_up |= true;
 
             match result {
                 RawConnectionResult::Connected {
@@ -654,8 +647,6 @@ impl Stream for TcpTransport {
         }
 
         while let Poll::Ready(Some(connection)) = self.pending_connections.poll_next_unpin(cx) {
-            should_wake_up |= true;
-
             match connection {
                 Ok(connection) => {
                     let peer = connection.peer();
@@ -680,11 +671,6 @@ impl Stream for TcpTransport {
                     }
                 }
             }
-        }
-
-        // We have filtered out all `Poll::Ready` events.
-        if should_wake_up {
-            cx.waker().wake_by_ref();
         }
 
         Poll::Pending

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -378,10 +378,15 @@ impl Transport for TcpTransport {
     }
 
     fn accept_pending(&mut self, connection_id: ConnectionId) -> crate::Result<()> {
-        let pending = self
-            .pending_inbound_connections
-            .remove(&connection_id)
-            .ok_or(Error::ConnectionDoesntExist(connection_id))?;
+        let pending = self.pending_inbound_connections.remove(&connection_id).ok_or_else(|| {
+            tracing::error!(
+                target: LOG_TARGET,
+                ?connection_id,
+                "Cannot accept non existent pending connection",
+            );
+
+            Error::ConnectionDoesntExist(connection_id)
+        })?;
 
         self.on_inbound_connection(connection_id, pending.connection, pending.address);
 
@@ -389,9 +394,18 @@ impl Transport for TcpTransport {
     }
 
     fn reject_pending(&mut self, connection_id: ConnectionId) -> crate::Result<()> {
-        self.pending_inbound_connections
-            .remove(&connection_id)
-            .map_or(Err(Error::ConnectionDoesntExist(connection_id)), |_| Ok(()))
+        self.pending_inbound_connections.remove(&connection_id).map_or_else(
+            || {
+                tracing::error!(
+                    target: LOG_TARGET,
+                    ?connection_id,
+                    "Cannot reject non existent pending connection",
+                );
+
+                Err(Error::ConnectionDoesntExist(connection_id))
+            },
+            |_| Ok(()),
+        )
     }
 
     fn reject(&mut self, connection_id: ConnectionId) -> crate::Result<()> {

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -616,8 +616,15 @@ impl Stream for WebSocketTransport {
             };
         }
 
+        // Whenever we are receiving events by `Poll::Ready` and we choose to not propagate
+        // them to the higher levels, we should wake up the context to poll us again.
+        // Otherwise, the scheduler will not know that we are ready to be polled again.
+        let mut should_wake_up = false;
+
         while let Poll::Ready(Some(result)) = self.pending_raw_connections.poll_next_unpin(cx) {
             tracing::trace!(target: LOG_TARGET, ?result, "raw connection result");
+
+            should_wake_up |= true;
 
             match result {
                 RawConnectionResult::Connected {
@@ -679,6 +686,8 @@ impl Stream for WebSocketTransport {
         }
 
         while let Poll::Ready(Some(connection)) = self.pending_connections.poll_next_unpin(cx) {
+            should_wake_up |= true;
+
             match connection {
                 Ok(connection) => {
                     let peer = connection.peer();
@@ -703,6 +712,11 @@ impl Stream for WebSocketTransport {
                     }
                 }
             }
+        }
+
+        // We have filtered out all `Poll::Ready` events.
+        if should_wake_up {
+            cx.waker().wake_by_ref();
         }
 
         Poll::Pending

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -630,15 +630,8 @@ impl Stream for WebSocketTransport {
             };
         }
 
-        // Whenever we are receiving events by `Poll::Ready` and we choose to not propagate
-        // them to the higher levels, we should wake up the context to poll us again.
-        // Otherwise, the scheduler will not know that we are ready to be polled again.
-        let mut should_wake_up = false;
-
         while let Poll::Ready(Some(result)) = self.pending_raw_connections.poll_next_unpin(cx) {
             tracing::trace!(target: LOG_TARGET, ?result, "raw connection result");
-
-            should_wake_up |= true;
 
             match result {
                 RawConnectionResult::Connected {
@@ -700,8 +693,6 @@ impl Stream for WebSocketTransport {
         }
 
         while let Poll::Ready(Some(connection)) = self.pending_connections.poll_next_unpin(cx) {
-            should_wake_up |= true;
-
             match connection {
                 Ok(connection) => {
                     let peer = connection.peer();
@@ -726,11 +717,6 @@ impl Stream for WebSocketTransport {
                     }
                 }
             }
-        }
-
-        // We have filtered out all `Poll::Ready` events.
-        if should_wake_up {
-            cx.waker().wake_by_ref();
         }
 
         Poll::Pending


### PR DESCRIPTION
This PR handles the following:
- Align Webscoket listener with TCP listener to not miss out on `Poll::Ready(None)` events and enhance logging

- Add warnings whenever pending connection IDs do not exist

- ~~Filtering out `Poll::Ready` events into `Poll::Pending` without calling the context waker will result in the scheduler not polling in the future. This was happening, for example, for both TCP and Websocket when receiving a connection established event that was previously canceled~~


cc @paritytech/networking

Discovered during: https://github.com/paritytech/litep2p/issues/282

