### PR TITLE
req-resp: Fix memory leak of pending substreams

### DIFF
--- a/src/protocol/request_response/mod.rs
+++ b/src/protocol/request_response/mod.rs
@@ -292,6 +292,9 @@ impl RequestResponseProtocol {
     async fn on_connection_closed(&mut self, peer: PeerId) {
         tracing::debug!(target: LOG_TARGET, ?peer, protocol = %self.protocol, "connection closed");
 
+        // Remove any pending outbound substreams for this peer.
+        self.pending_outbound.retain(|_, context| context.peer != peer);
+
         let Some(context) = self.peers.remove(&peer) else {
             tracing::error!(
                 target: LOG_TARGET,


### PR DESCRIPTION
Similar to https://github.com/paritytech/litep2p/pull/296, there is a possibility of leaking memory in the following edge-case:
- T0: Connection is established and outbound substream is initiated with peer
  - This maps the substream ID to the request bytes information
- T1: Connection is closed before the service has a chance to report `TransportEvent::SubstreamOpened` or `TransportEvent::SubstreamOpenFailure`

In this case, if we connect and immediately disconnect with a request in flight, we are effectively leaking the request bytes.


Detected by:
- https://github.com/paritytech/litep2p/pull/294


### Dashboard

- We are leaking ~111 requests over 3 days timespan:

<img width="1484" alt="Screenshot 2024-12-03 at 10 41 01" src="https://github.com/user-attachments/assets/f6701017-4add-4aa1-aee1-e1f8d33d54f3">


cc @paritytech/networking 

