### PR TITLE
chore: Release version 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2024-12-03
+
+This release includes two fixes for small memory leaks happening on edge-cases in the notification and request-response protocols.
+
+### Fixed
+
+- req-resp: Fix memory leak of pending substreams  ([#297](https://github.com/paritytech/litep2p/pull/297))
+-  notification: Fix memory leak of pending substreams ([#296](https://github.com/paritytech/litep2p/pull/296))
+
 ## [0.8.2] - 2024-11-27
 
 This release ensures that the provided peer identity is verified at the crypto/noise protocol level, enhancing security and preventing potential misuses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This release includes two fixes for small memory leaks happening on edge-cases i
 ### Fixed
 
 - req-resp: Fix memory leak of pending substreams  ([#297](https://github.com/paritytech/litep2p/pull/297))
--  notification: Fix memory leak of pending substreams ([#296](https://github.com/paritytech/litep2p/pull/296))
+- notification: Fix memory leak of pending substreams ([#296](https://github.com/paritytech/litep2p/pull/296))
 
 ## [0.8.2] - 2024-11-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,7 +2866,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litep2p"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 
 [build-dependencies]


### PR DESCRIPTION

## [0.8.3] - 2024-12-03

This release includes two fixes for small memory leaks on edge-cases in the notification and request-response protocols.

### Fixed

- req-resp: Fix memory leak of pending substreams  ([#297](https://github.com/paritytech/litep2p/pull/297))
- notification: Fix memory leak of pending substreams ([#296](https://github.com/paritytech/litep2p/pull/296))

cc @paritytech/networking 