### PR TITLE
crypto/noise: Show peerIDs that fail to decode

### DIFF
--- a/src/codec/identity.rs
+++ b/src/codec/identity.rs
@@ -102,7 +102,7 @@ mod tests {
         let bytes = [3u8; 64];
         let mut bytes = BytesMut::from(&bytes[..]);
 
-        let decoded = codec.decode(&mut bytes);
+        assert!(codec.decode(&mut bytes).unwrap().is_none());
     }
 
     #[test]

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -350,6 +350,7 @@ pub struct NoiseSocket<S: AsyncRead + AsyncWrite + Unpin> {
     read_buffer: Vec<u8>,
     canonical_max_read: usize,
     decrypt_buffer: Option<Vec<u8>>,
+    peer: PeerId,
 }
 
 impl<S: AsyncRead + AsyncWrite + Unpin> NoiseSocket<S> {
@@ -358,6 +359,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> NoiseSocket<S> {
         noise: NoiseContext,
         max_read_ahead_factor: usize,
         max_write_buffer_size: usize,
+        peer: PeerId,
     ) -> Self {
         Self {
             io,
@@ -380,6 +382,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> NoiseSocket<S> {
                 max_read: max_read_ahead_factor * MAX_NOISE_MSG_LEN,
             },
             canonical_max_read: max_read_ahead_factor * MAX_NOISE_MSG_LEN,
+            peer,
         }
     }
 
@@ -764,6 +767,7 @@ pub async fn handshake<S: AsyncRead + AsyncWrite + Unpin>(
                 noise.into_transport()?,
                 max_read_ahead_factor,
                 max_write_buffer_size,
+                peer,
             ),
             peer,
         ))

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -893,6 +893,7 @@ mod tests {
                 MAX_READ_AHEAD_FACTOR,
                 MAX_WRITE_BUFFER_SIZE,
                 std::time::Duration::from_secs(10),
+                HandshakeTransport::Tcp,
             ),
             handshake(
                 io2,
@@ -901,6 +902,7 @@ mod tests {
                 MAX_READ_AHEAD_FACTOR,
                 MAX_WRITE_BUFFER_SIZE,
                 std::time::Duration::from_secs(10),
+                HandshakeTransport::Tcp,
             )
         );
         let (mut res1, mut res2) = (res1.unwrap(), res2.unwrap());

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -549,7 +549,9 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for NoiseSocket<S> {
                                         target: LOG_TARGET,
                                         ?error,
                                         peer = ?this.peer,
-                                        "failed to decrypt message for bigger buffers"
+                                        buf_len = ?buf.len(),
+                                        frame_size = ?frame_size,
+                                        "failed to decrypt message"
                                     );
 
                                     return Poll::Ready(Err(io::ErrorKind::InvalidData.into()));
