### PR TITLE
chore: Update hickory-resolver to version 0.24.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
 dependencies = [
  "cfg-if",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tokio-tungstenite = { version = "0.20.0", features = ["rustls-tls-native-roots"]
 tokio-util = { version = "0.7.11", features = ["compat", "io", "codec"] }
 tokio = { version = "1.26.0", features = ["rt", "net", "io-util", "time", "macros", "sync", "parking_lot"] }
 tracing = { version = "0.1.40", features = ["log"] }
-hickory-resolver = "0.24.1"
+hickory-resolver = "0.24.2"
 uint = "0.9.5"
 unsigned-varint = { version = "0.8.0", features = ["codec"] }
 url = "2.4.0"


### PR DESCRIPTION
Update hickory resolver to latest release version to avoid the following security incident:
- https://rustsec.org/advisories/RUSTSEC-2024-0421.html

The incident is not impacting substrate based chains, because we use `crypto/noise` on top of connections. Therefore, malicious nodes cannot impersonate other peerIDs.