### PR TITLE
chore: Release litep2p v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.2] - 2025-03-11
+## [0.9.3] - 2025-03-11
 
 This release introduces an API for setting the maximum kademlia message size.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2025-03-11
+
+This release introduces an API for setting the maximum kademlia message size.
+
+### Changed
+
+- kad: Set upper limits for kademlia messages  ([#357](https://github.com/paritytech/litep2p/pull/357))
+
 ## [0.9.2] - 2025-03-10
 
 This release downgrades a spamming log message to debug level and adds tests for the WebSocket stream implementation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "litep2p"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "asynchronous-codec 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 
 [build-dependencies]


### PR DESCRIPTION

## [0.9.3] - 2025-03-11

This release introduces an API for setting the maximum kademlia message size.

### Changed

- kad: Set upper limits for kademlia messages  ([#357](https://github.com/paritytech/litep2p/pull/357))