@@ -573,7 +575,9 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for NoiseSocket<S> {
                                             target: LOG_TARGET,
                                             ?error,
                                             peer = ?this.peer,
-                                            "failed to decrypt message for smaller buffers"
+                                            buf_len = ?buf.len(),
+                                            frame_size = ?frame_size,
+                                            "failed to decrypt message for smaller buffer"
                                         );
 
                                         return Poll::Ready(Err(io::ErrorKind::InvalidData.into()));

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -545,7 +545,13 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for NoiseSocket<S> {
                                 buf,
                             ) {
                                 Err(error) => {
-                                    tracing::error!(target: LOG_TARGET, ?error, peer = ?this.peer, "failed to decrypt message for bigger buffers");
+                                    tracing::error!(
+                                        target: LOG_TARGET,
+                                        ?error,
+                                        peer = ?this.peer,
+                                        "failed to decrypt message for bigger buffers"
+                                    );
+
                                     return Poll::Ready(Err(io::ErrorKind::InvalidData.into()));
                                 }
                                 Ok(nread) => {
@@ -563,7 +569,13 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for NoiseSocket<S> {
                                     &mut buffer,
                                 ) {
                                     Err(error) => {
-                                        tracing::error!(target: LOG_TARGET, ?error, "failed to decrypt message for smaller buffers");
+                                        tracing::error!(
+                                            target: LOG_TARGET,
+                                            ?error,
+                                            peer = ?this.peer,
+                                            "failed to decrypt message for smaller buffers"
+                                        );
+
                                         return Poll::Ready(Err(io::ErrorKind::InvalidData.into()));
                                     }
                                     Ok(nread) => {

--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -545,7 +545,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for NoiseSocket<S> {
                                 buf,
                             ) {
                                 Err(error) => {
-                                    tracing::error!(target: LOG_TARGET, ?error, "failed to decrypt message");
+                                    tracing::error!(target: LOG_TARGET, ?error, peer = ?this.peer, "failed to decrypt message for bigger buffers");
                                     return Poll::Ready(Err(io::ErrorKind::InvalidData.into()));
                                 }
                                 Ok(nread) => {
@@ -563,7 +563,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for NoiseSocket<S> {
                                     &mut buffer,
                                 ) {
                                     Err(error) => {
-                                        tracing::error!(target: LOG_TARGET, ?error, "failed to decrypt message");
+                                        tracing::error!(target: LOG_TARGET, ?error, "failed to decrypt message for smaller buffers");
                                         return Poll::Ready(Err(io::ErrorKind::InvalidData.into()));
                                     }
                                     Ok(nread) => {

--- a/src/protocol/libp2p/kademlia/bucket.rs
+++ b/src/protocol/libp2p/kademlia/bucket.rs
@@ -128,7 +128,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let target = Key::from(PeerId::random());
-        let mut iter = bucket.closest_iter(&target);
+        let iter = bucket.closest_iter(&target);
         let mut prev = None;
 
         for node in iter {
@@ -173,7 +173,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let target = Key::from(PeerId::random());
-        let mut iter = bucket.closest_iter(&target);
+        let iter = bucket.closest_iter(&target);
         let mut prev = None;
         let mut num_peers = 0usize;
 

--- a/src/transport/tcp/connection.rs
+++ b/src/transport/tcp/connection.rs
@@ -438,6 +438,7 @@ impl TcpConnection {
             max_read_ahead_factor,
             max_write_buffer_size,
             substream_open_timeout,
+            noise::HandshakeTransport::Tcp,
         )
         .await?;
 
@@ -1154,6 +1155,7 @@ mod tests {
                 5,
                 2,
                 std::time::Duration::from_secs(10),
+                noise::HandshakeTransport::Tcp,
             )
             .await
             .unwrap();
@@ -1212,6 +1214,7 @@ mod tests {
                 5,
                 2,
                 std::time::Duration::from_secs(10),
+                noise::HandshakeTransport::Tcp,
             )
             .await
             .unwrap();
@@ -1286,6 +1289,7 @@ mod tests {
                 5,
                 2,
                 std::time::Duration::from_secs(10),
+                noise::HandshakeTransport::Tcp,
             )
             .await
             .unwrap();
@@ -1339,6 +1343,7 @@ mod tests {
                 5,
                 2,
                 std::time::Duration::from_secs(10),
+                noise::HandshakeTransport::Tcp,
             )
             .await
             .unwrap();

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -323,6 +323,7 @@ impl WebSocketConnection {
             max_read_ahead_factor,
             max_write_buffer_size,
             substream_open_timeout,
+            noise::HandshakeTransport::WebSocket,
         )
         .await?;
 
@@ -1094,6 +1095,7 @@ mod tests {
                 5,
                 2,
                 std::time::Duration::from_secs(10),
+                noise::HandshakeTransport::WebSocket,
             )
             .await
             .unwrap();
@@ -1162,6 +1164,7 @@ mod tests {
                 5,
                 2,
                 std::time::Duration::from_secs(10),
+                noise::HandshakeTransport::WebSocket,
             )
             .await
             .unwrap();
@@ -1261,6 +1264,7 @@ mod tests {
                 5,
                 2,
                 std::time::Duration::from_secs(10),
+                noise::HandshakeTransport::WebSocket,
             )
             .await
             .unwrap();
@@ -1320,6 +1324,7 @@ mod tests {
                 5,
                 2,
                 std::time::Duration::from_secs(10),
+                noise::HandshakeTransport::WebSocket,
             )
             .await
             .unwrap();

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -888,6 +888,7 @@ mod tests {
                 5,
                 2,
                 std::time::Duration::from_secs(10),
+                noise::HandshakeTransport::WebSocket,
             )
             .await
             .unwrap();

--- a/tests/conformance/rust/kademlia.rs
+++ b/tests/conformance/rust/kademlia.rs
@@ -24,7 +24,7 @@ use libp2p::{
     identify, identity,
     kad::{
         self, store::RecordStore, AddProviderOk, GetProvidersOk, InboundRequest,
-        KademliaEvent as Libp2pKademliaEvent, QueryResult, RecordKey as Libp2pRecordKey,
+        KademliaEvent as Libp2pKademliaEvent, QueryResult,
     },
     swarm::{keep_alive, AddressScore, NetworkBehaviour, SwarmBuilder, SwarmEvent},
     PeerId, Swarm,


### PR DESCRIPTION
This PR enriches the errors coming from the crypto/noise decryption by providing peer IDs.

This is useful for debugging:
- https://github.com/paritytech/polkadot-sdk/issues/8525
