### PR TITLE
crypto/noise: Set timeout limits for the noise handshake

### DIFF
--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -709,62 +709,71 @@ pub async fn handshake<S: AsyncRead + AsyncWrite + Unpin>(
     role: Role,
     max_read_ahead_factor: usize,
     max_write_buffer_size: usize,
+    timeout: std::time::Duration,
 ) -> Result<(NoiseSocket<S>, PeerId), NegotiationError> {
-    tracing::debug!(target: LOG_TARGET, ?role, "start noise handshake");
+    let handle_handshake = async move {
+        tracing::debug!(target: LOG_TARGET, ?role, "start noise handshake");
 
-    let mut noise = NoiseContext::new(keypair, role)?;
-    let payload = match role {
-        Role::Dialer => {
-            // write initial message
-            let first_message = noise.first_message(Role::Dialer)?;
-            let _ = io.write(&first_message).await?;
-            io.flush().await?;
+        let mut noise = NoiseContext::new(keypair, role)?;
+        let payload = match role {
+            Role::Dialer => {
+                // write initial message
+                let first_message = noise.first_message(Role::Dialer)?;
+                let _ = io.write(&first_message).await?;
+                io.flush().await?;
 
-            // read back response which contains the remote peer id
-            let message = noise.read_handshake_message(&mut io).await?;
-            // Decode the remote identity message.
-            let payload = handshake_schema::NoiseHandshakePayload::decode(message)
+                // read back response which contains the remote peer id
+                let message = noise.read_handshake_message(&mut io).await?;
+                // Decode the remote identity message.
+                let payload = handshake_schema::NoiseHandshakePayload::decode(message)
                 .map_err(ParseError::from)
                 .map_err(|err| {
                     tracing::error!(target: LOG_TARGET, ?err, "failed to decode remote identity message");
                     err
                 })?;
 
-            // send the final message which contains local peer id
-            let second_message = noise.second_message()?;
-            let _ = io.write(&second_message).await?;
-            io.flush().await?;
+                // send the final message which contains local peer id
+                let second_message = noise.second_message()?;
+                let _ = io.write(&second_message).await?;
+                io.flush().await?;
 
-            payload
-        }
-        Role::Listener => {
-            // read remote's first message
-            let _ = noise.read_handshake_message(&mut io).await?;
+                payload
+            }
+            Role::Listener => {
+                // read remote's first message
+                let _ = noise.read_handshake_message(&mut io).await?;
 
-            // send local peer id.
-            let second_message = noise.second_message()?;
-            let _ = io.write(&second_message).await?;
-            io.flush().await?;
+                // send local peer id.
+                let second_message = noise.second_message()?;
+                let _ = io.write(&second_message).await?;
+                io.flush().await?;
 
-            // read remote's second message which contains their peer id
-            let message = noise.read_handshake_message(&mut io).await?;
-            // Decode the remote identity message.
-            handshake_schema::NoiseHandshakePayload::decode(message).map_err(ParseError::from)?
-        }
+                // read remote's second message which contains their peer id
+                let message = noise.read_handshake_message(&mut io).await?;
+                // Decode the remote identity message.
+                handshake_schema::NoiseHandshakePayload::decode(message)
+                    .map_err(ParseError::from)?
+            }
+        };
+
+        let dh_remote_pubkey = noise.get_handshake_dh_remote_pubkey()?;
+        let peer = parse_and_verify_peer_id(payload, dh_remote_pubkey)?;
+
+        Ok((
+            NoiseSocket::new(
+                io,
+                noise.into_transport()?,
+                max_read_ahead_factor,
+                max_write_buffer_size,
+            ),
+            peer,
+        ))
     };
 
-    let dh_remote_pubkey = noise.get_handshake_dh_remote_pubkey()?;
-    let peer = parse_and_verify_peer_id(payload, dh_remote_pubkey)?;
-
-    Ok((
-        NoiseSocket::new(
-            io,
-            noise.into_transport()?,
-            max_read_ahead_factor,
-            max_write_buffer_size,
-        ),
-        peer,
-    ))
+    match tokio::time::timeout(timeout, handle_handshake).await {
+        Err(_) => Err(NegotiationError::Timeout),
+        Ok(result) => result,
+    }
 }
 
 // TODO: https://github.com/paritytech/litep2p/issues/125 add more tests

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -817,14 +817,16 @@ mod tests {
                 &keypair1,
                 Role::Dialer,
                 MAX_READ_AHEAD_FACTOR,
-                MAX_WRITE_BUFFER_SIZE
+                MAX_WRITE_BUFFER_SIZE,
+                std::time::Duration::from_secs(10),
             ),
             handshake(
                 io2,
                 &keypair2,
                 Role::Listener,
                 MAX_READ_AHEAD_FACTOR,
-                MAX_WRITE_BUFFER_SIZE
+                MAX_WRITE_BUFFER_SIZE,
+                std::time::Duration::from_secs(10),
             )
         );
         let (mut res1, mut res2) = (res1.unwrap(), res2.unwrap());

