### PR TITLE
identify: Improve identify message decoding

### DIFF
--- a/src/protocol/libp2p/identify.rs
+++ b/src/protocol/libp2p/identify.rs
@@ -329,6 +329,16 @@ impl Identify {
 
             tracing::trace!(target: LOG_TARGET, ?peer, ?info, "peer identified");
 
+            // The check ensures the provided public key is the same one as the
+            // one exchanged during the connection establishment.
+            if let Some(public_key) = &info.public_key {
+                let public_key = PublicKey::from_protobuf_encoding(&public_key)?;
+                if public_key.to_peer_id() != peer {
+                    tracing::debug!(target: LOG_TARGET, ?peer, "peer identified provided invalid public key");
+                    return Err(Error::InvalidData);
+                }
+            }
+
             let listen_addresses = info
                 .listen_addrs
                 .iter()

--- a/src/protocol/libp2p/identify.rs
+++ b/src/protocol/libp2p/identify.rs
@@ -372,7 +372,7 @@ impl Identify {
                     }
                     if let Some(multiaddr::Protocol::P2p(peer_id)) = address.iter().last() {
                         if peer_id != peer.into() {
-                            tracing::debug!(target: LOG_TARGET, ?peer, ?address, "peer identified provided invalid listen address");
+                            tracing::debug!(target: LOG_TARGET, ?peer, ?address, "peer identified provided listen address with incorrect peer ID; discarding the address");
                             return None;
                         }
                     }

--- a/src/protocol/libp2p/identify.rs
+++ b/src/protocol/libp2p/identify.rs
@@ -194,7 +194,10 @@ pub(crate) struct Identify {
 impl Identify {
     /// Create new [`Identify`] protocol.
     pub(crate) fn new(service: TransportService, config: Config) -> Self {
-        let public = config.public.expect("public key to be supplied");
+        // The public key is always supplied by litep2p and is the one
+        // used to identify the local peer. This is a similar story to the
+        // supported protocols.
+        let public = config.public.expect("public key to always be supplied by litep2p; qed");
         let local_peer_id = public.to_peer_id();
 
         Self {

--- a/src/protocol/libp2p/identify.rs
+++ b/src/protocol/libp2p/identify.rs
@@ -392,7 +392,7 @@ impl Identify {
 
                     if let Some(multiaddr::Protocol::P2p(peer_id)) = address.iter().last() {
                         if peer_id != local_peer_id.into() {
-                            tracing::debug!(target: LOG_TARGET, ?peer, ?address, "peer identified provided invalid observed address");
+                            tracing::debug!(target: LOG_TARGET, ?peer, ?address, "peer identified provided observed address with peer ID not matching our peer ID; discarding address");
                             return None;
                         }
                     }


### PR DESCRIPTION
This PR improves the decoding of the identify messages by checking the following:
- if provided, the public key must decode properly and point towards the same peer ID
  - on failure the identify message is not propagated to the higher levels
- empty addresses or addresses corresponding to different peers are removed from the message
- added extra debug logs to the identify component

### Testing Done
- discovered the whole network of polkadot and kusama using https://github.com/lexnv/subp2p-explorer
- all the provided identify messages decoded correctly (including all addresses and pKs)

cc @paritytech/networking 