### PR TITLE
transport: Fix waking up on filtered events from `poll_next` 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub mod types;
 pub mod yamux;
 
 mod bandwidth;
+mod utils;
 mod multistream_select;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,8 @@ pub mod types;
 pub mod yamux;
 
 mod bandwidth;
-mod utils;
 mod multistream_select;
+mod utils;
 
 #[cfg(test)]
 mod mock;

--- a/src/protocol/libp2p/kademlia/executor.rs
+++ b/src/protocol/libp2p/kademlia/executor.rs
@@ -19,9 +19,8 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{
-    protocol::libp2p::kademlia::{futures_stream::FuturesStream, query::QueryId},
-    substream::Substream,
-    PeerId,
+    protocol::libp2p::kademlia::query::QueryId, substream::Substream,
+    utils::futures_stream::FuturesStream, PeerId,
 };
 
 use bytes::{Bytes, BytesMut};

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -71,7 +71,6 @@ const PARALLELISM_FACTOR: usize = 3;
 mod bucket;
 mod config;
 mod executor;
-mod futures_stream;
 mod handle;
 mod message;
 mod query;

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -23,10 +23,10 @@
 use crate::{
     protocol::libp2p::kademlia::{
         config::{DEFAULT_PROVIDER_REFRESH_INTERVAL, DEFAULT_PROVIDER_TTL},
-        futures_stream::FuturesStream,
         record::{ContentProvider, Key, ProviderRecord, Record},
         types::Key as KademliaKey,
     },
+    utils::futures_stream::FuturesStream,
     PeerId,
 };
 

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -34,6 +34,7 @@ use crate::{
         Transport, TransportBuilder, TransportEvent,
     },
     types::ConnectionId,
