### PR TITLE
transport_service/logs: Provide less details for trace logs

### DIFF
--- a/src/protocol/transport_service.rs
+++ b/src/protocol/transport_service.rs
@@ -180,7 +180,7 @@ impl KeepAliveTracker {
             ?peer,
             ?connection_id,
             ?self.keep_alive_timeout,
-            last_activity = ?self.last_activity,
+            last_activity = ?self.last_activity.len(),
             pending_keep_alive_timeouts = ?self.pending_keep_alive_timeouts.len(),
             "substream activity",
         );


### PR DESCRIPTION
Tiny PR to provide fewer details for trace logs of the transport service components.

During testing of Kusama litep2p on local nodes, I noticed that the information provided by the `last_activity` is excessive. This is a dump of all connected peers with a timestamp, and for 1k inbound and 1k outbound peers provides too much information.

cc @paritytech/networking 