### PR TITLE
notification: Fix memory leak of pending substreams

### DIFF
--- a/src/protocol/notification/mod.rs
+++ b/src/protocol/notification/mod.rs
@@ -435,6 +435,10 @@ impl NotificationProtocol {
                             },
                         );
                     }
+                    // User initiated an outbound substream but the connection was closed before the
+                    // substream was fully open.
+                    // To have consistent state tracking in the user protocol, substream rejection
+                    // must be reported to the user.
                     (OutboundState::OutboundInitiated { substream }, _) => {
                         tracing::debug!(
                             target: LOG_TARGET,
@@ -452,12 +456,11 @@ impl NotificationProtocol {
                             )
                             .await;
                     }
-                    // user either initiated an outbound substream or an outbound substream was
-                    // opened/being opened as a result of an accepted inbound substream but was not
-                    // yet fully open
+                    // An outbound substream was opened/being opened as a result of an accepted
+                    // inbound substream but was not yet fully open.
                     //
-                    // to have consistent state tracking in the user protocol, substream rejection
-                    // must be reported to the user
+                    // To have consistent state tracking in the user protocol, substream rejection
+                    // must be reported to the user.
                     (OutboundState::Negotiating | OutboundState::Open { .. }, _) => {
                         tracing::debug!(
                             target: LOG_TARGET,

--- a/src/protocol/notification/mod.rs
+++ b/src/protocol/notification/mod.rs
@@ -258,7 +258,7 @@ pub(crate) struct NotificationProtocol {
     /// Connected peers.
     peers: HashMap<PeerId, PeerContext>,
 
-    /// Pending outboudn substreams.
+    /// Pending outbound substreams.
     pending_outbound: HashMap<SubstreamId, PeerId>,
 
     /// Handshaking service which reads and writes the handshakes to inbound
@@ -384,6 +384,8 @@ impl NotificationProtocol {
     async fn on_connection_closed(&mut self, peer: PeerId) -> crate::Result<()> {
         tracing::trace!(target: LOG_TARGET, ?peer, protocol = %self.protocol, "connection closed");
 
+        self.pending_outbound.retain(|_, p| p != &peer);
+
         let Some(context) = self.peers.remove(&peer) else {
             tracing::error!(
                 target: LOG_TARGET,
@@ -435,33 +437,18 @@ impl NotificationProtocol {
                             },
                         );
                     }
-                    // User initiated an outbound substream but the connection was closed before the
-                    // substream was fully open.
-                    // To have consistent state tracking in the user protocol, substream rejection
-                    // must be reported to the user.
-                    (OutboundState::OutboundInitiated { substream }, _) => {
-                        tracing::debug!(
-                            target: LOG_TARGET,
-                            ?peer,
-                            protocol = %self.protocol,
-                            "connection closed outbound substream initiated ",
-                        );
-                        // We need to remove this state to avoid a memory leak.
-                        self.pending_outbound.remove(&substream);
-
-                        self.event_handle
-                            .report_notification_stream_open_failure(
-                                peer,
-                                NotificationError::Rejected,
-                            )
-                            .await;
-                    }
-                    // An outbound substream was opened/being opened as a result of an accepted
-                    // inbound substream but was not yet fully open.
+                    // user either initiated an outbound substream or an outbound substream was
+                    // opened/being opened as a result of an accepted inbound substream but was not
+                    // yet fully open
                     //
-                    // To have consistent state tracking in the user protocol, substream rejection
-                    // must be reported to the user.
-                    (OutboundState::Negotiating | OutboundState::Open { .. }, _) => {
+                    // to have consistent state tracking in the user protocol, substream rejection
+                    // must be reported to the user
+                    (
+                        OutboundState::OutboundInitiated { .. }
+                        | OutboundState::Negotiating
+                        | OutboundState::Open { .. },
+                        _,
+                    ) => {
                         tracing::debug!(
                             target: LOG_TARGET,
                             ?peer,


### PR DESCRIPTION
This PR fixes a subtle memory leak that can happen in the following edge-case situation:
- connection is established and substream outbound is initiated with remote peer
- the substream ID is tracked until the substream either completes successfully or fails
- the connection is closed soon after, leading to no substream events ever being generated

For this edge-cases, we need to remove the tracking of the substream ID when the connection is reported as closed.

This has been detected after running a node for more than 2 days with the following generic metrics PR:
- https://github.com/paritytech/litep2p/pull/294

Closes: https://github.com/paritytech/litep2p/issues/295

cc @paritytech/networking 