+    utils::futures_stream::FuturesStream,
 };
 
 use futures::{
@@ -111,12 +112,11 @@ pub(crate) struct TcpTransport {
     pending_inbound_connections: HashMap<ConnectionId, PendingInboundConnection>,
 
     /// Pending opening connections.
-    pending_connections: FuturesUnordered<
-        BoxFuture<'static, Result<NegotiatedConnection, (ConnectionId, DialError)>>,
-    >,
+    pending_connections:
+        FuturesStream<BoxFuture<'static, Result<NegotiatedConnection, (ConnectionId, DialError)>>>,
 
     /// Pending raw, unnegotiated connections.
-    pending_raw_connections: FuturesUnordered<BoxFuture<'static, RawConnectionResult>>,
+    pending_raw_connections: FuturesStream<BoxFuture<'static, RawConnectionResult>>,
 
     /// Opened raw connection, waiting for approval/rejection from `TransportManager`.
     opened_raw: HashMap<ConnectionId, (TcpStream, Multiaddr)>,
@@ -295,8 +295,8 @@ impl TransportBuilder for TcpTransport {
                 pending_open: HashMap::new(),
                 pending_dials: HashMap::new(),
                 pending_inbound_connections: HashMap::new(),
-                pending_connections: FuturesUnordered::new(),
-                pending_raw_connections: FuturesUnordered::new(),
+                pending_connections: FuturesStream::new(),
+                pending_raw_connections: FuturesStream::new(),
                 cancel_futures: HashMap::new(),
             },
             listen_addresses,
@@ -584,13 +584,8 @@ impl Stream for TcpTransport {
             };
         }
 
-        // When we filter `Poll::Ready(event)` events are return `Poll::Pending`, we need to also
-        // wake the current context. Otherwise, the scheduler will not call again `poll_next`.
-        let mut should_wake_up = false;
-
         while let Poll::Ready(Some(result)) = self.pending_raw_connections.poll_next_unpin(cx) {
             tracing::trace!(target: LOG_TARGET, ?result, "raw connection result");
-            should_wake_up |= true;
 
             match result {
                 RawConnectionResult::Connected {
@@ -652,8 +647,6 @@ impl Stream for TcpTransport {
         }
 
         while let Poll::Ready(Some(connection)) = self.pending_connections.poll_next_unpin(cx) {
-            should_wake_up |= true;
-
             match connection {
                 Ok(connection) => {
                     let peer = connection.peer();
@@ -678,11 +671,6 @@ impl Stream for TcpTransport {
                     }
                 }
             }
-        }
-
-        // We have filtered out `Poll::Ready` events.
-        if should_wake_up {
-            cx.waker().wake_by_ref();
         }
 
         Poll::Pending

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -584,8 +584,13 @@ impl Stream for TcpTransport {
             };
         }
 
+        // When we filter `Poll::Ready(event)` events are return `Poll::Pending`, we need to also
+        // wake the current context. Otherwise, the scheduler will not call again `poll_next`.
+        let mut should_wake_up = false;
+
         while let Poll::Ready(Some(result)) = self.pending_raw_connections.poll_next_unpin(cx) {
             tracing::trace!(target: LOG_TARGET, ?result, "raw connection result");
+            should_wake_up |= true;
 
             match result {
                 RawConnectionResult::Connected {
@@ -647,6 +652,8 @@ impl Stream for TcpTransport {
         }
 
         while let Poll::Ready(Some(connection)) = self.pending_connections.poll_next_unpin(cx) {
+            should_wake_up |= true;
+
             match connection {
                 Ok(connection) => {
                     let peer = connection.peer();
@@ -671,6 +678,11 @@ impl Stream for TcpTransport {
                     }
                 }
             }
+        }
+
+        // We have filtered out `Poll::Ready` events.
+        if should_wake_up {
+            cx.waker().wake_by_ref();
         }
 
         Poll::Pending

--- a/src/utils/futures_stream.rs
+++ b/src/utils/futures_stream.rs
@@ -44,7 +44,7 @@ impl<F> FuturesStream<F> {
         }
     }
 
-    /// Number of futeres in the stream.
+    /// Number of futures in the stream.
     #[cfg(test)]
     pub fn len(&self) -> usize {
         self.futures.len()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,21 @@
+// Copyright 2024 litep2p developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+pub mod futures_stream;


### PR DESCRIPTION
This PR ensures that the transport (TCP / WebSocket) implementation wakes up the waker `FuturesUnordered` on adding futures to the set.

This is one of the async rough edges in Rust, to properly illustrate the issue I've compiled this rust example (comment and uncomment like 43 to see the issue in action):

### Example 1
The future is not polled again: 
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=1e801c4864599c54a98bb9f30be1fdd5

### Example 2
The future is delayed (from 2s to 3s) because it relies on some other implementation to wake up the context waker:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=951080892763ca7d02ae9c5617da6c5d

### Particular implementation

The `poll_next` implementation polls 3 objects:
- `listener`: accepts incoming socket connections
- `pending_raw_connections`: dialing futures to establish socket connection
- `pending_connections`: negotiating futures to establish libp2p protocols

When adding futures to either `pending_raw_connections` or `pending_connections`, the futures are not polled immediately. Instead, they will get polled the first time an already present future finishes execution.

This effectively leads to delays in processing both raw connections and pending connections.
This PR in combination with https://github.com/paritytech/litep2p/pull/286 has improved the connection stability of litep2p for a high number of connections (500 in and 500 out). The decreasing line represents release 0.8 configured with 500 in and out peers, while the stable line from 11/12 represents litep2p with incoming PR patches. (I've restarted the node 3/4 times for more debug logs):

![Screenshot 2024-11-12 at 14 49 43](https://github.com/user-attachments/assets/01d7f864-e219-4bed-b798-bd84b4356522)



### Next Steps

- There are a few other places were this may be happening, I'll have a look at them after we sort out connection limits. 
- @dmitry-markin suggested an even more optimized way of handling this by polling each future individually to feed them a context waker before adding to the inner FuturesUnordered 🙏  

