### PR TITLE
features: Move quic related dependencies under feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,8 @@ network-interface = "1.1.1"
 parking_lot = "0.12.3"
 pin-project = "1.1.0"
 prost = "0.12.6"
-quinn = { version = "0.9.3", default-features = false, features = ["tls-rustls", "runtime-tokio"], optional = true }
 rand = { version = "0.8.0", features = ["getrandom"] }
 rcgen = "0.10.0"
-ring = "0.16.20"
 serde = "1.0.158"
 sha2 = "0.10.8"
 simple-dns = "0.9.3"
@@ -47,18 +45,17 @@ hickory-resolver = "0.24.2"
 uint = "0.10.0"
 unsigned-varint = { version = "0.8.0", features = ["codec"] }
 url = "2.5.4"
-webpki = { version = "0.22.4", optional = true }
 x25519-dalek = "2.0.1"
 x509-parser = "0.17.0"
 yasna = "0.5.0"
 zeroize = "1.8.1"
 yamux = "0.13.4"
 
-# Exposed dependencies. Breaking changes to these are breaking changes to us.
-[dependencies.rustls]
-version = "0.20.7"
-default-features = false
-features = ["dangerous_configuration"] # Must enable this to allow for custom verification code.
+# Quic related dependencies. Quic is an experimental feature flag. The dependencies must be updated.
+quinn = { version = "0.9.3", default-features = false, features = ["tls-rustls", "runtime-tokio"], optional = true }
+rustls = { version = "0.20.7", default-features = false, features = ["dangerous_configuration"], optional = true }
+ring = { version = "0.16.20", optional = true }
+webpki = { version = "0.22.4", optional = true }
 
 [dev-dependencies]
 asynchronous-codec = "0.7.0"
@@ -86,7 +83,7 @@ futures_ringbuf = "0.4.0"
 
 [features]
 custom_sc_network = []
-quic = ["dep:webpki", "dep:quinn"]
+quic = ["dep:webpki", "dep:quinn", "dep:rustls", "dep:ring"]
 webrtc = ["dep:str0m"]
 websocket = ["dep:tokio-tungstenite"]
 

--- a/src/multistream_select/dialer_select.rs
+++ b/src/multistream_select/dialer_select.rs
@@ -35,7 +35,6 @@ use crate::{
 
 use bytes::BytesMut;
 use futures::prelude::*;
-use rustls::internal::msgs::hsjoiner::HandshakeJoiner;
 use std::{
     convert::TryFrom as _,
     iter, mem,


### PR DESCRIPTION
The following crates are made optional, depending on the Quic feature flag:
- ring
- rustls

This effectively ensures that litep2p is not leaking outdated dependencies for experimental features (ie quic).

Closes: https://github.com/paritytech/litep2p/issues/330

cc @paritytech/networking 