### PR TITLE
websocket/stream/tests: Add tests for the stream implementation

### DIFF
--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -278,4 +278,18 @@ mod tests {
             state => panic!("Expected state {state:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn test_read_poll_pending() {
+        let (mut stream, mut _server) = create_test_stream().await;
+
+        let mut buffer = [0u8; 10];
+        let mut cx = std::task::Context::from_waker(futures::task::noop_waker_ref());
+        let pin_stream = Pin::new(&mut stream);
+
+        assert!(matches!(
+            pin_stream.poll_read(&mut cx, &mut buffer),
+            Poll::Pending
+        ));
+    }
 }

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -211,4 +211,13 @@ mod tests {
         let (mut stream, mut _server) = create_test_stream().await;
         assert!(stream.flush().await.is_ok());
     }
+
+    #[tokio::test]
+    async fn test_write_and_flush() {
+        let (mut stream, mut _server) = create_test_stream().await;
+        let data = b"hello world";
+
+        stream.write_all(data).await.unwrap();
+        assert!(stream.flush().await.is_ok());
+    }
 }

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -31,8 +31,6 @@ use std::{
     task::{Context, Poll},
 };
 
-// TODO: add tests
-
 const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
 /// Send state.
@@ -291,5 +289,18 @@ mod tests {
             pin_stream.poll_read(&mut cx, &mut buffer),
             Poll::Pending
         ));
+    }
+
+    #[tokio::test]
+    async fn test_read_from_internal_buffers() {
+        let (mut stream, server) = create_test_stream().await;
+        drop(server);
+
+        stream.read_buffer = Bytes::from_static(b"hello world");
+
+        let mut buffer = [0u8; 32];
+        let bytes_read = stream.read(&mut buffer).await.unwrap();
+        assert_eq!(bytes_read, 11);
+        assert_eq!(&buffer[..bytes_read], b"hello world");
     }
 }

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -96,7 +96,6 @@ impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncWrite for BufferedStream<S
         loop {
             match std::mem::replace(&mut self.state, State::Poisoned) {
                 State::ReadyToSend => {
-                    println!("poll ready unpin ");
                     match self.stream.poll_ready_unpin(cx) {
                         Poll::Ready(Ok(())) => {}
                         Poll::Ready(Err(_error)) =>
@@ -106,8 +105,6 @@ impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncWrite for BufferedStream<S
                             return Poll::Pending;
                         }
                     }
-
-                    println!("start send unpin");
 
                     let message = std::mem::take(&mut self.write_buffer);
                     match self.stream.start_send_unpin(Message::Binary(message.freeze())) {
@@ -122,8 +119,6 @@ impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncWrite for BufferedStream<S
                 }
 
                 State::FlushPending => {
-                    println!("poll flush");
-
                     match self.stream.poll_flush_unpin(cx) {
                         Poll::Ready(Ok(())) => {}
                         Poll::Ready(Err(_error)) =>

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -205,4 +205,10 @@ mod tests {
         assert_eq!(bytes_written, data.len());
         assert_eq!(&stream.write_buffer[..], data);
     }
+
+    #[tokio::test]
+    async fn test_flush_empty_buffer() {
+        let (mut stream, mut _server) = create_test_stream().await;
+        assert!(stream.flush().await.is_ok());
+    }
 }

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -220,4 +220,10 @@ mod tests {
         stream.write_all(data).await.unwrap();
         assert!(stream.flush().await.is_ok());
     }
+
+    #[tokio::test]
+    async fn test_close_stream() {
+        let (mut stream, mut _server) = create_test_stream().await;
+        assert!(stream.close().await.is_ok());
+    }
 }


### PR DESCRIPTION
This PR tests the following scenarios for the websocket stream implementation: 
- Test reading from internal buffers without touching the streams
- Test poll pending during reads
- Test poisoned state
- Ping pong between server and client
- Test closing the stream
- Test write and flush
- Test flushing on empty buffer
- Test write to internal buffers

cc @paritytech/networking 