### PR TITLE
kad: Improve robustness of addresses from the routing table

### DIFF
--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -667,10 +667,10 @@ impl Kademlia {
     }
 
     /// Handle dial failure.
-    fn on_dial_failure(&mut self, peer: PeerId, address: Multiaddr) {
-        tracing::trace!(target: LOG_TARGET, ?peer, ?address, "failed to dial peer");
+    fn on_dial_failure(&mut self, peer: PeerId, addresses: Vec<Multiaddr>) {
+        tracing::trace!(target: LOG_TARGET, ?peer, ?addresses, "failed to dial peer");
 
-        self.routing_table.remove_address(Key::from(peer), &address);
+        self.routing_table.remove_addresses(Key::from(peer), &addresses);
 
         let Some(actions) = self.pending_dials.remove(&peer) else {
             return;
@@ -682,7 +682,7 @@ impl Kademlia {
                     target: LOG_TARGET,
                     ?peer,
                     query = ?query_id,
-                    ?address,
+                    ?addresses,
                     "report failure for pending query",
                 );
 
@@ -923,8 +923,8 @@ impl Kademlia {
                     Some(TransportEvent::SubstreamOpenFailure { substream, error }) => {
                         self.on_substream_open_failure(substream, error).await;
                     }
-                    Some(TransportEvent::DialFailure { peer, address }) =>
-                        self.on_dial_failure(peer, address),
+                    Some(TransportEvent::DialFailure { peer, addresses }) =>
+                        self.on_dial_failure(peer, addresses),
                     None => return Err(Error::EssentialTaskClosed),
                 },
                 context = self.executor.next() => {

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -670,6 +670,8 @@ impl Kademlia {
     fn on_dial_failure(&mut self, peer: PeerId, address: Multiaddr) {
         tracing::trace!(target: LOG_TARGET, ?peer, ?address, "failed to dial peer");
 
+        self.routing_table.remove_address(Key::from(peer), &address);
+
         let Some(actions) = self.pending_dials.remove(&peer) else {
             return;
         };
@@ -921,7 +923,7 @@ impl Kademlia {
                     Some(TransportEvent::SubstreamOpenFailure { substream, error }) => {
                         self.on_substream_open_failure(substream, error).await;
                     }
-                    Some(TransportEvent::DialFailure { peer, address, .. }) =>
+                    Some(TransportEvent::DialFailure { peer, address }) =>
                         self.on_dial_failure(peer, address),
                     None => return Err(Error::EssentialTaskClosed),
                 },

--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -317,7 +317,7 @@ mod tests {
         KademliaPeer {
             peer,
             key: Key::from(peer),
-            addresses: vec![],
+            address_store: Default::default(),
             connection: ConnectionType::Connected,
         }
     }
@@ -353,7 +353,12 @@ mod tests {
         let mut context = FindNodeContext::new(config, VecDeque::new());
         assert!(context.is_done());
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QueryFailed { query: QueryId(0) });
+        match event {
+            QueryAction::QueryFailed { query, .. } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        };
     }
 
     #[test]
@@ -522,7 +527,12 @@ mod tests {
 
         // Produces the result.
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QuerySucceeded { query: QueryId(0) });
+        match event {
+            QueryAction::QuerySucceeded { query, .. } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        };
     }
 
     #[test]
@@ -550,7 +560,12 @@ mod tests {
         context.register_response(closest, vec![]);
 
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QuerySucceeded { query: QueryId(0) });
+        match event {
+            QueryAction::QuerySucceeded { query } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        };
     }
 
     #[test]
@@ -602,7 +617,12 @@ mod tests {
         context.register_response(closest, vec![]);
 
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QuerySucceeded { query: QueryId(0) });
+        match event {
+            QueryAction::QuerySucceeded { query, .. } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        };
     }
 
     #[test]
@@ -665,7 +685,12 @@ mod tests {
 
         // Produces the result.
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QuerySucceeded { query: QueryId(0) });
+        match event {
+            QueryAction::QuerySucceeded { query } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        };
 
         // Because the FindNode query keeps a window of the best K (3 in this case) peers,
         // we expect to produce the best K peers. As opposed to having only the last entry

--- a/src/protocol/libp2p/kademlia/query/get_providers.rs
+++ b/src/protocol/libp2p/kademlia/query/get_providers.rs
@@ -294,18 +294,13 @@ mod tests {
         KademliaPeer {
             peer,
             key: Key::from(peer),
-            addresses: vec![],
+            address_store: Default::default(),
             connection: ConnectionType::NotConnected,
         }
     }
 
     fn peer_to_kad_with_addresses(peer: PeerId, addresses: Vec<Multiaddr>) -> KademliaPeer {
-        KademliaPeer {
-            peer,
-            key: Key::from(peer),
-            addresses,
-            connection: ConnectionType::NotConnected,
-        }
+        KademliaPeer::new(peer, addresses, ConnectionType::NotConnected)
     }
 
     #[test]
@@ -316,7 +311,12 @@ mod tests {
         assert!(context.is_done());
 
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QueryFailed { query: QueryId(0) });
+        match event {
+            QueryAction::QueryFailed { query, .. } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        }
     }
 
     #[test]
@@ -443,7 +443,12 @@ mod tests {
 
         // Produces the result.
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QuerySucceeded { query: QueryId(0) });
+        match event {
+            QueryAction::QuerySucceeded { query, .. } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        }
 
         // Check results.
         let found_providers = context.found_providers();

--- a/src/protocol/libp2p/kademlia/query/get_providers.rs
+++ b/src/protocol/libp2p/kademlia/query/get_providers.rs
@@ -117,7 +117,7 @@ impl GetProvidersContext {
         // Merge addresses of different provider records of the same peer.
         let mut providers = HashMap::<PeerId, HashSet<Multiaddr>>::new();
         found_providers.into_iter().for_each(|provider| {
-            providers.entry(provider.peer).or_default().extend(provider.addresses)
+            providers.entry(provider.peer).or_default().extend(provider.addresses())
         });
 
         // Convert into `Vec<KademliaPeer>`

--- a/src/protocol/libp2p/kademlia/query/get_record.rs
+++ b/src/protocol/libp2p/kademlia/query/get_record.rs
@@ -326,7 +326,7 @@ mod tests {
         KademliaPeer {
             peer,
             key: Key::from(peer),
-            addresses: vec![],
+            address_store: Default::default(),
             connection: ConnectionType::Connected,
         }
     }
@@ -396,7 +396,12 @@ mod tests {
         let mut context = GetRecordContext::new(config, VecDeque::new(), false);
         assert!(context.is_done());
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QueryFailed { query: QueryId(0) });
+        match event {
+            QueryAction::QueryFailed { query } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        }
 
         let config = GetRecordConfig {
             known_records: 1,
@@ -405,7 +410,12 @@ mod tests {
         let mut context = GetRecordContext::new(config, VecDeque::new(), false);
         assert!(context.is_done());
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QuerySucceeded { query: QueryId(0) });
+        match event {
+            QueryAction::QuerySucceeded { query } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        }
     }
 
     #[test]
@@ -562,7 +572,12 @@ mod tests {
 
         // Produces the result.
         let event = context.next_action().unwrap();
-        assert_eq!(event, QueryAction::QuerySucceeded { query: QueryId(0) });
+        match event {
+            QueryAction::QuerySucceeded { query } => {
+                assert_eq!(query, QueryId(0));
+            }
+            _ => panic!("Unexpected event"),
+        }
 
         // Check results.
         assert_eq!(

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -104,7 +104,7 @@ enum QueryType {
 }
 
 /// Query action.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum QueryAction {
     /// Send message to peer.
     SendMessage {

--- a/src/protocol/libp2p/kademlia/record.rs
+++ b/src/protocol/libp2p/kademlia/record.rs
@@ -23,6 +23,7 @@ use crate::{
     protocol::libp2p::kademlia::types::{
         ConnectionType, Distance, KademliaPeer, Key as KademliaKey,
     },
+    transport::manager::address::{AddressRecord, AddressStore},
     Multiaddr, PeerId,
 };
 
@@ -166,10 +167,15 @@ pub struct ContentProvider {
 
 impl From<ContentProvider> for KademliaPeer {
     fn from(provider: ContentProvider) -> Self {
+        let mut address_store = AddressStore::new();
+        for address in provider.addresses.iter() {
+            address_store.insert(AddressRecord::from_raw_multiaddr(address.clone()));
+        }
+
         Self {
             key: KademliaKey::from(provider.peer),
             peer: provider.peer,
-            addresses: provider.addresses,
+            address_store,
             connection: ConnectionType::NotConnected,
         }
     }

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -120,16 +120,16 @@ impl RoutingTable {
     }
 
     /// Remove the address of the peer from the routing table on dail failures.
-    pub fn remove_address(&mut self, key: Key<PeerId>, address: &Multiaddr) {
+    pub fn remove_addresses(&mut self, key: Key<PeerId>, addresses: &[Multiaddr]) {
         tracing::trace!(
             target: LOG_TARGET,
             ?key,
-            ?address,
+            ?addresses,
             "on dial failure"
         );
 
         if let KBucketEntry::Occupied(entry) = self.entry(key) {
-            entry.addresses.retain(|addr| addr != address);
+            entry.addresses.retain(|addr| !addresses.contains(addr));
         }
     }
 

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -120,7 +120,7 @@ impl RoutingTable {
     }
 
     /// Remove the address of the peer from the routing table on dail failures.
-    pub fn on_dial_failure(&mut self, key: Key<PeerId>, address: Multiaddr) {
+    pub fn remove_address(&mut self, key: Key<PeerId>, address: &Multiaddr) {
         tracing::trace!(
             target: LOG_TARGET,
             ?key,
@@ -129,7 +129,7 @@ impl RoutingTable {
         );
 
         if let KBucketEntry::Occupied(entry) = self.entry(key) {
-            entry.addresses.retain(|addr| addr != &address);
+            entry.addresses.retain(|addr| addr != address);
         }
     }
 

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -180,7 +180,7 @@ impl RoutingTable {
 
         match self.entry(Key::from(peer)) {
             KBucketEntry::Occupied(entry) => {
-                entry.addresses = addresses;
+                entry.push_addresses(addresses);
                 entry.connection = connection;
             }
             mut entry @ KBucketEntry::Vacant(_) => {

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -119,6 +119,20 @@ impl RoutingTable {
         self.buckets[index.get()].entry(key)
     }
 
+    /// Remove the address of the peer from the routing table on dail failures.
+    pub fn on_dial_failure(&mut self, key: Key<PeerId>, address: Multiaddr) {
+        tracing::trace!(
+            target: LOG_TARGET,
+            ?key,
+            ?address,
+            "on dial failure"
+        );
+
+        if let KBucketEntry::Occupied(entry) = self.entry(key) {
+            entry.addresses.retain(|addr| addr != &address);
+        }
+    }
+
     /// Add known peer to [`RoutingTable`].
     ///
     /// In order to bootstrap the lookup process, the routing table must be aware of

--- a/src/protocol/libp2p/kademlia/types.rs
+++ b/src/protocol/libp2p/kademlia/types.rs
@@ -242,7 +242,7 @@ impl From<ConnectionType> for i32 {
 }
 
 /// Kademlia peer.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KademliaPeer {
     /// Peer key.
     pub(super) key: Key<PeerId>,
@@ -279,6 +279,11 @@ impl KademliaPeer {
         for address in addresses {
             self.address_store.insert(AddressRecord::from_raw_multiaddr(address));
         }
+    }
+
+    /// Returns the addresses of the peer.
+    pub fn addresses(&self) -> Vec<Multiaddr> {
+        self.address_store.addresses(MAX_ADDRESSES)
     }
 }
 

--- a/src/protocol/libp2p/kademlia/types.rs
+++ b/src/protocol/libp2p/kademlia/types.rs
@@ -35,6 +35,9 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+/// Maximum number of addresses to store for a peer.
+const MAX_ADDRESSES: usize = 64;
+
 construct_uint! {
     /// 256-bit unsigned integer.
     pub(super) struct U256(4);
@@ -258,6 +261,18 @@ impl KademliaPeer {
             addresses,
             connection,
             key: Key::from(peer),
+        }
+    }
+
+    /// Add the following addresses to the kademlia peer if there's enough space.
+    pub fn push_addresses(&mut self, addresses: impl IntoIterator<Item = Multiaddr>) {
+        let space = MAX_ADDRESSES.saturating_sub(self.addresses.len());
+
+        // TODO: Replace with `HashSet`.
+        for address in addresses.into_iter().take(space) {
+            if !self.addresses.contains(&address) {
+                self.addresses.push(address);
+            }
         }
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -82,8 +82,8 @@ pub enum TransportEvent {
         /// Peer ID.
         peer: PeerId,
 
-        /// Dialed address.
-        address: Multiaddr,
+        /// Dialed addresseses.
+        addresses: Vec<Multiaddr>,
     },
 
     /// Substream opened for `peer`.

--- a/src/protocol/notification/mod.rs
+++ b/src/protocol/notification/mod.rs
@@ -1565,12 +1565,12 @@ impl NotificationProtocol {
     }
 
     /// Handle dial failure.
-    async fn on_dial_failure(&mut self, peer: PeerId, address: Multiaddr) {
+    async fn on_dial_failure(&mut self, peer: PeerId, addresses: Vec<Multiaddr>) {
         tracing::trace!(
             target: LOG_TARGET,
             ?peer,
             protocol = %self.protocol,
-            ?address,
+            ?addresses,
             "handle dial failure",
         );
 
@@ -1579,7 +1579,7 @@ impl NotificationProtocol {
                 target: LOG_TARGET,
                 ?peer,
                 protocol = %self.protocol,
-                ?address,
+                ?addresses,
                 "dial failure for an unknown peer",
             );
             return;
@@ -1587,7 +1587,7 @@ impl NotificationProtocol {
 
         match context.state {
             PeerState::Dialing => {
-                tracing::debug!(target: LOG_TARGET, ?peer, protocol = %self.protocol, ?address, "failed to dial peer");
+                tracing::debug!(target: LOG_TARGET, ?peer, protocol = %self.protocol, ?addresses, "failed to dial peer");
                 self.event_handle
                     .report_notification_stream_open_failure(peer, NotificationError::DialFailure)
                     .await;
@@ -1769,7 +1769,7 @@ impl NotificationProtocol {
                 Some(TransportEvent::SubstreamOpenFailure { substream, error }) => {
                     self.on_substream_open_failure(substream, error).await;
                 }
-                Some(TransportEvent::DialFailure { peer, address, .. }) => self.on_dial_failure(peer, address).await,
+                Some(TransportEvent::DialFailure { peer, addresses }) => self.on_dial_failure(peer, addresses).await,
                 None => (),
             },
             result = self.pending_validations.select_next_some(), if !self.pending_validations.is_empty() => {

--- a/src/protocol/notification/tests/notification.rs
+++ b/src/protocol/notification/tests/notification.rs
@@ -325,7 +325,7 @@ async fn dial_failure_for_non_dialing_peer() {
     let (peer, _receiver) = register_peer(&mut notif, &mut tx).await;
 
     // dial failure for the peer even though it's not dialing
-    notif.on_dial_failure(peer, Multiaddr::empty()).await;
+    notif.on_dial_failure(peer, vec![]).await;
 
     assert!(std::matches!(
         notif.peers.get(&peer),

--- a/src/protocol/protocol_set.rs
+++ b/src/protocol/protocol_set.rs
@@ -88,8 +88,8 @@ pub enum InnerTransportEvent {
         /// Peer ID.
         peer: PeerId,
 
-        /// Dialed address.
-        address: Multiaddr,
+        /// Dialed addresses.
+        addresses: Vec<Multiaddr>,
     },
 
     /// Substream opened for `peer`.
@@ -144,8 +144,8 @@ pub enum InnerTransportEvent {
 impl From<InnerTransportEvent> for TransportEvent {
     fn from(event: InnerTransportEvent) -> Self {
         match event {
-            InnerTransportEvent::DialFailure { peer, address } =>
-                TransportEvent::DialFailure { peer, address },
+            InnerTransportEvent::DialFailure { peer, addresses } =>
+                TransportEvent::DialFailure { peer, addresses },
             InnerTransportEvent::SubstreamOpened {
                 peer,
                 protocol,

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -147,7 +147,7 @@ impl Ord for AddressRecord {
 }
 
 /// Store for peer addresses.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AddressStore {
     /// Addresses available.
     pub addresses: HashMap<Multiaddr, AddressRecord>,

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -100,6 +100,15 @@ impl AddressRecord {
         }
     }
 
+    /// Create `AddressRecord` from `Multiaddr`.
+    ///
+    /// This method does not check if the address contains `PeerId`.
+    ///
+    /// Please consider using [`Self::from_multiaddr`] from the transport manager code.
+    pub fn from_raw_multiaddr_with_score(address: Multiaddr, score: i32) -> AddressRecord {
+        AddressRecord { address, score }
+    }
+
     /// Get address score.
     #[cfg(test)]
     pub fn score(&self) -> i32 {
@@ -138,7 +147,7 @@ impl Ord for AddressRecord {
 }
 
 /// Store for peer addresses.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AddressStore {
     /// Addresses available.
     pub addresses: HashMap<Multiaddr, AddressRecord>,
@@ -206,6 +215,10 @@ impl AddressStore {
     /// Check if [`AddressStore`] is empty.
     pub fn is_empty(&self) -> bool {
         self.addresses.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.addresses.clear();
     }
 
     /// Insert the address record into [`AddressStore`] with the provided score.

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -88,6 +88,18 @@ impl AddressRecord {
         })
     }
 
+    /// Create `AddressRecord` from `Multiaddr`.
+    ///
+    /// This method does not check if the address contains `PeerId`.
+    ///
+    /// Please consider using [`Self::from_multiaddr`] from the transport manager code.
+    pub fn from_raw_multiaddr(address: Multiaddr) -> AddressRecord {
+        AddressRecord {
+            address,
+            score: 0i32,
+        }
+    }
+
     /// Get address score.
     #[cfg(test)]
     pub fn score(&self) -> i32 {

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -1095,7 +1095,7 @@ impl TransportManager {
                                                 );
                                                 match context.tx.try_send(InnerTransportEvent::DialFailure {
                                                     peer,
-                                                    address: address.clone(),
+                                                    addresses: vec![address.clone()],
                                                 }) {
                                                     Ok(()) => {}
                                                     Err(_) => {
@@ -1111,7 +1111,7 @@ impl TransportManager {
                                                             .tx
                                                             .send(InnerTransportEvent::DialFailure {
                                                                 peer,
-                                                                address: address.clone(),
+                                                                addresses: vec![address.clone()],
                                                             })
                                                             .await;
                                                     }
@@ -1237,12 +1237,17 @@ impl TransportManager {
                                         "inform protocols about open failure",
                                     );
 
+                                    let addresses = errors
+                                        .iter()
+                                        .map(|(address, _)| address.clone())
+                                        .collect::<Vec<_>>();
+
                                     for (protocol, context) in &self.protocols {
                                         let _ = match context
                                             .tx
                                             .try_send(InnerTransportEvent::DialFailure {
                                                 peer,
-                                                address: Multiaddr::empty(),
+                                                addresses: addresses.clone(),
                                             }) {
                                             Ok(_) => Ok(()),
                                             Err(_) => {
@@ -1258,7 +1263,7 @@ impl TransportManager {
                                                     .tx
                                                     .send(InnerTransportEvent::DialFailure {
                                                         peer,
-                                                        address: Multiaddr::empty(),
+                                                        addresses: addresses.clone(),
                                                     })
                                                     .await
                                             }

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -60,7 +60,7 @@ use std::{
 pub use handle::{TransportHandle, TransportManagerHandle};
 pub use types::SupportedTransport;
 
-mod address;
+pub(crate) mod address;
 pub mod limits;
 mod peer_state;
 mod types;


### PR DESCRIPTION

This PR improves the robustness of the kademlia addresses stored in the routing table.

The implementation uses an eventually-consistent address store, based on the information provided by the transport manager. This has the benefit of not sharing the transport manager address store with the routing table, therefore not paying for the performance hit of locking the addresses (globally) on kademlia queries.

- transport manager exposes all dialed addresses properly to the installed protocols
- the kademlia peer contains an address store instead of a plain vector (bounded to 32 entries -- please note that the transport manager holds up to 64 entries)
  - similar to the transport manager, the addresses are sorted by score depending on success / failure dials
  - when an address score is negative it is subject to removal
- on successful dial, the score is increased for the address of said peer
- on dial failures, the score of the failed addresses is decreased
- known good addresses are always provided first
- all kademlia queries rely on this information and the addresses are provided sorted by their score

This resolved the following issue, with the mention that undialed or dialed but failed addresses are still provided if the address store has enough capacity. This ensures that addresses that fail due to temporary network errors, or errors specific to our node (ie, behind firewall -- other peers may reach the address) are provided:
- https://github.com/paritytech/litep2p/issues/209

cc @paritytech/networking 
