### PR TITLE
kad: Provide partial results to speedup `GetRecord` queries

### DIFF
--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -197,9 +197,17 @@ pub enum KademliaEvent {
     GetRecordSuccess {
         /// Query ID.
         query_id: QueryId,
+    },
 
-        /// Found records.
-        records: RecordsType,
+    /// `GET_VALUE` inflight query produced a result.
+    ///
+    /// This event is emitted when a peer responds to the query with a record.
+    GetRecordPartialResult {
+        /// Query ID.
+        query_id: QueryId,
+
+        /// Found record.
+        record: PeerRecord,
     },
 
     /// `GET_PROVIDERS` query succeeded.

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -1107,9 +1107,16 @@ impl Kademlia {
                                 (Some(record), Quorum::One) => {
                                     let _ = self
                                         .event_tx
+                                        .send(KademliaEvent::GetRecordPartialResult { query_id, record: PeerRecord {
+                                            peer: self.service.local_peer_id(),
+                                            record: record.clone(),
+                                        } })
+                                        .await;
+
+                                    let _ = self
+                                        .event_tx
                                         .send(KademliaEvent::GetRecordSuccess {
                                             query_id,
-                                            records: RecordsType::LocalStore(record.clone()),
                                         })
                                         .await;
                                 }

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -1121,6 +1121,17 @@ impl Kademlia {
                                         .await;
                                 }
                                 (record, _) => {
+                                    let local_record = record.is_some();
+                                    if let Some(record) = record {
+                                        let _ = self
+                                            .event_tx
+                                            .send(KademliaEvent::GetRecordPartialResult { query_id, record: PeerRecord {
+                                                peer: self.service.local_peer_id(),
+                                                record: record.clone(),
+                                            } })
+                                            .await;
+                                    }
+
                                     self.engine.start_get_record(
                                         query_id,
                                         key.clone(),
@@ -1128,7 +1139,7 @@ impl Kademlia {
                                             .closest(&Key::new(key), self.replication_factor)
                                             .into(),
                                         quorum,
-                                        record.cloned(),
+                                        local_record,
                                     );
                                 }
                             }


### PR DESCRIPTION
This PR provides the partial results of the `GetRecord` kademlia query.
- A new `GetRecordPartialResult` event is introduced for kademlia
- `GetRecordSuccess` is modified to include only the query ID
- Kademlia `GetRecord` implementation no longer stores network records internally and forwards valid (unexpired) ones back to the user


The change is needed to speedup authority discovery for substrate based chains.


More context can be found at: https://github.com/paritytech/polkadot-sdk/issues/7077#issuecomment-2575662449

### Next Steps
- [ ] Adjust testing to API breaking change
- [ ] Investigate CPU impact (as suggested by @dmitry-markin this should be unnoticeable 🙏 )