### PR TITLE
req-resp: Fix panic on connection closed for substream open failure

### DIFF
--- a/src/protocol/request_response/mod.rs
+++ b/src/protocol/request_response/mod.rs
@@ -296,7 +296,7 @@ impl RequestResponseProtocol {
             tracing::error!(
                 target: LOG_TARGET,
                 ?peer,
-                "state mismatch: peer doesn't exist",
+                "Peer does not exist or substream open failed during connection establishment",
             );
             return;
         };

--- a/src/protocol/request_response/mod.rs
+++ b/src/protocol/request_response/mod.rs
@@ -298,7 +298,6 @@ impl RequestResponseProtocol {
                 ?peer,
                 "state mismatch: peer doesn't exist",
             );
-            debug_assert!(false);
             return;
         };
 

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -92,7 +92,6 @@ async fn connection_closed_twice() {
 
 #[tokio::test]
 #[cfg(debug_assertions)]
-#[should_panic]
 async fn connection_established_twice() {
     let (mut protocol, _handle, _manager, _tx) = protocol();
 


### PR DESCRIPTION
When a new connection is reported to the request-response protocol, the protocol tracks the state of the connection if and only if it could open a substream with the remote peer.

We do not track the state of the connection in cases where the substream cannot be opened because the connection is closed.

A further `ConnectionClosed` event triggered a debug_assert assumption for this case. The assumption is wrong since opening substreams can fail which informs us that the connection is closed.


Connection details not tracked:
https://github.com/paritytech/litep2p/blob/eed0f755d591eb49e1b715a78aceb5a653ddf529/src/protocol/request_response/mod.rs#L267-L284

Which later leads to panics:
https://github.com/paritytech/litep2p/blob/d6fae559fbe2aaf8cb3fff021fb5608ca7b43766/src/protocol/request_response/mod.rs#L295-L301



Related to: https://github.com/paritytech/litep2p/issues/290
