### PR TITLE
websocket/stream: Fix state reset and backport connection tests

### DIFF
--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -1215,4 +1215,76 @@ mod tests {
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn yamux_timeout_dialer() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+
+        let listener = TcpListener::bind("[::1]:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let (Ok(mut dialer), Ok((stream, dialer_address))) =
+            tokio::join!(TcpStream::connect(address.clone()), listener.accept(),)
+        else {
+            panic!("failed to establish connection");
+        };
+
+        let peer_id = PeerId::random();
+        let dialer_address = Multiaddr::empty()
+            .with(Protocol::from(dialer_address.ip()))
+            .with(Protocol::Tcp(dialer_address.port()))
+            .with(Protocol::Ws(std::borrow::Cow::Borrowed("/")))
+            .with(Protocol::P2p(peer_id.into()));
+
+        let (url, peer) = WebSocketTransport::multiaddr_into_url(dialer_address.clone()).unwrap();
+
+        tokio::spawn(async move {
+            // Negotiate websocket.
+            let stream = tokio_tungstenite::client_async_tls(url, dialer).await.unwrap().0;
+            let mut dialer = BufferedStream::new(stream);
+
+            let (stream, _proto) = WebSocketConnection::negotiate_protocol(
+                dialer,
+                &Role::Dialer,
+                vec!["/noise"],
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+            // do a noise handshake
+            let keypair = Keypair::generate();
+            let (_stream, _peer) = noise::handshake(
+                stream.inner(),
+                &keypair,
+                Role::Dialer,
+                5,
+                2,
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        match WebSocketConnection::accept_connection(
+            stream,
+            ConnectionId::from(0usize),
+            Keypair::generate(),
+            dialer_address,
+            Default::default(),
+            5,
+            2,
+            Duration::from_secs(10),
+        )
+        .await
+        {
+            Ok(_) => panic!("connection was supposed to fail"),
+            Err(NegotiationError::Timeout) => {}
+            Err(error) => panic!("{error:?}"),
+        }
+    }
 }

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -665,4 +665,55 @@ mod tests {
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn multistream_select_not_supported_listener() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+
+        let listener = TcpListener::bind("[::1]:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let (Ok(mut dialer), Ok((stream, dialer_address))) =
+            tokio::join!(TcpStream::connect(address.clone()), listener.accept(),)
+        else {
+            panic!("failed to establish connection");
+        };
+
+        let peer_id = PeerId::random();
+        let dialer_address = Multiaddr::empty()
+            .with(Protocol::from(dialer_address.ip()))
+            .with(Protocol::Tcp(dialer_address.port()))
+            .with(Protocol::Ws(std::borrow::Cow::Borrowed("/")))
+            .with(Protocol::P2p(peer_id.into()));
+
+        let (url, peer) = WebSocketTransport::multiaddr_into_url(dialer_address.clone()).unwrap();
+
+        tokio::spawn(async move {
+            // Negotiate websocket.
+            let stream = tokio_tungstenite::client_async_tls(url, dialer).await.unwrap().0;
+            let mut dialer = BufferedStream::new(stream);
+            let _ = dialer.write_all(&vec![0x12u8; 256]).await;
+        });
+
+        match WebSocketConnection::accept_connection(
+            stream,
+            ConnectionId::from(0usize),
+            Keypair::generate(),
+            dialer_address,
+            Default::default(),
+            5,
+            2,
+            Duration::from_secs(10),
+        )
+        .await
+        {
+            Ok(_) => panic!("connection was supposed to fail"),
+            Err(NegotiationError::MultistreamSelectError(
+                crate::multistream_select::NegotiationError::ProtocolError(_),
+            )) => {}
+            Err(error) => panic!("invalid error: {error:?}"),
+        }
+    }
 }

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -985,4 +985,67 @@ mod tests {
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn noise_timeout_dialer() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+
+        let listener = TcpListener::bind("[::1]:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let stream = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let stream = BufferedStream::new(stream);
+
+            let (stream, _proto) = WebSocketConnection::negotiate_protocol(
+                stream,
+                &Role::Listener,
+                vec!["/noise"],
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        let peer_id = PeerId::random();
+        let address = Multiaddr::empty()
+            .with(Protocol::from(address.ip()))
+            .with(Protocol::Tcp(address.port()))
+            .with(Protocol::Ws(std::borrow::Cow::Borrowed("/")))
+            .with(Protocol::P2p(peer_id.into()));
+
+        let (url, peer) = WebSocketTransport::multiaddr_into_url(address.clone()).unwrap();
+        let (_, stream) = WebSocketTransport::dial_peer(
+            address.clone(),
+            Default::default(),
+            Duration::from_secs(10),
+            false,
+        )
+        .await
+        .unwrap();
+
+        match WebSocketConnection::open_connection(
+            ConnectionId::from(0usize),
+            Keypair::generate(),
+            stream,
+            address.clone(),
+            peer.clone(),
+            url,
+            Default::default(),
+            5,
+            2,
+            Duration::from_secs(10),
+        )
+        .await
+        {
+            Ok(_) => panic!("connection was supposed to fail"),
+            Err(NegotiationError::Timeout) => {}
+            Err(error) => panic!("invalid error: {error:?}"),
+        }
+    }
 }

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -913,4 +913,76 @@ mod tests {
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn noise_wrong_handshake_listener() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+
+        let listener = TcpListener::bind("[::1]:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let (Ok(dialer), Ok((stream, dialer_address))) =
+            tokio::join!(TcpStream::connect(address.clone()), listener.accept(),)
+        else {
+            panic!("failed to establish connection");
+        };
+
+        let peer_id = PeerId::random();
+
+        let dialer_address = Multiaddr::empty()
+            .with(Protocol::from(dialer_address.ip()))
+            .with(Protocol::Tcp(dialer_address.port()))
+            .with(Protocol::Ws(std::borrow::Cow::Borrowed("/")))
+            .with(Protocol::P2p(peer_id.into()));
+
+        let (url, peer) = WebSocketTransport::multiaddr_into_url(dialer_address.clone()).unwrap();
+
+        tokio::spawn(async move {
+            // Negotiate websocket.
+            let stream = tokio_tungstenite::client_async_tls(url, dialer).await.unwrap().0;
+            let mut dialer = BufferedStream::new(stream);
+
+            // Sleep while negotiating /yamux.
+            let (stream, _proto) = WebSocketConnection::negotiate_protocol(
+                dialer,
+                &Role::Dialer,
+                vec!["/noise"],
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+            // The next step is providing the noise handshake. However, we jump
+            // directly to negotiating yamux.
+            let (stream, _proto) = WebSocketConnection::negotiate_protocol(
+                stream,
+                &Role::Dialer,
+                vec!["/yamux/1.0.0"],
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        match WebSocketConnection::accept_connection(
+            stream,
+            ConnectionId::from(0usize),
+            Keypair::generate(),
+            dialer_address,
+            Default::default(),
+            5,
+            2,
+            Duration::from_secs(10),
+        )
+        .await
+        {
+            Ok(_) => panic!("connection was supposed to fail"),
+            Err(NegotiationError::Timeout) => {}
+            Err(error) => panic!("invalid error: {error:?}"),
+        }
+    }
 }

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -840,4 +840,77 @@ mod tests {
             Err(error) => panic!("invalid error: {error:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn noise_timeout_listener() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+
+        let listener = TcpListener::bind("[::1]:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let (Ok(dialer), Ok((stream, dialer_address))) =
+            tokio::join!(TcpStream::connect(address.clone()), listener.accept(),)
+        else {
+            panic!("failed to establish connection");
+        };
+
+        let keypair = Keypair::generate();
+        let peer_id = PeerId::from_public_key(&keypair.public().into());
+
+        let dialer_address = Multiaddr::empty()
+            .with(Protocol::from(dialer_address.ip()))
+            .with(Protocol::Tcp(dialer_address.port()))
+            .with(Protocol::Ws(std::borrow::Cow::Borrowed("/")))
+            .with(Protocol::P2p(peer_id.into()));
+
+        let (url, peer) = WebSocketTransport::multiaddr_into_url(dialer_address.clone()).unwrap();
+
+        tokio::spawn(async move {
+            // Negotiate websocket.
+            let stream = tokio_tungstenite::client_async_tls(url, dialer).await.unwrap().0;
+            let mut dialer = BufferedStream::new(stream);
+
+            // Sleep while negotiating /yamux.
+            let (stream, _proto) = WebSocketConnection::negotiate_protocol(
+                dialer,
+                &Role::Dialer,
+                vec!["/noise"],
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+            let (stream, peer) = noise::handshake(
+                stream.inner(),
+                &keypair,
+                Role::Dialer,
+                5,
+                2,
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        match WebSocketConnection::accept_connection(
+            stream,
+            ConnectionId::from(0usize),
+            Keypair::generate(),
+            dialer_address,
+            Default::default(),
+            5,
+            2,
+            Duration::from_secs(10),
+        )
+        .await
+        {
+            Ok(_) => panic!("connection was supposed to fail"),
+            Err(NegotiationError::Timeout) => {}
+            Err(error) => panic!("invalid error: {error:?}"),
+        }
+    }
 }

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -1287,4 +1287,81 @@ mod tests {
             Err(error) => panic!("{error:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn yamux_timeout_listener() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init();
+
+        let listener = TcpListener::bind("[::1]:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let keypair = Keypair::generate();
+        let peer_id = PeerId::from_public_key(&keypair.public().into());
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let stream = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let stream = BufferedStream::new(stream);
+
+            let (stream, _proto) = WebSocketConnection::negotiate_protocol(
+                stream,
+                &Role::Listener,
+                vec!["/noise"],
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+            // do a noise handshake
+            let (stream, _peer) = noise::handshake(
+                stream.inner(),
+                &keypair,
+                Role::Listener,
+                5,
+                2,
+                std::time::Duration::from_secs(10),
+            )
+            .await
+            .unwrap();
+
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        });
+
+        let address = Multiaddr::empty()
+            .with(Protocol::from(address.ip()))
+            .with(Protocol::Tcp(address.port()))
+            .with(Protocol::Ws(std::borrow::Cow::Borrowed("/")))
+            .with(Protocol::P2p(peer_id.into()));
+
+        let (url, peer) = WebSocketTransport::multiaddr_into_url(address.clone()).unwrap();
+        let (_, stream) = WebSocketTransport::dial_peer(
+            address.clone(),
+            Default::default(),
+            Duration::from_secs(10),
+            false,
+        )
+        .await
+        .unwrap();
+
+        match WebSocketConnection::open_connection(
+            ConnectionId::from(0usize),
+            Keypair::generate(),
+            stream,
+            address.clone(),
+            peer.clone(),
+            url,
+            Default::default(),
+            5,
+            2,
+            Duration::from_secs(10),
+        )
+        .await
+        {
+            Ok(_) => panic!("connection was supposed to fail"),
+            Err(NegotiationError::Timeout) => {}
+            Err(error) => panic!("invalid error: {error:?}"),
+        }
+    }
 }

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -34,6 +34,7 @@ use std::{
 const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
 /// Send state.
+#[derive(Debug)]
 enum State {
     /// State is poisoned.
     Poisoned,
@@ -46,6 +47,7 @@ enum State {
 }
 
 /// Buffered stream which implements `AsyncRead + AsyncWrite`
+#[derive(Debug)]
 pub(super) struct BufferedStream<S: AsyncRead + AsyncWrite + Unpin> {
     /// Write buffer.
     write_buffer: BytesMut,
@@ -124,7 +126,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncWrite for BufferedStream<S
                         Poll::Ready(Err(_error)) =>
                             return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into())),
                         Poll::Pending => {
-                            self.state = State::ReadyToSend;
+                            self.state = State::FlushPending;
                             return Poll::Pending;
                         }
                     }

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -762,7 +762,7 @@ async fn simultaneous_dial_ipv6_quic() {
     }
 }
 
-#[cfg(feature = "webscocket")]
+#[cfg(feature = "websocket")]
 #[tokio::test]
 async fn websocket_over_ipv6() {
     let _ = tracing_subscriber::fmt()

--- a/tests/protocol/request_response.rs
+++ b/tests/protocol/request_response.rs
@@ -36,7 +36,6 @@ use litep2p::transport::websocket::config::Config as WebSocketConfig;
 use futures::{channel, StreamExt};
 use multiaddr::{Multiaddr, Protocol};
 use multihash::Multihash;
-use rand::{Rng, SeedableRng};
 use tokio::time::sleep;
 
 #[cfg(feature = "quic")]


### PR DESCRIPTION
This PR addresses a bug in the WebSocket stream state machine. The internal state was incorrectly reset to `State::ReadyToSend` upon receiving `Poll::Pending`. The correct behavior is to retain the `State::FlushPending` state until the flush operation completes.

Additionally, the following tests were backported from the TCP connection component:
- yamux_timeout_listener
- yamux_timeout_dialer
- yamux_not_supported_listener
- yamux_not_supported_dialer
- noise_timeout_dialer
- noise_wrong_handshake_listener
- noise_timeout_listener
- noise_not_supported_listener
- noise_not_supported_dialer
- multistream_select_not_supported_listener
- multistream_select_not_supported_dialer

While at it, we had a test guarded by a wrongly named feature flag `webscocket`, which is now also enabled.

cc @paritytech/networking 