### PR TITLE
kad: Bound kademlia messages to the replication factor

### DIFF
--- a/src/protocol/libp2p/kademlia/message.rs
+++ b/src/protocol/libp2p/kademlia/message.rs
@@ -240,7 +240,7 @@ impl KademliaMessage {
     }
 
     /// Get [`KademliaMessage`] from bytes.
-    pub fn from_bytes(bytes: BytesMut) -> Option<Self> {
+    pub fn from_bytes(bytes: BytesMut, replication_factor: usize) -> Option<Self> {
         match schema::kademlia::Message::decode(bytes) {
             Ok(message) => match message.r#type {
                 // FIND_NODE
@@ -249,6 +249,7 @@ impl KademliaMessage {
                         .closer_peers
                         .iter()
                         .filter_map(|peer| KademliaPeer::try_from(peer).ok())
+                        .take(replication_factor)
                         .collect();
 
                     Some(Self::FindNode {
@@ -286,6 +287,7 @@ impl KademliaMessage {
                             .closer_peers
                             .iter()
                             .filter_map(|peer| KademliaPeer::try_from(peer).ok())
+                            .take(replication_factor)
                             .collect(),
                     })
                 }
@@ -296,6 +298,7 @@ impl KademliaMessage {
                         .provider_peers
                         .iter()
                         .filter_map(|peer| KademliaPeer::try_from(peer).ok())
+                        .take(replication_factor)
                         .collect();
 
                     Some(Self::AddProvider { key, providers })
@@ -307,11 +310,13 @@ impl KademliaMessage {
                         .closer_peers
                         .iter()
                         .filter_map(|peer| KademliaPeer::try_from(peer).ok())
+                        .take(replication_factor)
                         .collect();
                     let providers = message
                         .provider_peers
                         .iter()
                         .filter_map(|peer| KademliaPeer::try_from(peer).ok())
+                        .take(replication_factor)
                         .collect();
 
                     Some(Self::GetProviders {

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -419,7 +419,9 @@ impl Kademlia {
     ) -> crate::Result<()> {
         tracing::trace!(target: LOG_TARGET, ?peer, query = ?query_id, "handle message from peer");
 
-        match KademliaMessage::from_bytes(message).ok_or(Error::InvalidData)? {
+        match KademliaMessage::from_bytes(message, self.replication_factor)
+            .ok_or(Error::InvalidData)?
+        {
             KademliaMessage::FindNode { target, peers } => {
                 match query_id {
                     Some(query_id) => {


### PR DESCRIPTION
This tiny PR boudns the kademlia peers from over-the-wire messages to the replication factor.

This change is done to align with the kademlia spec