### PR TITLE
chore: Release litep2p v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2024-12-12
+
+This release aims to make the MDNS component more robust by fixing a bug that caused the MDNS service to fail to register opened substreams. Additionally, the release includes several improvements to the `identify` protocol, replacing `FuturesUnordered` with `FuturesStream` for better performance.
+
+### Fixed
+
+- mdns/fix: Failed to register opened substream  ([#301](https://github.com/paritytech/litep2p/pull/301))
+
+### Changed
+
+- identify: Replace FuturesUnordered with FuturesStream  ([#302](https://github.com/paritytech/litep2p/pull/302))
+- chore: Update hickory-resolver to version 0.24.2  ([#304](https://github.com/paritytech/litep2p/pull/304))
+- ci: Ensure cargo-machete is working with rust version from CI  ([#303](https://github.com/paritytech/litep2p/pull/303))
+
 ## [0.8.3] - 2024-12-03
 
 This release includes two fixes for small memory leaks happening on edge-cases in the notification and request-response protocols.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,7 +2866,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litep2p"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [build-dependencies]


### PR DESCRIPTION
## [0.8.4] - 2024-12-12

This release aims to make the MDNS component more robust by fixing a bug that caused the MDNS service to fail to register opened substreams. Additionally, the release includes several improvements to the `identify` protocol, replacing `FuturesUnordered` with `FuturesStream` for better performance.

### Fixed

- mdns/fix: Failed to register opened substream  ([#301](https://github.com/paritytech/litep2p/pull/301))

### Changed

- identify: Replace FuturesUnordered with FuturesStream  ([#302](https://github.com/paritytech/litep2p/pull/302))
- chore: Update hickory-resolver to version 0.24.2  ([#304](https://github.com/paritytech/litep2p/pull/304))
- ci: Ensure cargo-machete is working with rust version from CI  ([#303](https://github.com/paritytech/litep2p/pull/303))


cc @paritytech/networking 