--- a/src/transport/tcp/connection.rs
+++ b/src/transport/tcp/connection.rs
@@ -437,6 +437,7 @@ impl TcpConnection {
             role,
             max_read_ahead_factor,
             max_write_buffer_size,
+            substream_open_timeout,
         )
         .await?;
 

--- a/src/transport/tcp/connection.rs
+++ b/src/transport/tcp/connection.rs
@@ -1147,8 +1147,16 @@ mod tests {
             let keypair = Keypair::generate();
 
             // do a noise handshake
-            let (stream, _peer) =
-                noise::handshake(stream.inner(), &keypair, Role::Dialer, 5, 2).await.unwrap();
+            let (stream, _peer) = noise::handshake(
+                stream.inner(),
+                &keypair,
+                Role::Dialer,
+                5,
+                2,
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
             let stream: NoiseSocket<Compat<TcpStream>> = stream;
 
             // after the handshake, try to negotiate some random protocol instead of yamux
@@ -1197,8 +1205,16 @@ mod tests {
 
             // do a noise handshake
             let keypair = Keypair::generate();
-            let (stream, _peer) =
-                noise::handshake(stream.inner(), &keypair, Role::Listener, 5, 2).await.unwrap();
+            let (stream, _peer) = noise::handshake(
+                stream.inner(),
+                &keypair,
+                Role::Listener,
+                5,
+                2,
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
             let stream: NoiseSocket<Compat<TcpStream>> = stream;
 
             // after the handshake, try to negotiate some random protocol instead of yamux
@@ -1263,8 +1279,16 @@ mod tests {
 
             // do a noise handshake
             let keypair = Keypair::generate();
-            let (stream, _peer) =
-                noise::handshake(stream.inner(), &keypair, Role::Dialer, 5, 2).await.unwrap();
+            let (stream, _peer) = noise::handshake(
+                stream.inner(),
+                &keypair,
+                Role::Dialer,
+                5,
+                2,
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
             let _stream: NoiseSocket<Compat<TcpStream>> = stream;
 
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;
@@ -1308,8 +1332,16 @@ mod tests {
 
             // do a noise handshake
             let keypair = Keypair::generate();
-            let (stream, _peer) =
-                noise::handshake(stream.inner(), &keypair, Role::Listener, 5, 2).await.unwrap();
+            let (stream, _peer) = noise::handshake(
+                stream.inner(),
+                &keypair,
+                Role::Listener,
+                5,
+                2,
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
             let _stream: NoiseSocket<Compat<TcpStream>> = stream;
 
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;

--- a/src/transport/websocket/mod.rs
+++ b/src/transport/websocket/mod.rs
@@ -147,6 +147,7 @@ impl WebSocketTransport {
         let connection_open_timeout = self.config.connection_open_timeout;
         let max_read_ahead_factor = self.config.noise_read_ahead_frame_count;
         let max_write_buffer_size = self.config.noise_write_buffer_size;
+        let substream_open_timeout = self.config.substream_open_timeout;
         let address = Multiaddr::empty()
             .with(Protocol::from(address.ip()))
             .with(Protocol::Tcp(address.port()))
@@ -162,6 +163,7 @@ impl WebSocketTransport {
                     yamux_config,
                     max_read_ahead_factor,
                     max_write_buffer_size,
+                    substream_open_timeout,
                 )
                 .await
                 .map_err(|error| (connection_id, error.into()))
@@ -342,6 +344,7 @@ impl Transport for WebSocketTransport {
         let connection_open_timeout = self.config.connection_open_timeout;
         let max_read_ahead_factor = self.config.noise_read_ahead_frame_count;
         let max_write_buffer_size = self.config.noise_write_buffer_size;
+        let substream_open_timeout = self.config.substream_open_timeout;
         let dial_addresses = self.dial_addresses.clone();
         let nodelay = self.config.nodelay;
 
@@ -369,6 +372,7 @@ impl Transport for WebSocketTransport {
                 yamux_config,
                 max_read_ahead_factor,
                 max_write_buffer_size,
+                substream_open_timeout,
             )
             .await
             .map_err(|error| (connection_id, error.into()))
@@ -536,6 +540,7 @@ impl Transport for WebSocketTransport {
         let max_read_ahead_factor = self.config.noise_read_ahead_frame_count;
         let max_write_buffer_size = self.config.noise_write_buffer_size;
         let connection_open_timeout = self.config.connection_open_timeout;
+        let substream_open_timeout = self.config.substream_open_timeout;
         let keypair = self.context.keypair.clone();
 
         tracing::trace!(
@@ -559,6 +564,7 @@ impl Transport for WebSocketTransport {
                     yamux_config,
                     max_read_ahead_factor,
                     max_write_buffer_size,
+                    substream_open_timeout,
                 )
                 .await
                 .map_err(|error| (connection_id, error.into()))

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -34,6 +34,7 @@ use std::{
 const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
 /// Send state.
+#[derive(Debug)]
 enum State {
     /// State is poisoned.
     Poisoned,
@@ -46,6 +47,7 @@ enum State {
 }
 
 /// Buffered stream which implements `AsyncRead + AsyncWrite`
+#[derive(Debug)]
 pub(super) struct BufferedStream<S: AsyncRead + AsyncWrite + Unpin> {
     /// Write buffer.
     write_buffer: BytesMut,
@@ -124,7 +126,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncWrite for BufferedStream<S
                         Poll::Ready(Err(_error)) =>
                             return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into())),
                         Poll::Pending => {
-                            self.state = State::ReadyToSend;
+                            self.state = State::FlushPending;
                             return Poll::Pending;
                         }
                     }

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -762,7 +762,7 @@ async fn simultaneous_dial_ipv6_quic() {
     }
 }
 
-#[cfg(feature = "webscocket")]
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn websocket_over_ipv6() {
     let _ = tracing_subscriber::fmt()

--- a/tests/protocol/request_response.rs
+++ b/tests/protocol/request_response.rs
@@ -36,7 +36,6 @@ use litep2p::transport::websocket::config::Config as WebSocketConfig;
 use futures::{channel, StreamExt};
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
-use rand::{Rng, SeedableRng};
 use tokio::time::sleep;
 
 #[cfg(feature = "quic")]


### PR DESCRIPTION
This PR sets timeout limits for the crypto/noise handshake negotiation.

By default, the timeout is bounded similar to protocol negotiation to the substream open timeout.

To allow this change, the WebSocket internal API has been opened to accept the open timeout. Before this change, we had no granular control and used the connection timeout as a fallback.

cc @paritytech/networking 