### PR TITLE
multistream-select: Enforce `io::error` instead of empty protocols

### DIFF
--- a/src/multistream_select/dialer_select.rs
+++ b/src/multistream_select/dialer_select.rs
@@ -25,7 +25,8 @@ use crate::{
     error::{self, Error, ParseError},
     multistream_select::{
         protocol::{
-            encode_multistream_message, HeaderLine, Message, MessageIO, Protocol, ProtocolError,
+            webrtc_encode_multistream_message, HeaderLine, Message, MessageIO, Protocol,
+            ProtocolError,
         },
         Negotiated, NegotiationError, Version,
     },
@@ -305,7 +306,7 @@ pub enum HandshakeResult {
 /// Handshake state.
 #[derive(Debug)]
 enum HandshakeState {
-    /// Wainting to receive any response from remote peer.
+    /// Waiting to receive any response from remote peer.
     WaitingResponse,
 
     /// Waiting to receive the actual application protocol from remote peer.
@@ -314,7 +315,7 @@ enum HandshakeState {
 
 /// `multistream-select` dialer handshake state.
 #[derive(Debug)]
-pub struct DialerState {
+pub struct WebRtcDialerState {
     /// Proposed main protocol.
     protocol: ProtocolName,
 
@@ -325,16 +326,16 @@ pub struct DialerState {
     state: HandshakeState,
 }
 
-impl DialerState {
+impl WebRtcDialerState {
     /// Propose protocol to remote peer.
     ///
-    /// Return [`DialerState`] which is used to drive forward the negotiation and an encoded
+    /// Return [`WebRtcDialerState`] which is used to drive forward the negotiation and an encoded
     /// `multistream-select` message that contains the protocol proposal for the substream.
     pub fn propose(
         protocol: ProtocolName,
         fallback_names: Vec<ProtocolName>,
     ) -> crate::Result<(Self, Vec<u8>)> {
-        let message = encode_multistream_message(
+        let message = webrtc_encode_multistream_message(
             std::iter::once(protocol.clone())
                 .chain(fallback_names.clone())
                 .filter_map(|protocol| Protocol::try_from(protocol.as_ref()).ok())
@@ -353,7 +354,7 @@ impl DialerState {
         ))
     }
 
-    /// Register response to [`DialerState`].
+    /// Register response to [`WebRtcDialerState`].
     pub fn register_response(
         &mut self,
         payload: Vec<u8>,
@@ -757,7 +758,7 @@ mod tests {
     #[test]
     fn propose() {
         let (mut dialer_state, message) =
-            DialerState::propose(ProtocolName::from("/13371338/proto/1"), vec![]).unwrap();
+            WebRtcDialerState::propose(ProtocolName::from("/13371338/proto/1"), vec![]).unwrap();
         let message = bytes::BytesMut::from(&message[..]).freeze();
 
         let Message::Protocols(protocols) = Message::decode(message).unwrap() else {
@@ -779,7 +780,7 @@ mod tests {
 
     #[test]
     fn propose_with_fallback() {
-        let (mut dialer_state, message) = DialerState::propose(
+        let (mut dialer_state, message) = WebRtcDialerState::propose(
             ProtocolName::from("/13371338/proto/1"),
             vec![ProtocolName::from("/sup/proto/1")],
         )
@@ -815,7 +816,7 @@ mod tests {
         let _ = message.encode(&mut bytes).map_err(|_| Error::InvalidData).unwrap();
 
         let (mut dialer_state, _message) =
-            DialerState::propose(ProtocolName::from("/13371338/proto/1"), vec![]).unwrap();
+            WebRtcDialerState::propose(ProtocolName::from("/13371338/proto/1"), vec![]).unwrap();
 
         match dialer_state.register_response(bytes.freeze().to_vec()) {
             Err(error::NegotiationError::MultistreamSelectError(NegotiationError::Failed)) => {}
@@ -834,7 +835,7 @@ mod tests {
         let _ = message.encode(&mut bytes).map_err(|_| Error::InvalidData).unwrap();
 
         let (mut dialer_state, _message) =
-            DialerState::propose(ProtocolName::from("/13371338/proto/1"), vec![]).unwrap();
+            WebRtcDialerState::propose(ProtocolName::from("/13371338/proto/1"), vec![]).unwrap();
 
         match dialer_state.register_response(bytes.freeze().to_vec()) {
             Err(error::NegotiationError::MultistreamSelectError(NegotiationError::Failed)) => {}
@@ -844,7 +845,7 @@ mod tests {
 
     #[test]
     fn negotiate_main_protocol() {
-        let message = encode_multistream_message(
+        let message = webrtc_encode_multistream_message(
             vec![Message::Protocol(
                 Protocol::try_from(&b"/13371338/proto/1"[..]).unwrap(),
             )]
@@ -853,7 +854,7 @@ mod tests {
         .unwrap()
         .freeze();
 
-        let (mut dialer_state, _message) = DialerState::propose(
+        let (mut dialer_state, _message) = WebRtcDialerState::propose(
             ProtocolName::from("/13371338/proto/1"),
             vec![ProtocolName::from("/sup/proto/1")],
         )
@@ -862,13 +863,13 @@ mod tests {
         match dialer_state.register_response(message.to_vec()) {
             Ok(HandshakeResult::Succeeded(negotiated)) =>
                 assert_eq!(negotiated, ProtocolName::from("/13371338/proto/1")),
-            _ => panic!("invalid event"),
+            event => panic!("invalid event {event:?}"),
         }
     }
 
     #[test]
     fn negotiate_fallback_protocol() {
-        let message = encode_multistream_message(
+        let message = webrtc_encode_multistream_message(
             vec![Message::Protocol(
                 Protocol::try_from(&b"/sup/proto/1"[..]).unwrap(),
             )]
@@ -877,7 +878,7 @@ mod tests {
         .unwrap()
         .freeze();
 
-        let (mut dialer_state, _message) = DialerState::propose(
+        let (mut dialer_state, _message) = WebRtcDialerState::propose(
             ProtocolName::from("/13371338/proto/1"),
             vec![ProtocolName::from("/sup/proto/1")],
         )

--- a/src/multistream_select/mod.rs
+++ b/src/multistream_select/mod.rs
@@ -76,9 +76,10 @@ mod negotiated;
 mod protocol;
 
 pub use crate::multistream_select::{
-    dialer_select::{dialer_select_proto, DialerSelectFuture, DialerState, HandshakeResult},
+    dialer_select::{dialer_select_proto, DialerSelectFuture, HandshakeResult, WebRtcDialerState},
     listener_select::{
-        listener_negotiate, listener_select_proto, ListenerSelectFuture, ListenerSelectResult,
+        listener_select_proto, webrtc_listener_negotiate, ListenerSelectFuture,
+        ListenerSelectResult,
     },
     negotiated::{Negotiated, NegotiatedComplete, NegotiationError},
     protocol::{HeaderLine, Message, Protocol, ProtocolError},

--- a/src/multistream_select/protocol.rs
+++ b/src/multistream_select/protocol.rs
@@ -467,3 +467,24 @@ impl From<uvi::decode::Error> for ProtocolError {
         Self::from(io::Error::new(io::ErrorKind::InvalidData, err.to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_main_messages() {
+        // Decode main messages.
+        let bytes = Bytes::from_static(MSG_MULTISTREAM_1_0);
+        assert_eq!(
+            Message::decode(bytes).unwrap(),
+            Message::Header(HeaderLine::V1)
+        );
+
+        let bytes = Bytes::from_static(MSG_PROTOCOL_NA);
+        assert_eq!(Message::decode(bytes).unwrap(), Message::NotAvailable);
+
+        let bytes = Bytes::from_static(MSG_LS);
+        assert_eq!(Message::decode(bytes).unwrap(), Message::ListProtocols);
+    }
+}

--- a/src/multistream_select/protocol.rs
+++ b/src/multistream_select/protocol.rs
@@ -487,4 +487,14 @@ mod tests {
         let bytes = Bytes::from_static(MSG_LS);
         assert_eq!(Message::decode(bytes).unwrap(), Message::ListProtocols);
     }
+
+    #[test]
+    fn test_decode_empty_message() {
+        // Empty message should decode to an IoError, not Header::Protocols.
+        let bytes = Bytes::from_static(b"");
+        match Message::decode(bytes).unwrap_err() {
+            ProtocolError::IoError(io) => assert_eq!(io.kind(), io::ErrorKind::InvalidData),
+            err => panic!("Unexpected error: {:?}", err),
+        };
+    }
 }

--- a/src/multistream_select/protocol.rs
+++ b/src/multistream_select/protocol.rs
@@ -249,6 +249,9 @@ pub fn webrtc_encode_multistream_message(
         header.append(&mut proto_bytes);
     }
 
+    // For the `Message::Protocols` to be interpreted correctly, it must be followed by a newline.
+    header.push(b'\n');
+
     Ok(BytesMut::from(&header[..]))
 }
 

--- a/src/multistream_select/protocol.rs
+++ b/src/multistream_select/protocol.rs
@@ -201,8 +201,7 @@ impl Message {
         let mut remaining: &[u8] = &msg;
         loop {
             // A well-formed message must be terminated with a newline.
-            // TODO: don't do this
-            if remaining == [b'\n'] || remaining.is_empty() {
+            if remaining == [b'\n'] {
                 break;
             } else if protocols.len() == MAX_PROTOCOLS {
                 return Err(ProtocolError::TooManyProtocols);

--- a/src/multistream_select/protocol.rs
+++ b/src/multistream_select/protocol.rs
@@ -227,7 +227,12 @@ impl Message {
 }
 
 /// Create `multistream-select` message from an iterator of `Message`s.
-pub fn encode_multistream_message(
+///
+/// # Note
+///
+/// This is implementation is not compliant with the multistream-select protocol spec.
+/// The only purpose of this was to get the `multistream-select` protocol working with smoldot.
+pub fn webrtc_encode_multistream_message(
     messages: impl IntoIterator<Item = Message>,
 ) -> crate::Result<BytesMut> {
     // encode `/multistream-select/1.0.0` header


### PR DESCRIPTION
This PR brings parity between the litep2p mutlistream-select implementation and the libp2p one.

There was a mismatch in the litep2p implementation which resulted in decoding empty bytes into `Message::Protocols([ ])`. In contrast, libp2p returns an `io::error` since the message is invalid.

While at it have added a few tests to ensure our implementation works as expected

cc @paritytech/networking 