### PR TITLE
chore: Release litep2p v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2025-04-29
+
+### Fixed
+
+- notifications: Exit protocols on handle drop to save up CPU of `minimal-relay-chains`  ([#376](https://github.com/paritytech/litep2p/pull/376))
+- identify: Improve identify message decoding  ([#379](https://github.com/paritytech/litep2p/pull/379))
+- crypto/noise: Set timeout limits for the noise handshake  ([#373](https://github.com/paritytech/litep2p/pull/373))
+- kad: Improve robustness of addresses from the routing table  ([#369](https://github.com/paritytech/litep2p/pull/369))
+- kad: Bound kademlia messages to the replication factor  ([#371](https://github.com/paritytech/litep2p/pull/371))
+- codec: Decode smaller payloads for identity to None  ([#362](https://github.com/paritytech/litep2p/pull/362))
+
+### Added
+
+- bitswap: Add write timeout for sending frames  ([#361](https://github.com/paritytech/litep2p/pull/361))
+- notif/tests: check test state  ([#360](https://github.com/paritytech/litep2p/pull/360))
+- SRLabs: Introduce simple fuzzing harness  ([#367](https://github.com/paritytech/litep2p/pull/367))
+- SRLabs: Introduce Fuzzing Harness  ([#365](https://github.com/paritytech/litep2p/pull/365))
+
+### Changed
+
+- features: Move quic related dependencies under feature flag  ([#359](https://github.com/paritytech/litep2p/pull/359))
+- tests/substrate: Remove outdated substrate specific conformace testing  ([#370](https://github.com/paritytech/litep2p/pull/370))
+- ci: Update stable dependencies  ([#375](https://github.com/paritytech/litep2p/pull/375))
+- build(deps): bump hex-literal from 0.4.1 to 1.0.0  ([#381](https://github.com/paritytech/litep2p/pull/381))
+- build(deps): bump tokio from 1.44.1 to 1.44.2 in /fuzz/structure-aware  ([#378](https://github.com/paritytech/litep2p/pull/378))
+- build(deps): bump Swatinem/rust-cache from 2.7.7 to 2.7.8  ([#363](https://github.com/paritytech/litep2p/pull/363))
+- build(deps): bump tokio from 1.43.0 to 1.43.1  ([#368](https://github.com/paritytech/litep2p/pull/368))
+- build(deps): bump openssl from 0.10.70 to 0.10.72  ([#366](https://github.com/paritytech/litep2p/pull/366))
+
 ## [0.9.3] - 2025-03-11
 
 This release introduces an API for setting the maximum kademlia message size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.4] - 2025-04-29
 
+This release brings several improvements and fixes to litep2p, advancing its stability and readiness for production use.
+
+### Performance Improvements
+
+This release addresses an issue where notification protocols failed to exit on handle drop, lowering CPU usage in scenarios like minimal-relay-chains from 7% to 0.1%.
+
+### Robustness Improvements
+
+- Kademlia:
+  - Optimized address store by sorting addresses based on dialing score, bounding memory consumption and improving efficiency.
+  - Limited `FIND_NODE` responses to the replication factor, reducing data stored in the routing table.
+  - Address store improvements enhance robustness against routing table alterations.
+
+- Identify Codec:
+  - Enhanced message decoding to manage malformed or unexpected messages gracefully.
+
+- Bitswap:
+  - Introduced a write timeout for sending frames, preventing protocol hangs or delays.
+
+### Testing and Reliability
+
+- Fuzzing Harness: Added a fuzzing harness by SRLabs to uncover and resolve potential issues, improving code robustness. Thanks to @R9295 for the contribution!
+
+- Testing Enhancements: Improved notification state machine testing. Thanks to Dominique (@Imod7) for the contribution!
+
+### Dependency Management
+
+- Updated all dependencies for stable feature flags (default and "websocket") to their latest versions.
+
+- Reorganized dependencies under specific feature flags, shrinking the default feature set and avoiding exposure of outdated dependencies from experimental features.
+
 ### Fixed
 
 - notifications: Exit protocols on handle drop to save up CPU of `minimal-relay-chains`  ([#376](https://github.com/paritytech/litep2p/pull/376))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.4] - 2025-04-29
+## [0.9.4] - 2025-05-01
 
 This release brings several improvements and fixes to litep2p, advancing its stability and readiness for production use.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,7 +1886,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 
 # cargo-machete does not detect serde_millis usage, so we ignore the warning

--- a/src/protocol/libp2p/identify.rs
+++ b/src/protocol/libp2p/identify.rs
@@ -345,20 +345,6 @@ impl Identify {
 
             tracing::trace!(target: LOG_TARGET, ?peer, ?info, "peer identified");
 
-            // The check ensures the provided public key is the same one as the
-            // one exchanged during the connection establishment.
-            if let Some(public_key) = &info.public_key {
-                let public_key = PublicKey::from_protobuf_encoding(&public_key).map_err(|err| {
-                    tracing::debug!(target: LOG_TARGET, ?peer, ?err, "peer identified provided undecodable public key");
-                    err
-                })?;
-
-                if public_key.to_peer_id() != peer {
-                    tracing::debug!(target: LOG_TARGET, ?peer, "peer identified provided invalid public key");
-                    return Err(Error::InvalidData);
-                }
-            }
-
             let listen_addresses = info
                 .listen_addrs
                 .iter()


### PR DESCRIPTION
## [0.9.4] - 2025-04-29

This release brings several improvements and fixes to litep2p, advancing its stability and readiness for production use.

### Performance Improvements

This release addresses an issue where notification protocols failed to exit on handle drop, lowering CPU usage in scenarios like minimal-relay-chains from 7% to 0.1%.

### Robustness Improvements

- Kademlia:
  - Optimized address store by sorting addresses based on dialing score, bounding memory consumption and improving efficiency.
  - Limited `FIND_NODE` responses to the replication factor, reducing data stored in the routing table.
  - Address store improvements enhance robustness against routing table alterations.

- Identify Codec:
  - Enhanced message decoding to manage malformed or unexpected messages gracefully.

- Bitswap:
  - Introduced a write timeout for sending frames, preventing protocol hangs or delays.

### Testing and Reliability

- Fuzzing Harness: Added a fuzzing harness by SRLabs to uncover and resolve potential issues, improving code robustness. Thanks to @R9295 for the contribution!

- Testing Enhancements: Improved notification state machine testing. Thanks to Dominique (@Imod7) for the contribution!

### Dependency Management

- Updated all dependencies for stable feature flags (default and "websocket") to their latest versions.

- Reorganized dependencies under specific feature flags, shrinking the default feature set and avoiding exposure of outdated dependencies from experimental features.

### Fixed

- notifications: Exit protocols on handle drop to save up CPU of `minimal-relay-chains`  ([#376](https://github.com/paritytech/litep2p/pull/376))
- identify: Improve identify message decoding  ([#379](https://github.com/paritytech/litep2p/pull/379))
- crypto/noise: Set timeout limits for the noise handshake  ([#373](https://github.com/paritytech/litep2p/pull/373))
- kad: Improve robustness of addresses from the routing table  ([#369](https://github.com/paritytech/litep2p/pull/369))
- kad: Bound kademlia messages to the replication factor  ([#371](https://github.com/paritytech/litep2p/pull/371))
- codec: Decode smaller payloads for identity to None  ([#362](https://github.com/paritytech/litep2p/pull/362))

### Added

- bitswap: Add write timeout for sending frames  ([#361](https://github.com/paritytech/litep2p/pull/361))
- notif/tests: check test state  ([#360](https://github.com/paritytech/litep2p/pull/360))
- SRLabs: Introduce simple fuzzing harness  ([#367](https://github.com/paritytech/litep2p/pull/367))
- SRLabs: Introduce Fuzzing Harness  ([#365](https://github.com/paritytech/litep2p/pull/365))

### Changed

- features: Move quic related dependencies under feature flag  ([#359](https://github.com/paritytech/litep2p/pull/359))
- tests/substrate: Remove outdated substrate specific conformace testing  ([#370](https://github.com/paritytech/litep2p/pull/370))
- ci: Update stable dependencies  ([#375](https://github.com/paritytech/litep2p/pull/375))
- build(deps): bump hex-literal from 0.4.1 to 1.0.0  ([#381](https://github.com/paritytech/litep2p/pull/381))
- build(deps): bump tokio from 1.44.1 to 1.44.2 in /fuzz/structure-aware  ([#378](https://github.com/paritytech/litep2p/pull/378))
- build(deps): bump Swatinem/rust-cache from 2.7.7 to 2.7.8  ([#363](https://github.com/paritytech/litep2p/pull/363))
- build(deps): bump tokio from 1.43.0 to 1.43.1  ([#368](https://github.com/paritytech/litep2p/pull/368))
- build(deps): bump openssl from 0.10.70 to 0.10.72  ([#366](https://github.com/paritytech/litep2p/pull/366))
