### PR TITLE
manager: Enhance connection lifecycle with custom connection policies

### DIFF
--- a/src/codec/identity.rs
+++ b/src/codec/identity.rs
@@ -103,8 +103,8 @@ mod tests {
         let copy = bytes.clone();
         let mut bytes = BytesMut::from(&bytes[..]);
 
-        let decoded = codec.decode(&mut bytes);
-        assert_eq!(decoded, copy);
+        // The smaller payload will not be decoded as the identity code needs 100 bytes.
+        assert!(codec.decode(&mut bytes).unwrap().is_none());
     }
 
     #[test]

--- a/src/codec/identity.rs
+++ b/src/codec/identity.rs
@@ -100,9 +100,11 @@ mod tests {
     fn decoding_smaller_payloads() {
         let mut codec = Identity::new(100);
         let bytes = vec![3u8; 64];
+        let copy = bytes.clone();
         let mut bytes = BytesMut::from(&bytes[..]);
 
         let decoded = codec.decode(&mut bytes);
+        assert_eq!(decoded, copy);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,8 +29,7 @@ use crate::{
         notification, request_response, UserProtocol,
     },
     transport::{
-        manager::limits::{ConnectionLimitsConfig, ConnectionMiddleware},
-        tcp::config::Config as TcpConfig,
+        manager::limits::ConnectionMiddleware, tcp::config::Config as TcpConfig,
         KEEP_ALIVE_TIMEOUT, MAX_PARALLEL_DIALS,
     },
     types::protocol::ProtocolName,
@@ -120,9 +119,6 @@ pub struct ConfigBuilder {
     /// Maximum number of parallel dial attempts.
     max_parallel_dials: usize,
 
-    /// Connection limits config.
-    connection_limits: ConnectionLimitsConfig,
-
     /// Close the connection if no substreams are open within this time frame.
     keep_alive_timeout: Duration,
 
@@ -159,7 +155,6 @@ impl ConfigBuilder {
             notification_protocols: HashMap::new(),
             request_response_protocols: HashMap::new(),
             known_addresses: Vec::new(),
-            connection_limits: ConnectionLimitsConfig::default(),
             keep_alive_timeout: KEEP_ALIVE_TIMEOUT,
             connection_middleware: None,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,12 +271,7 @@ impl ConfigBuilder {
         self
     }
 
-    /// Set connection limits configuration.
-    pub fn with_connection_limits(mut self, config: ConnectionLimitsConfig) -> Self {
-        self.connection_limits = config;
-        self
-    }
-
+    /// Set connection middleware.
     pub fn with_connection_middleware(mut self, middleware: Box<dyn ConnectionMiddleware>) -> Self {
         self.connection_middleware = Some(middleware);
         self
@@ -315,7 +310,6 @@ impl ConfigBuilder {
             notification_protocols: self.notification_protocols,
             request_response_protocols: self.request_response_protocols,
             known_addresses: self.known_addresses,
-            connection_limits: self.connection_limits,
             keep_alive_timeout: self.keep_alive_timeout,
             connection_middleware: self.connection_middleware.take(),
         }
@@ -374,9 +368,6 @@ pub struct Litep2pConfig {
 
     /// Known addresses.
     pub(crate) known_addresses: Vec<(PeerId, Vec<Multiaddr>)>,
-
-    /// Connection limits config.
-    pub(crate) connection_limits: ConnectionLimitsConfig,
 
     /// Close the connection if no substreams are open within this time frame.
     pub(crate) keep_alive_timeout: Duration,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,6 @@ impl Litep2p {
             supported_transports,
             bandwidth_sink.clone(),
             litep2p_config.max_parallel_dials,
-            litep2p_config.connection_limits,
             litep2p_config.connection_middleware,
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ impl Litep2p {
             bandwidth_sink.clone(),
             litep2p_config.max_parallel_dials,
             litep2p_config.connection_limits,
+            litep2p_config.connection_middleware,
         );
 
         // add known addresses to `TransportManager`, if any exist

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -1230,10 +1230,7 @@ mod tests {
     use crate::{
         codec::ProtocolCodec,
         crypto::ed25519::Keypair,
-        transport::{
-            manager::{limits::ConnectionLimitsConfig, TransportManager},
-            ConnectionLimits, KEEP_ALIVE_TIMEOUT,
-        },
+        transport::{manager::TransportManager, ConnectionLimits, KEEP_ALIVE_TIMEOUT},
         types::protocol::ProtocolName,
         BandwidthSink,
     };

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -1232,7 +1232,7 @@ mod tests {
         crypto::ed25519::Keypair,
         transport::{
             manager::{limits::ConnectionLimitsConfig, TransportManager},
-            KEEP_ALIVE_TIMEOUT,
+            ConnectionLimits, KEEP_ALIVE_TIMEOUT,
         },
         types::protocol::ProtocolName,
         BandwidthSink,
@@ -1251,7 +1251,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         let peer = PeerId::random();

--- a/src/protocol/mdns.rs
+++ b/src/protocol/mdns.rs
@@ -336,7 +336,10 @@ mod tests {
     use super::*;
     use crate::{
         crypto::ed25519::Keypair,
-        transport::manager::{limits::ConnectionLimitsConfig, TransportManager},
+        transport::{
+            manager::{limits::ConnectionLimitsConfig, TransportManager},
+            ConnectionLimits,
+        },
         BandwidthSink,
     };
     use futures::StreamExt;
@@ -354,7 +357,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         let mdns1 = Mdns::new(
@@ -377,7 +380,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         let mdns2 = Mdns::new(

--- a/src/protocol/mdns.rs
+++ b/src/protocol/mdns.rs
@@ -336,10 +336,7 @@ mod tests {
     use super::*;
     use crate::{
         crypto::ed25519::Keypair,
-        transport::{
-            manager::{limits::ConnectionLimitsConfig, TransportManager},
-            ConnectionLimits,
-        },
+        transport::{manager::TransportManager, ConnectionLimits},
         BandwidthSink,
     };
     use futures::StreamExt;

--- a/src/protocol/notification/tests/mod.rs
+++ b/src/protocol/notification/tests/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     transport::{
         manager::{limits::ConnectionLimitsConfig, TransportManager},
-        KEEP_ALIVE_TIMEOUT,
+        ConnectionLimits, KEEP_ALIVE_TIMEOUT,
     },
     types::protocol::ProtocolName,
     BandwidthSink, PeerId,
@@ -56,7 +56,7 @@ fn make_notification_protocol() -> (
         HashSet::new(),
         BandwidthSink::new(),
         8usize,
-        ConnectionLimitsConfig::default(),
+        Some(Box::new(ConnectionLimits::new(Default::default()))),
     );
 
     let peer = PeerId::random();

--- a/src/protocol/notification/tests/mod.rs
+++ b/src/protocol/notification/tests/mod.rs
@@ -29,10 +29,7 @@ use crate::{
         },
         InnerTransportEvent, ProtocolCommand, TransportService,
     },
-    transport::{
-        manager::{limits::ConnectionLimitsConfig, TransportManager},
-        ConnectionLimits, KEEP_ALIVE_TIMEOUT,
-    },
+    transport::{manager::TransportManager, ConnectionLimits, KEEP_ALIVE_TIMEOUT},
     types::protocol::ProtocolName,
     BandwidthSink, PeerId,
 };

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -31,7 +31,7 @@ use crate::{
     substream::Substream,
     transport::{
         manager::{limits::ConnectionLimitsConfig, TransportManager},
-        KEEP_ALIVE_TIMEOUT,
+        ConnectionLimits, KEEP_ALIVE_TIMEOUT,
     },
     types::{RequestId, SubstreamId},
     BandwidthSink, Error, PeerId, ProtocolName,
@@ -54,7 +54,7 @@ fn protocol() -> (
         HashSet::new(),
         BandwidthSink::new(),
         8usize,
-        ConnectionLimitsConfig::default(),
+        Some(Box::new(ConnectionLimits::new(Default::default()))),
     );
 
     let peer = PeerId::random();

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -29,10 +29,7 @@ use crate::{
         InnerTransportEvent, SubstreamError, TransportService,
     },
     substream::Substream,
-    transport::{
-        manager::{limits::ConnectionLimitsConfig, TransportManager},
-        ConnectionLimits, KEEP_ALIVE_TIMEOUT,
-    },
+    transport::{manager::TransportManager, ConnectionLimits, KEEP_ALIVE_TIMEOUT},
     types::{RequestId, SubstreamId},
     BandwidthSink, Error, PeerId, ProtocolName,
 };

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -22,7 +22,7 @@
 
 use crate::{transport::Endpoint, types::ConnectionId, PeerId};
 
-use std::collections::HashSet;
+use std::{collections::HashSet, net::SocketAddr};
 
 /// A middleware trait for implementing connection limits.
 ///
@@ -49,7 +49,11 @@ pub trait ConnectionMiddleware: Send {
     /// At this point, no protocol negotiation has occurred and the peer identity is
     /// unknown. The connection ID provided is the one that will be used for the
     /// connection.
-    fn check_inbound(&mut self, connection_id: ConnectionId) -> crate::Result<()>;
+    fn check_inbound(
+        &mut self,
+        connection_id: ConnectionId,
+        address: SocketAddr,
+    ) -> crate::Result<()>;
 
     /// Verifies if a new connection (inbound or outbound) can be established.
     ///
@@ -157,7 +161,11 @@ impl ConnectionMiddleware for ConnectionLimits {
         Ok(usize::MAX)
     }
 
-    fn check_inbound(&mut self, _connection_id: ConnectionId) -> crate::Result<()> {
+    fn check_inbound(
+        &mut self,
+        _connection_id: ConnectionId,
+        _address: SocketAddr,
+    ) -> crate::Result<()> {
         if let Some(max_incoming_connections) = self.config.max_incoming_connections {
             if self.incoming_connections.len() >= max_incoming_connections {
                 return Err(ConnectionLimitsError::MaxIncomingConnectionsExceeded.into());

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -206,6 +206,28 @@ impl ConnectionLimits {
     }
 }
 
+impl ConnectionMiddleware for ConnectionLimits {
+    fn outbound_capacity(&mut self) -> crate::Result<usize> {
+        self.on_dial_address().map_err(Into::into)
+    }
+
+    fn check_inbound(&mut self) -> crate::Result<()> {
+        self.on_incoming().map_err(Into::into)
+    }
+
+    fn can_accept_connection(&mut self, _peer: PeerId, endpoint: &Endpoint) -> crate::Result<()> {
+        self.can_accept_connection(endpoint.is_listener()).map_err(Into::into)
+    }
+
+    fn on_connection_established(&mut self, _peer: PeerId, endpoint: &Endpoint) {
+        self.accept_established_connection(endpoint.connection_id(), endpoint.is_listener());
+    }
+
+    fn on_connection_closed(&mut self, _peer: PeerId, connection_id: ConnectionId) {
+        self.on_connection_closed(connection_id);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -102,14 +102,14 @@ pub trait ConnectionMiddleware: Send {
 
     /// Registers a connection as established.
     ///
-    /// This method will be called after a successful check using [`Self::check_connection`].
+    /// This method will be called after a successful check using [`Self::can_accept_connection`].
     /// The peer ID and endpoint are provided to identify the connection and are identical
     /// to the ones used in [`Self::can_accept_connection`].
     fn on_connection_established(&mut self, peer: PeerId, endpoint: &Endpoint);
 
     /// Deregisters a connection when it is closed.
     ///
-    /// This method will be called after a [`Self::register_connection`] call.
+    /// This method will be called after a [`Self::on_connection_established`] call.
     /// The connection ID corresponds the endpoint provided in the
     /// [`Self::on_connection_established`] method.
     fn on_connection_closed(&mut self, peer: PeerId, connection_id: ConnectionId);

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -40,14 +40,10 @@ pub trait ConnectionMiddleware: Send {
     /// Returns the number of allowed outbound connections.
     /// If there is no limit, returns `Ok(usize::MAX)`.
     /// If the node cannot accept any more outbound connections, returns an error.
-    fn outbound_capacity(&mut self) -> crate::Result<usize> {
-        Ok(usize::MAX)
-    }
+    fn outbound_capacity(&mut self) -> crate::Result<usize>;
 
     /// Checks whether a new inbound connection can be accepted before processing it.
-    fn check_inbound(&mut self) -> crate::Result<()> {
-        Ok(())
-    }
+    fn check_inbound(&mut self, connection_id: ConnectionId) -> crate::Result<()>;
 
     /// Verifies if a new connection (inbound or outbound) can be established.
     ///
@@ -155,7 +151,7 @@ impl ConnectionMiddleware for ConnectionLimits {
         Ok(usize::MAX)
     }
 
-    fn check_inbound(&mut self) -> crate::Result<()> {
+    fn check_inbound(&mut self, _connection_id: ConnectionId) -> crate::Result<()> {
         if let Some(max_incoming_connections) = self.config.max_incoming_connections {
             if self.incoming_connections.len() >= max_incoming_connections {
                 return Err(ConnectionLimitsError::MaxIncomingConnectionsExceeded.into());

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -217,46 +217,66 @@ mod tests {
         let connection_id_in_3 = ConnectionId::random();
 
         // Establish incoming connection.
-        assert!(limits.can_accept_connection(true).is_ok());
-        limits.accept_established_connection(connection_id_in_1, true);
+        let endpoint = Endpoint::Listener {
+            address: Default::default(),
+            connection_id: connection_id_in_1,
+        };
+        assert!(limits.can_accept_connection(PeerId::random(), &endpoint).is_ok());
+        limits.on_connection_established(PeerId::random(), &endpoint);
         assert_eq!(limits.incoming_connections.len(), 1);
 
-        assert!(limits.can_accept_connection(true).is_ok());
-        limits.accept_established_connection(connection_id_in_2, true);
+        let endpoint = Endpoint::Listener {
+            address: Default::default(),
+            connection_id: connection_id_in_2,
+        };
+        assert!(limits.can_accept_connection(PeerId::random(), &endpoint).is_ok());
+        limits.on_connection_established(PeerId::random(), &endpoint);
         assert_eq!(limits.incoming_connections.len(), 2);
 
-        assert!(limits.can_accept_connection(true).is_ok());
-        limits.accept_established_connection(connection_id_in_3, true);
+        let endpoint = Endpoint::Listener {
+            address: Default::default(),
+            connection_id: connection_id_in_3,
+        };
+        assert!(limits.can_accept_connection(PeerId::random(), &endpoint).is_ok());
+        limits.on_connection_established(PeerId::random(), &endpoint);
         assert_eq!(limits.incoming_connections.len(), 3);
 
         assert_eq!(
-            limits.can_accept_connection(true).unwrap_err(),
+            limits.can_accept_connection(PeerId::random(), &endpoint).unwrap_err(),
             ConnectionLimitsError::MaxIncomingConnectionsExceeded
         );
         assert_eq!(limits.incoming_connections.len(), 3);
 
         // Establish outgoing connection.
-        assert!(limits.can_accept_connection(false).is_ok());
-        limits.accept_established_connection(connection_id_out_1, false);
+        let endpoint = Endpoint::Dialer {
+            address: Default::default(),
+            connection_id: connection_id_out_1,
+        };
+        assert!(limits.can_accept_connection(PeerId::random(), &endpoint).is_ok());
+        limits.accept_established_connection(PeerId::random(), &endpoint);
         assert_eq!(limits.incoming_connections.len(), 3);
         assert_eq!(limits.outgoing_connections.len(), 1);
 
-        assert!(limits.can_accept_connection(false).is_ok());
-        limits.accept_established_connection(connection_id_out_2, false);
+        let endpoint = Endpoint::Dialer {
+            address: Default::default(),
+            connection_id: connection_id_out_2,
+        };
+        assert!(limits.can_accept_connection(PeerId::random(), &endpoint).is_ok());
+        limits.accept_established_connection(PeerId::random(), &endpoint);
         assert_eq!(limits.incoming_connections.len(), 3);
         assert_eq!(limits.outgoing_connections.len(), 2);
 
         assert_eq!(
-            limits.can_accept_connection(false).unwrap_err(),
+            limits.can_accept_connection(PeerId::random(), &endpoint).unwrap_err(),
             ConnectionLimitsError::MaxOutgoingConnectionsExceeded
         );
 
-        // Close connections with peer a.
-        limits.on_connection_closed(connection_id_in_1);
+        // Close connections with 1.
+        limits.on_connection_closed(PeerId::random(), connection_id_in_1);
         assert_eq!(limits.incoming_connections.len(), 2);
         assert_eq!(limits.outgoing_connections.len(), 2);
 
-        limits.on_connection_closed(connection_id_out_1);
+        limits.on_connection_closed(PeerId::random(), connection_id_out_1);
         assert_eq!(limits.incoming_connections.len(), 2);
         assert_eq!(limits.outgoing_connections.len(), 1);
     }

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -45,6 +45,10 @@ pub trait ConnectionMiddleware: Send {
     fn outbound_capacity(&mut self, peer: PeerId) -> crate::Result<usize>;
 
     /// Checks whether a new inbound connection can be accepted before processing it.
+    ///
+    /// At this point, no protocol negotiation has occurred and the peer identity is
+    /// unknown. The connection ID provided is the one that will be used for the
+    /// connection.
     fn check_inbound(&mut self, connection_id: ConnectionId) -> crate::Result<()>;
 
     /// Verifies if a new connection (inbound or outbound) can be established.

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -25,16 +25,29 @@ use crate::{transport::Endpoint, types::ConnectionId, PeerId};
 use std::collections::HashSet;
 
 /// A middleware trait for implementing connection limits.
+///
+/// The middleware interacts with the transport manager at two entry points:
+/// - before the connection is negotiated via [`Self::outbound_capacity`] and
+///   [`Self::check_inbound`]
+/// - after the connection is established via [`Self::can_accept_connection`],
+///   [`Self::on_connection_established`]  and [`Self::on_connection_closed`].
+///
+/// Returning an error from any of the methods will prevent the connection from being
+/// accepted by the transport manager.
 pub trait ConnectionMiddleware {
     /// Determines the number of outbound connections permitted to be established.
     ///
-    /// Returns the number of allowed outbound connections. If there is no limit,
-    /// returns `Ok(usize::MAX)`. If the node cannot accept any more outbound
-    /// connections, returns an error.
-    fn outbound_capacity(&mut self) -> crate::Result<usize>;
+    /// Returns the number of allowed outbound connections.
+    /// If there is no limit, returns `Ok(usize::MAX)`.
+    /// If the node cannot accept any more outbound connections, returns an error.
+    fn outbound_capacity(&mut self) -> crate::Result<usize> {
+        Ok(usize::MAX)
+    }
 
     /// Checks whether a new inbound connection can be accepted before processing it.
-    fn check_inbound(&mut self) -> crate::Result<()>;
+    fn check_inbound(&mut self) -> crate::Result<()> {
+        Ok(())
+    }
 
     /// Verifies if a new connection (inbound or outbound) can be established.
     ///

--- a/src/transport/manager/limits.rs
+++ b/src/transport/manager/limits.rs
@@ -279,11 +279,7 @@ mod tests {
         limits.on_connection_established(PeerId::random(), &endpoint);
         assert_eq!(limits.incoming_connections.len(), 3);
 
-        let err = limits.can_accept_connection(PeerId::random(), &endpoint).unwrap_err();
-        // assert_eq!(
-        //     limits.can_accept_connection(PeerId::random(), &endpoint).unwrap_err(),
-        //     ConnectionLimitsError::MaxIncomingConnectionsExceeded.into(),
-        // );
+        assert!(limits.can_accept_connection(PeerId::random(), &endpoint).is_err());
         assert_eq!(limits.incoming_connections.len(), 3);
 
         // Establish outgoing connection.
@@ -304,12 +300,7 @@ mod tests {
         limits.on_connection_established(PeerId::random(), &endpoint);
         assert_eq!(limits.incoming_connections.len(), 3);
         assert_eq!(limits.outgoing_connections.len(), 2);
-
-        let err = limits.can_accept_connection(PeerId::random(), &endpoint).unwrap_err();
-        // assert_eq!(
-        //     limits.can_accept_connection(PeerId::random(), &endpoint).unwrap_err(),
-        //     ConnectionLimitsError::MaxOutgoingConnectionsExceeded.into(),
-        // );
+        assert!(limits.can_accept_connection(PeerId::random(), &endpoint).is_err());
 
         // Close connections with 1.
         limits.on_connection_closed(PeerId::random(), connection_id_in_1);

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -49,6 +49,7 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use std::{
     collections::{HashMap, HashSet},
+    net::SocketAddr,
     pin::Pin,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -693,9 +694,13 @@ impl TransportManager {
         Ok(())
     }
 
-    fn on_pending_incoming_connection(&mut self, connection_id: ConnectionId) -> crate::Result<()> {
+    fn on_pending_incoming_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        address: SocketAddr,
+    ) -> crate::Result<()> {
         if let Some(middleware) = &mut self.connection_middleware {
-            middleware.check_inbound(connection_id)?;
+            middleware.check_inbound(connection_id, address)?;
         }
 
         Ok(())
@@ -1299,8 +1304,8 @@ impl TransportManager {
                                 }
                             }
                         },
-                        TransportEvent::PendingInboundConnection { connection_id, .. } => {
-                            if self.on_pending_incoming_connection(connection_id).is_ok() {
+                        TransportEvent::PendingInboundConnection { connection_id, address } => {
+                            if self.on_pending_incoming_connection(connection_id, address).is_ok() {
                                 tracing::trace!(
                                     target: LOG_TARGET,
                                     ?connection_id,

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -690,9 +690,9 @@ impl TransportManager {
         Ok(())
     }
 
-    fn on_pending_incoming_connection(&mut self) -> crate::Result<()> {
+    fn on_pending_incoming_connection(&mut self, connection_id: ConnectionId) -> crate::Result<()> {
         if let Some(middleware) = &mut self.connection_middleware {
-            middleware.check_inbound()?;
+            middleware.check_inbound(connection_id)?;
         }
 
         Ok(())
@@ -1297,7 +1297,7 @@ impl TransportManager {
                             }
                         },
                         TransportEvent::PendingInboundConnection { connection_id } => {
-                            if self.on_pending_incoming_connection().is_ok() {
+                            if self.on_pending_incoming_connection(connection_id).is_ok() {
                                 tracing::trace!(
                                     target: LOG_TARGET,
                                     ?connection_id,

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -1334,7 +1334,7 @@ impl TransportManager {
 #[cfg(test)]
 mod tests {
     use crate::transport::manager::{address::AddressStore, peer_state::SecondaryOrDialing};
-    use limits::ConnectionLimitsConfig;
+    use limits::{ConnectionLimits, ConnectionLimitsConfig};
 
     use multihash::Multihash;
 
@@ -1521,7 +1521,7 @@ mod tests {
             HashSet::new(),
             sink,
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         manager.register_protocol(
@@ -1548,7 +1548,7 @@ mod tests {
             HashSet::new(),
             sink,
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         manager.register_protocol(
@@ -1578,7 +1578,7 @@ mod tests {
             HashSet::new(),
             sink,
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         manager.register_protocol(
@@ -1611,7 +1611,7 @@ mod tests {
             HashSet::new(),
             sink,
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1628,7 +1628,7 @@ mod tests {
             HashSet::new(),
             sink,
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         assert!(manager.dial(local_peer_id).await.is_err());
@@ -1641,7 +1641,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1671,7 +1671,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -1733,7 +1733,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1764,7 +1764,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1809,7 +1809,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1828,7 +1828,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1861,7 +1861,7 @@ mod tests {
             transports,
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         // ipv6
@@ -1923,7 +1923,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1990,7 +1990,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -2077,7 +2077,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -2162,7 +2162,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2271,7 +2271,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2367,7 +2367,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2476,7 +2476,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2580,7 +2580,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2724,7 +2724,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         manager.on_dial_failure(ConnectionId::random()).unwrap();
@@ -2743,7 +2743,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         manager.on_connection_closed(PeerId::random(), ConnectionId::random()).unwrap();
     }
@@ -2761,7 +2761,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         manager
             .on_connection_opened(
@@ -2785,7 +2785,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2809,7 +2809,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2836,7 +2836,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         manager
@@ -2857,7 +2857,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2877,7 +2877,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         assert!(manager.next().await.is_none());
@@ -2890,7 +2890,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         let peer = {
@@ -2938,7 +2938,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         let peer = {
@@ -3001,7 +3001,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         let peer = {
@@ -3044,7 +3044,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         // transport doesn't start with ip/dns
@@ -3110,7 +3110,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
 
         async fn call_manager(manager: &mut TransportManager, address: Multiaddr) {
@@ -3164,7 +3164,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -3250,7 +3250,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -3338,9 +3338,11 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default()
-                .max_incoming_connections(Some(3))
-                .max_outgoing_connections(Some(2)),
+            Some(Box::new(ConnectionLimits::new(
+                ConnectionLimitsConfig::default()
+                    .max_incoming_connections(Some(3))
+                    .max_outgoing_connections(Some(2)),
+            ))),
         );
         // The connection limit is agnostic of the underlying transports.
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -3414,9 +3416,11 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default()
-                .max_incoming_connections(Some(3))
-                .max_outgoing_connections(Some(2)),
+            Some(Box::new(ConnectionLimits::new(
+                ConnectionLimitsConfig::default()
+                    .max_incoming_connections(Some(3))
+                    .max_outgoing_connections(Some(2)),
+            ))),
         );
         // The connection limit is agnostic of the underlying transports.
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -3503,7 +3507,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -3556,7 +3560,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -3708,7 +3712,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -3794,7 +3798,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            Some(Box::new(ConnectionLimits::new(Default::default()))),
         );
         let peer = PeerId::random();
         let connection_id = ConnectionId::from(0);

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -1299,7 +1299,7 @@ impl TransportManager {
                                 }
                             }
                         },
-                        TransportEvent::PendingInboundConnection { connection_id } => {
+                        TransportEvent::PendingInboundConnection { connection_id, .. } => {
                             if self.on_pending_incoming_connection(connection_id).is_ok() {
                                 tracing::trace!(
                                     target: LOG_TARGET,

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -443,7 +443,7 @@ impl TransportManager {
     pub async fn dial(&mut self, peer: PeerId) -> crate::Result<()> {
         // Don't alter the peer state if there's no capacity to dial.
         let available_capacity = if let Some(middleware) = &mut self.connection_middleware {
-            middleware.outbound_capacity()?
+            middleware.outbound_capacity(peer)?
         } else {
             usize::MAX
         };
@@ -521,7 +521,10 @@ impl TransportManager {
     /// Returns an error if address it not valid.
     pub async fn dial_address(&mut self, address: Multiaddr) -> crate::Result<()> {
         if let Some(middleware) = &mut self.connection_middleware {
-            middleware.outbound_capacity()?;
+            let peer = PeerId::try_from_multiaddr(&address)
+                .ok_or(Error::AddressError(AddressError::PeerIdMissing))?;
+
+            middleware.outbound_capacity(peer)?;
         }
 
         let address_record = AddressRecord::from_multiaddr(address)

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -41,6 +41,7 @@ use crate::{
 use address::{scores, AddressStore};
 use futures::{Stream, StreamExt};
 use indexmap::IndexMap;
+use limits::ConnectionMiddleware;
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
 use parking_lot::RwLock;
@@ -252,6 +253,9 @@ pub struct TransportManager {
 
     /// Opening connections errors.
     opening_errors: HashMap<ConnectionId, Vec<(Multiaddr, DialError)>>,
+
+    /// Connection middleware.
+    connection_middleware: Option<Box<dyn ConnectionMiddleware>>,
 }
 
 impl TransportManager {
@@ -263,6 +267,7 @@ impl TransportManager {
         bandwidth_sink: BandwidthSink,
         max_parallel_dials: usize,
         connection_limits_config: limits::ConnectionLimitsConfig,
+        connection_middleware: Option<Box<dyn ConnectionMiddleware>>,
     ) -> (Self, TransportManagerHandle) {
         let local_peer_id = PeerId::from_public_key(&keypair.public().into());
         let peers = Arc::new(RwLock::new(HashMap::new()));
@@ -300,6 +305,7 @@ impl TransportManager {
                 next_connection_id: Arc::new(AtomicUsize::new(0usize)),
                 connection_limits: limits::ConnectionLimits::new(connection_limits_config),
                 opening_errors: HashMap::new(),
+                connection_middleware,
             },
             handle,
         )

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -1345,6 +1345,7 @@ mod tests {
     use limits::{ConnectionLimits, ConnectionLimitsConfig};
 
     use multihash::Multihash;
+    use std::net::IpAddr;
 
     use super::*;
     use crate::{
@@ -1452,6 +1453,7 @@ mod tests {
         tx_ws
             .send(TransportEvent::PendingInboundConnection {
                 connection_id: ConnectionId::from(1),
+                address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
             })
             .await
             .expect("chanel to be open");
@@ -1470,6 +1472,7 @@ mod tests {
         tx_tcp
             .send(TransportEvent::PendingInboundConnection {
                 connection_id: ConnectionId::from(2),
+                address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
             })
             .await
             .expect("chanel to be open");
@@ -1488,12 +1491,14 @@ mod tests {
         tx_ws
             .send(TransportEvent::PendingInboundConnection {
                 connection_id: ConnectionId::from(3),
+                address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
             })
             .await
             .expect("chanel to be open");
         tx_tcp
             .send(TransportEvent::PendingInboundConnection {
                 connection_id: ConnectionId::from(4),
+                address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
             })
             .await
             .expect("chanel to be open");

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -25,7 +25,7 @@ use crate::{error::DialError, transport::manager::TransportHandle, types::Connec
 use futures::Stream;
 use multiaddr::Multiaddr;
 
-use std::{fmt::Debug, time::Duration};
+use std::{fmt::Debug, net::SocketAddr, time::Duration};
 
 pub(crate) mod common;
 #[cfg(feature = "quic")]
@@ -131,6 +131,9 @@ pub(crate) enum TransportEvent {
     PendingInboundConnection {
         /// Connection ID.
         connection_id: ConnectionId,
+
+        /// The socket address which initiated the connection.
+        address: SocketAddr,
     },
 
     /// Connection opened to remote but not yet negotiated.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -39,7 +39,9 @@ pub mod websocket;
 pub(crate) mod dummy;
 pub(crate) mod manager;
 
-pub use manager::limits::{ConnectionLimitsConfig, ConnectionLimitsError};
+pub use manager::limits::{
+    ConnectionLimits, ConnectionLimitsConfig, ConnectionLimitsError, ConnectionMiddleware,
+};
 
 /// Timeout for opening a connection.
 pub(crate) const CONNECTION_OPEN_TIMEOUT: Duration = Duration::from_secs(10);

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -501,6 +501,7 @@ impl Stream for QuicTransport {
 
             return Poll::Ready(Some(TransportEvent::PendingInboundConnection {
                 connection_id,
+                address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
             }));
         }
 

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -660,7 +660,7 @@ mod tests {
 
         let event = transport1.next().await.unwrap();
         match event {
-            TransportEvent::PendingInboundConnection { connection_id } => {
+            TransportEvent::PendingInboundConnection { connection_id, .. } => {
                 transport1.accept_pending(connection_id).unwrap();
             }
             _ => panic!("unexpected event"),

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -685,9 +685,7 @@ mod tests {
         codec::ProtocolCodec,
         crypto::ed25519::Keypair,
         executor::DefaultExecutor,
-        transport::manager::{
-            limits::ConnectionLimitsConfig, ProtocolContext, SupportedTransport, TransportManager,
-        },
+        transport::manager::{ProtocolContext, SupportedTransport, TransportManager},
         types::protocol::ProtocolName,
         BandwidthSink, PeerId,
     };

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -979,7 +979,7 @@ mod tests {
             HashSet::new(),
             BandwidthSink::new(),
             8usize,
-            ConnectionLimitsConfig::default(),
+            None,
         );
         let handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -579,6 +579,7 @@ impl Stream for TcpTransport {
 
                     Poll::Ready(Some(TransportEvent::PendingInboundConnection {
                         connection_id,
+                        address,
                     }))
                 }
             };

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -770,7 +770,7 @@ mod tests {
 
         let event = transport1.next().await.unwrap();
         match event {
-            TransportEvent::PendingInboundConnection { connection_id } => {
+            TransportEvent::PendingInboundConnection { connection_id, .. } => {
                 transport1.accept_pending(connection_id).unwrap();
             }
             _ => panic!("unexpected event"),
@@ -864,7 +864,7 @@ mod tests {
         // Reject connection.
         let event = transport1.next().await.unwrap();
         match event {
-            TransportEvent::PendingInboundConnection { connection_id } => {
+            TransportEvent::PendingInboundConnection { connection_id, .. } => {
                 transport1.reject_pending(connection_id).unwrap();
             }
             _ => panic!("unexpected event"),

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -625,6 +625,7 @@ impl Stream for WebSocketTransport {
 
                     Poll::Ready(Some(TransportEvent::PendingInboundConnection {
                         connection_id,
+                        address,
                     }))
                 }
             };


### PR DESCRIPTION
This PR makes the litep2p more generic wrt implementing custom connection limits and policies.

- the `ConnectionMiddleware` trait is introduced to offer the ability for developers to implement custom connection policies that hook directly into the connection lifecycle
- the trait offers the ability to reject connections before or after the negotiation process
- the `ConnectionLimits` object is refactored to implement the middleware trait
- the `TransportEvent::PendingInboundConnection`  is enhanced with the socket address of the remote endpoint



A new middleware trait, named  `ConnectionMiddleware` is introduced:

```rust
pub trait ConnectionMiddleware: Send {
   fn outbound_capacity(&mut self, peer: PeerId) -> crate::Result<usize>;

    fn check_inbound(
        &mut self,
        connection_id: ConnectionId,
        address: SocketAddr,
    ) -> crate::Result<()>;

    fn can_accept_connection(&mut self, peer: PeerId, endpoint: &Endpoint) -> crate::Result<()>;

    fn on_connection_established(&mut self, peer: PeerId, endpoint: &Endpoint);

    fn on_connection_closed(&mut self, peer: PeerId, connection_id: ConnectionId);
}
```

cc @paritytech/networking 