### PR TITLE
improve error handling in webRTC-related noise function

### DIFF
--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -164,6 +164,11 @@ impl NoiseContext {
     /// Get remote public key from the received Noise payload.
     #[cfg(feature = "webrtc")]
     pub fn get_remote_public_key(&mut self, reply: &[u8]) -> Result<PublicKey, NegotiationError> {
+        if reply.len() < 2 {
+            tracing::error!(target: LOG_TARGET, "reply too short to contain length prefix");
+            return Err(NegotiationError::ParseError(ParseError::InvalidReplyLength));
+        }
+
         let (len_slice, reply) = reply.split_at(2);
         let len = u16::from_be_bytes(
             len_slice

--- a/src/error.rs
+++ b/src/error.rs
@@ -149,6 +149,9 @@ pub enum AddressError {
     /// The provided address contains an invalid multihash.
     #[error("Multihash does not contain a valid peer ID : `{0:?}`")]
     InvalidPeerId(Multihash),
+    /// The provided multihash is invalid.
+    #[error("The provided multihash is  not valid")]
+    InvalidMultihash,
 }
 
 #[derive(Debug, thiserror::Error, PartialEq)]
@@ -179,6 +182,9 @@ pub enum ParseError {
     /// This error is protocol specific.
     #[error("Invalid data")]
     InvalidData,
+    /// The provided reply length is not valid
+    #[error("Invalid reply length")]
+    InvalidReplyLength,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ use types::ConnectionId;
 
 use std::{collections::HashSet, sync::Arc};
 
+use crate::error::AddressError;
 pub use bandwidth::BandwidthSink;
 pub use error::Error;
 pub use peer_id::PeerId;
@@ -352,9 +353,9 @@ impl Litep2p {
 
             for address in transport_listen_addresses {
                 transport_manager.register_listen_address(address.clone());
-                listen_addresses.push(address.with(Protocol::P2p(
-                    Multihash::from_bytes(&local_peer_id.to_bytes()).unwrap(),
-                )));
+                let peer_id_multihash = Multihash::from_bytes(&local_peer_id.to_bytes())
+                    .map_err(|_e| Error::AddressError(AddressError::InvalidMultihash))?;
+                listen_addresses.push(address.with(Protocol::P2p(peer_id_multihash)));
             }
 
             transport_manager.register_transport(SupportedTransport::WebRtc, Box::new(transport));


### PR DESCRIPTION
Closes #312 This PR

- [ ] eliminates all unsafe assumptions and panics in Noise-related WebRTC functions. Ensures litep2p behaves predictably even with malformed or malicious peers during the handshake phase.
- [ ]  removes assumption about the `reply` buffer size.

I am also looking at other functions to see if there should be any improvement, i will make this a draft PR untill i finish other improvements or if i find no other improvements needed.