### PR TITLE
identify: Sufix litep2p to the agent version for visibility

### DIFF
--- a/src/protocol/libp2p/identify.rs
+++ b/src/protocol/libp2p/identify.rs
@@ -55,6 +55,9 @@ const _PUSH_PROTOCOL_NAME: &str = "/ipfs/id/push/1.0.0";
 /// Default agent version.
 const DEFAULT_AGENT: &str = "litep2p/1.0.0";
 
+/// Sufix name added to the user agent.
+const AGENT_SUFIX: &str = "(litep2p)";
+
 /// Size for `/ipfs/ping/1.0.0` payloads.
 // TODO: what is the max size?
 const IDENTIFY_PAYLOAD_SIZE: usize = 4096;
@@ -197,7 +200,10 @@ impl Identify {
             peers: HashMap::new(),
             public: config.public.expect("public key to be supplied"),
             protocol_version: config.protocol_version,
-            user_agent: config.user_agent.unwrap_or(DEFAULT_AGENT.to_string()),
+            user_agent: config
+                .user_agent
+                .map(|agent| format!("{} {}", agent, AGENT_SUFIX))
+                .unwrap_or(DEFAULT_AGENT.to_string()),
             pending_inbound: FuturesStream::new(),
             pending_outbound: FuturesStream::new(),
             protocols: config.protocols.iter().map(|protocol| protocol.to_string()).collect(),

--- a/tests/protocol/identify.rs
+++ b/tests/protocol/identify.rs
@@ -102,7 +102,7 @@ async fn identify_supported(transport1: Transport, transport2: Transport) {
                 tracing::info!("peer2 observed: {observed_address:?}");
 
                 assert_eq!(protocol_version, Some("/proto/2".to_string()));
-                assert_eq!(user_agent, Some("agent v2".to_string()));
+                assert_eq!(user_agent, Some("agent v2 (litep2p)".to_string()));
 
                 litep2p1_done = true;
 
@@ -115,7 +115,7 @@ async fn identify_supported(transport1: Transport, transport2: Transport) {
                 tracing::info!("peer1 observed: {observed_address:?}");
 
                 assert_eq!(protocol_version, Some("/proto/1".to_string()));
-                assert_eq!(user_agent, Some("agent v1".to_string()));
+                assert_eq!(user_agent, Some("agent v1 (litep2p)".to_string()));
 
                 litep2p2_done = true;
 


### PR DESCRIPTION
This PR adds the `(litep2p)` suffix to the agent version (user agent) of the identify protocol.

The change is needed to gain visibility into network backends and determine exactly the number of validators that are running litep2p.
Using tools like subp2p-explorer, we can determine if the litep2p validators were responsible for finality lags in kusama.

This reflects on the identify protocol:

```
info=Identify {
  protocol_version: Some("/substrate/1.0"),
  agent_version: Some("polkadot-parachain/v1.17.0-967989c5d94 (kusama-node-name-01) (litep2p)")
  ...
}
```

cc @paritytech/networking 
