### PR TITLE
websocket/stream: Avoid memory allocations on flushing

### DIFF
--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -33,6 +33,8 @@ use std::{
 
 // TODO: add tests
 
+const DEFAULT_BUF_SIZE: usize = 8 * 1024;
+
 /// Send state.
 enum State {
     /// State is poisoned.
@@ -70,7 +72,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> BufferedStream<S> {
     /// Create new [`BufferedStream`].
     pub(super) fn new(stream: WebSocketStream<S>) -> Self {
         Self {
-            write_buffer: Vec::with_capacity(2000),
+            write_buffer: Vec::with_capacity(DEFAULT_BUF_SIZE),
             read_buffer: None,
             write_ptr: 0usize,
             stream,
@@ -124,7 +126,6 @@ impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncWrite for BufferedStream<S
                 }
                 State::FlushPending => match futures::ready!(self.stream.poll_flush_unpin(cx)) {
                     Ok(_res) => {
-                        // TODO: optimize
                         self.state = State::ReadyToSend;
                         self.write_ptr = 0;
                         self.write_buffer.clear();

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -127,7 +127,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncWrite for BufferedStream<S
                         // TODO: optimize
                         self.state = State::ReadyToSend;
                         self.write_ptr = 0;
-                        self.write_buffer = Vec::with_capacity(2000);
+                        self.write_buffer.clear();
                         return Poll::Ready(Ok(()));
                     }
                     Err(_) => return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into())),

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -129,6 +129,9 @@ impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncWrite for BufferedStream<S
                         self.state = State::ReadyToSend;
                         self.write_ptr = 0;
                         self.write_buffer.clear();
+                        // In the unlikely event that the buffer is too large, we need to bound the
+                        // capacity to avoid unbounded memory usage.
+                        self.write_buffer.shrink_to(DEFAULT_BUF_SIZE);
                         return Poll::Ready(Ok(()));
                     }
                     Err(_) => return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into())),


### PR DESCRIPTION
This PR avoids an allocation by clearing out the write buffer elements.

While at it, have increased the buffer size from 2000 to 8192 for extra space and cache alignment. This is the default value used by std/tokio implementation for buffered operations. 