### PR TITLE
transport: Allow changing DNS resolver config

### DIFF
--- a/src/transport/common/listener.rs
+++ b/src/transport/common/listener.rs
@@ -26,16 +26,14 @@ use crate::{
 };
 
 use futures::Stream;
-use hickory_resolver::{
-    config::{ResolverConfig, ResolverOpts},
-    TokioAsyncResolver,
-};
+use hickory_resolver::TokioAsyncResolver;
 use multiaddr::{Multiaddr, Protocol};
 use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use socket2::{Domain, Socket, Type};
 use tokio::net::{TcpListener as TokioTcpListener, TcpStream};
 
 use std::{
+    borrow::Borrow,
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     pin::Pin,
@@ -73,7 +71,10 @@ pub enum DnsType {
 
 impl AddressType {
     /// Resolve the address to a concrete IP.
-    pub async fn lookup_ip(self) -> Result<SocketAddr, DnsError> {
+    pub async fn lookup_ip(
+        self,
+        resolver: impl Borrow<TokioAsyncResolver>,
+    ) -> Result<SocketAddr, DnsError> {
         let (url, port, dns_type) = match self {
             // We already have the IP address.
             AddressType::Socket(address) => return Ok(address),
@@ -84,23 +85,19 @@ impl AddressType {
             } => (address, port, dns_type),
         };
 
-        let lookup =
-            match TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default())
-                .lookup_ip(url.clone())
-                .await
-            {
-                Ok(lookup) => lookup,
-                Err(error) => {
-                    tracing::debug!(
-                        target: LOG_TARGET,
-                        ?error,
-                        "failed to resolve DNS address `{}`",
-                        url
-                    );
+        let lookup = match resolver.borrow().lookup_ip(url.clone()).await {
+            Ok(lookup) => lookup,
+            Err(error) => {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    ?error,
+                    "failed to resolve DNS address `{}`",
+                    url
+                );
 
-                    return Err(DnsError::ResolveError(url));
-                }
-            };
+                return Err(DnsError::ResolveError(url));
+            }
+        };
 
         let Some(ip) = lookup.iter().find(|ip| match dns_type {
             DnsType::Dns => true,

--- a/src/transport/tcp/config.rs
+++ b/src/transport/tcp/config.rs
@@ -80,6 +80,12 @@ pub struct Config {
     /// How long should litep2p wait for a substream to be opened before considering
     /// the substream rejected.
     pub substream_open_timeout: std::time::Duration,
+
+    /// DNS resolver config.
+    pub resolver_config: hickory_resolver::config::ResolverConfig,
+
+    /// DNS resolver options.
+    pub resolver_opts: hickory_resolver::config::ResolverOpts,
 }
 
 impl Default for Config {
@@ -96,6 +102,18 @@ impl Default for Config {
             noise_write_buffer_size: MAX_WRITE_BUFFER_SIZE,
             connection_open_timeout: CONNECTION_OPEN_TIMEOUT,
             substream_open_timeout: SUBSTREAM_OPEN_TIMEOUT,
+            resolver_config: Default::default(),
+            resolver_opts: Default::default(),
         }
+    }
+}
+
+impl Config {
+    /// Set DNS resolver according to system configuration.
+    pub fn set_system_resolver(&mut self) -> hickory_resolver::error::ResolveResult<()> {
+        let (resolver_config, resolver_opts) = hickory_resolver::system_conf::read_system_conf()?;
+        self.resolver_config = resolver_config;
+        self.resolver_opts = resolver_opts;
+        Ok(())
     }
 }

--- a/src/transport/tcp/connection.rs
+++ b/src/transport/tcp/connection.rs
@@ -751,6 +751,10 @@ mod tests {
     use crate::transport::tcp::TcpTransport;
 
     use super::*;
+    use hickory_resolver::{
+        config::{ResolverConfig, ResolverOpts},
+        TokioAsyncResolver,
+    };
     use tokio::{io::AsyncWriteExt, net::TcpListener};
 
     #[tokio::test]
@@ -774,6 +778,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
+            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default()),
         )
         .await
         .unwrap();
@@ -869,6 +874,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
+            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default()),
         )
         .await
         .unwrap();
@@ -1011,6 +1017,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
+            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default()),
         )
         .await
         .unwrap();
@@ -1057,6 +1064,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
+            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default()),
         )
         .await
         .unwrap();
@@ -1228,6 +1236,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
+            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default()),
         )
         .await
         .unwrap();
@@ -1354,6 +1363,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
+            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default()),
         )
         .await
         .unwrap();


### PR DESCRIPTION
Fixes #383 

I don't exactly know the implications of storing the resolver there but it looks reasonable to me (more than recreating it at each lookup).

Default config has the same behavior as before (Google servers), but now it can be changed.

I guess it's a semver-breaking change but unless using something like a static `OnceCell` I see no other way.

Also, please consider using (and enforcing) cargo clippy, it helps contributors cleaning their edits without having to scroll over preexisting warnings.