### PR TITLE
manager: Fix connection limits tracking of rejected connections 

### DIFF
--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -772,10 +772,7 @@ impl TransportManager {
         };
 
         // Reject the connection if exceeded limits.
-        if let Err(error) = self
-            .connection_limits
-            .on_connection_established(endpoint.connection_id(), endpoint.is_listener())
-        {
+        if let Err(error) = self.connection_limits.can_accept_connection(endpoint.is_listener()) {
             tracing::debug!(
                 target: LOG_TARGET,
                 ?peer,
@@ -804,6 +801,9 @@ impl TransportManager {
         );
 
         if connection_accepted {
+            self.connection_limits
+                .accept_established_connection(endpoint.connection_id(), endpoint.is_listener());
+
             // Cancel all pending dials if the connection was established.
             if let PeerState::Opening {
                 connection_id,


### PR DESCRIPTION
This PR ensures that connection IDs are properly tracked to enforce connection limits.

After ~1/2 days the substrate litep2p running node is starting to reject multiple pending socket connections.

This is related to the fact that accepting of established connection is a two-part process:
- step 1. Can we accept the connection based on number of connections?
- step 2. The transport manager transitions the peer state
- step 3. If the transition succeeds, the connection is tracked (inserted in a hashmap).

If step 2 fails, we were previously leaking the connection ID. The connection ID is also counting towards the maximum number of connections the node can sustain.

This PR effectively modifies the connection limits API, `on_connection_established` is split into two methods:
  - `can_accept_connection()`
  - `accept_established_connection()`

This fixes a subtle memory leak bounded at 10000 Connection IDs.
However, even more important, this fixes connection stability for long-running nodes.

Discovered during the investigation of:
- https://github.com/paritytech/litep2p/issues/282

cc @paritytech/networking 

