### PR TITLE
websocket: Fix connection stability on decrypt messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub mod yamux;
 
 mod bandwidth;
 mod multistream_select;
-mod utils;
+pub mod utils;
 
 #[cfg(test)]
 mod mock;

--- a/src/transport/websocket/stream.rs
+++ b/src/transport/websocket/stream.rs
@@ -21,7 +21,7 @@
 //! Stream implementation for `tokio_tungstenite::WebSocketStream` that implements
 //! `AsyncRead + AsyncWrite`
 
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Buf, Bytes};
 use futures::{SinkExt, StreamExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
@@ -31,27 +31,11 @@ use std::{
     task::{Context, Poll},
 };
 
-const DEFAULT_BUF_SIZE: usize = 8 * 1024;
-
-/// Send state.
-#[derive(Debug)]
-enum State {
-    /// State is poisoned.
-    Poisoned,
-
-    /// Sink is accepting input.
-    ReadyToSend,
-
-    /// Flush is pending for the sink.
-    FlushPending,
-}
+const LOG_TARGET: &str = "litep2p::transport::websocket::stream";
 
 /// Buffered stream which implements `AsyncRead + AsyncWrite`
 #[derive(Debug)]
 pub(super) struct BufferedStream<S: AsyncRead + AsyncWrite + Unpin> {
-    /// Write buffer.
-    write_buffer: BytesMut,
-
     /// Read buffer.
     ///
     /// The buffer is taken directly from the WebSocket stream.
@@ -59,19 +43,14 @@ pub(super) struct BufferedStream<S: AsyncRead + AsyncWrite + Unpin> {
 
     /// Underlying WebSocket stream.
     stream: WebSocketStream<S>,
-
-    /// Read state.
-    state: State,
 }
 
 impl<S: AsyncRead + AsyncWrite + Unpin> BufferedStream<S> {
     /// Create new [`BufferedStream`].
     pub(super) fn new(stream: WebSocketStream<S>) -> Self {
         Self {
-            write_buffer: BytesMut::with_capacity(DEFAULT_BUF_SIZE),
             read_buffer: Bytes::new(),
             stream,
-            state: State::ReadyToSend,
         }
     }
 }
@@ -79,73 +58,39 @@ impl<S: AsyncRead + AsyncWrite + Unpin> BufferedStream<S> {
 impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncWrite for BufferedStream<S> {
     fn poll_write(
         mut self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
+        cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        self.write_buffer.extend_from_slice(buf);
+        match futures::ready!(self.stream.poll_ready_unpin(cx)) {
+            Ok(()) => {
+                let message = Message::Binary(Bytes::copy_from_slice(buf));
 
-        Poll::Ready(Ok(buf.len()))
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        if self.write_buffer.is_empty() {
-            return self
-                .stream
-                .poll_ready_unpin(cx)
-                .map_err(|_| std::io::ErrorKind::UnexpectedEof.into());
-        }
-
-        loop {
-            match std::mem::replace(&mut self.state, State::Poisoned) {
-                State::ReadyToSend => {
-                    match self.stream.poll_ready_unpin(cx) {
-                        Poll::Ready(Ok(())) => {}
-                        Poll::Ready(Err(_error)) =>
-                            return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into())),
-                        Poll::Pending => {
-                            self.state = State::ReadyToSend;
-                            return Poll::Pending;
-                        }
-                    }
-
-                    let message = std::mem::take(&mut self.write_buffer);
-                    match self.stream.start_send_unpin(Message::Binary(message.freeze())) {
-                        Ok(()) => {}
-                        Err(_error) =>
-                            return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into())),
-                    }
-
-                    // Transition to flush pending state.
-                    self.state = State::FlushPending;
-                    continue;
+                if let Err(err) = self.stream.start_send_unpin(message) {
+                    tracing::debug!(target: LOG_TARGET, "Error during start send: {:?}", err);
+                    return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into()));
                 }
 
-                State::FlushPending => {
-                    match self.stream.poll_flush_unpin(cx) {
-                        Poll::Ready(Ok(())) => {}
-                        Poll::Ready(Err(_error)) =>
-                            return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into())),
-                        Poll::Pending => {
-                            self.state = State::FlushPending;
-                            return Poll::Pending;
-                        }
-                    }
-
-                    self.state = State::ReadyToSend;
-                    self.write_buffer = BytesMut::with_capacity(DEFAULT_BUF_SIZE);
-                    return Poll::Ready(Ok(()));
-                }
-                State::Poisoned =>
-                    return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into())),
+                Poll::Ready(Ok(buf.len()))
+            }
+            Err(err) => {
+                tracing::debug!(target: LOG_TARGET, "Error during poll ready: {:?}", err);
+                return Poll::Ready(Err(std::io::ErrorKind::UnexpectedEof.into()));
             }
         }
     }
 
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.stream.poll_flush_unpin(cx).map_err(|err| {
+            tracing::debug!(target: LOG_TARGET, "Error during poll flush: {:?}", err);
+            std::io::ErrorKind::UnexpectedEof.into()
+        })
+    }
+
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        match futures::ready!(self.stream.poll_close_unpin(cx)) {
-            Ok(_) => Poll::Ready(Ok(())),
-            Err(_) => Poll::Ready(Err(std::io::ErrorKind::PermissionDenied.into())),
-        }
+        self.stream.poll_close_unpin(cx).map_err(|err| {
+            tracing::debug!(target: LOG_TARGET, "Error during poll close: {:?}", err);
+            std::io::ErrorKind::PermissionDenied.into()
+        })
     }
 }
 
@@ -183,7 +128,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> futures::AsyncRead for BufferedStream<S>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+    use futures::{AsyncRead, AsyncReadExt, AsyncWriteExt};
     use tokio::io::DuplexStream;
     use tokio_tungstenite::{tungstenite::protocol::Role, WebSocketStream};
 
@@ -203,7 +148,6 @@ mod tests {
 
         let bytes_written = stream.write(data).await.unwrap();
         assert_eq!(bytes_written, data.len());
-        assert_eq!(&stream.write_buffer[..], data);
     }
 
     #[tokio::test]
@@ -251,38 +195,6 @@ mod tests {
             Err(error) => if error.kind() == std::io::ErrorKind::UnexpectedEof {},
             state => panic!("Unexpected state {state:?}"),
         };
-    }
-
-    #[tokio::test]
-    async fn test_poisoned_state() {
-        let (mut stream, server) = create_test_stream().await;
-        drop(server);
-
-        stream.state = State::Poisoned;
-
-        let mut buffer = [0u8; 10];
-        let result = stream.read(&mut buffer).await;
-        match result {
-            Err(error) => if error.kind() == std::io::ErrorKind::UnexpectedEof {},
-            state => panic!("Unexpected state {state:?}"),
-        };
-
-        let mut cx = std::task::Context::from_waker(futures::task::noop_waker_ref());
-        let mut pin_stream = Pin::new(&mut stream);
-
-        // Messages are buffered internally, the socket is not touched.
-        match pin_stream.as_mut().poll_write(&mut cx, &mut buffer) {
-            Poll::Ready(Ok(10)) => {}
-            state => panic!("Unexpected state {state:?}"),
-        }
-        // Socket is poisoned, the flush will fail.
-        match pin_stream.poll_flush(&mut cx) {
-            Poll::Ready(Err(error)) =>
-                if error.kind() == std::io::ErrorKind::UnexpectedEof {
-                    return;
-                },
-            state => panic!("Unexpected state {state:?}"),
-        }
     }
 
     #[tokio::test]

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -44,6 +44,8 @@ use crate::common::{add_transport, Transport};
 
 #[cfg(test)]
 mod protocol_dial_invalid_address;
+#[cfg(test)]
+mod stability;
 
 #[tokio::test]
 async fn two_litep2ps_work_tcp() {

--- a/tests/connection/stability.rs
+++ b/tests/connection/stability.rs
@@ -1,0 +1,344 @@
+// Copyright 2025 litep2p developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+use litep2p::{
+    codec::ProtocolCodec,
+    config::ConfigBuilder,
+    crypto::ed25519::Keypair,
+    protocol::{
+        libp2p::ping::Config as PingConfig, Direction, TransportEvent, TransportService,
+        UserProtocol,
+    },
+    substream::Substream,
+    transport::tcp::config::Config as TcpConfig,
+    types::protocol::ProtocolName,
+    utils::futures_stream::FuturesStream,
+    Litep2p, PeerId,
+};
+
+use futures::{future::BoxFuture, StreamExt};
+
+use crate::common::{add_transport, Transport};
+
+const PROTOCOL_NAME: &str = "/litep2p-stability/1.0.0";
+
+const LOG_TARGET: &str = "litep2p::stability";
+
+/// The stability protocol ensures a single transport connection
+/// (either TCP or WebSocket) can sustain multiple received packets.
+///
+/// The scenario puts stress on the internal buffers, ensuring that
+/// each layer behave properly.
+///
+/// ## Protocol Details
+///
+/// The protocol opens 16 outbound substreams on the connection established event.
+/// Therefore, it will handle 16 outbound substreams and 16 inbound substreams
+/// (open by the remote).
+///
+/// The outbound substreams will push a configurable number of packets, each of
+/// size 128 bytes, to the remote peer. While the inbound substreams will read
+/// the same number of packets from the remote peer.
+pub struct StabilityProtocol {
+    /// The number of identical packets to send / receive on a substream.
+    total_packets: usize,
+    inbound: FuturesStream<BoxFuture<'static, Result<(), String>>>,
+    outbound: FuturesStream<BoxFuture<'static, Result<(), String>>>,
+    /// Peer Id for logging purposes.
+    peer_id: PeerId,
+    /// The sender to notify the test that the protocol finished.
+    tx: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl StabilityProtocol {
+    fn new(total_packets: usize, peer_id: PeerId) -> (Self, tokio::sync::oneshot::Receiver<()>) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        (
+            Self {
+                total_packets,
+                inbound: FuturesStream::new(),
+                outbound: FuturesStream::new(),
+                peer_id,
+                tx: Some(tx),
+            },
+            rx,
+        )
+    }
+
+    fn handle_substream(&mut self, mut substream: Substream, direction: Direction) {
+        let mut total_packets = self.total_packets;
+        match direction {
+            Direction::Inbound => {
+                self.inbound.push(Box::pin(async move {
+                    while total_packets > 0 {
+                        let _payload = substream
+                            .next()
+                            .await
+                            .ok_or_else(|| {
+                                tracing::warn!(target: LOG_TARGET, "Failed to read None from substream");
+                                "Failed to read None from substream".to_string()
+                            })?
+                            .map_err(|err| {
+                                tracing::warn!(target: LOG_TARGET, "Failed to read from substream {:?}", err);
+                                "Failed to read from substream".to_string()
+                            })?;
+                        total_packets -= 1;
+                    }
+
+                    Ok(())
+                }));
+            }
+            Direction::Outbound { .. } => {
+                self.outbound.push(Box::pin(async move {
+                    let mut frame = vec![0; 128];
+                    for i in 0..frame.len() {
+                        frame[i] = i as u8;
+                    }
+
+                    while total_packets > 0 {
+                        substream.send_framed(frame.clone().into()).await.map_err(|err| {
+                            tracing::warn!("Failed to send to substream {:?}", err);
+                            "Failed to send to substream".to_string()
+                        })?;
+                        total_packets -= 1;
+                    }
+
+                    Ok(())
+                }));
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl UserProtocol for StabilityProtocol {
+    fn protocol(&self) -> ProtocolName {
+        PROTOCOL_NAME.into()
+    }
+
+    fn codec(&self) -> ProtocolCodec {
+        // Similar to the identify payload size.
+        ProtocolCodec::UnsignedVarint(Some(4096))
+    }
+
+    async fn run(mut self: Box<Self>, mut service: TransportService) -> litep2p::Result<()> {
+        let num_substreams = 16;
+        let mut handled_substreams = 0;
+
+        loop {
+            if handled_substreams == 2 * num_substreams {
+                tracing::info!(
+                    target: LOG_TARGET,
+                    handled_substreams,
+                    peer_id = %self.peer_id,
+                    "StabilityProtocol finished to handle packets",
+                );
+
+                self.tx.take().expect("Send happens only once; qed").send(()).unwrap();
+                // If one of the stability protocols finishes, while the
+                // the other is still reading data from the stream, the test
+                // might race if the substream detects the connection as closed.
+                futures::future::pending::<()>().await;
+            }
+
+            tokio::select! {
+                event = service.next() => match event {
+                    Some(TransportEvent::ConnectionEstablished { peer, .. }) => {
+                        for i in 0..num_substreams {
+                            match service.open_substream(peer) {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    tracing::error!(
+                                        target: LOG_TARGET,
+                                        ?e,
+                                        i,
+                                        peer_id = %self.peer_id,
+                                        "Failed to open substream"
+                                    );
+                                    // Drop the tx sender.
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                    Some(TransportEvent::ConnectionClosed { peer }) => {
+                        tracing::error!(
+                            target: LOG_TARGET,
+                            peer_id = %self.peer_id,
+                            "Connection closed unexpectedly: {}",
+                            peer
+                        );
+
+                        panic!("connection closed");
+                    }
+                    Some(TransportEvent::SubstreamOpened {
+                        substream,
+                        direction,
+                        ..
+                    }) => {
+                        self.handle_substream(substream, direction);
+                    }
+                    _ => {},
+                },
+
+                inbound = self.inbound.next(), if !self.inbound.is_empty() => {
+                    match inbound {
+                        Some(Ok(())) => {
+                            handled_substreams += 1;
+                        }
+                        Some(Err(err)) => {
+                            tracing::error!(
+                                target: LOG_TARGET,
+                                peer_id = %self.peer_id,
+                                "Inbound stream failed with error: {}",
+                                err
+                            );
+                            // Drop the tx sender.
+                            return Ok(());
+                        }
+                        None => {
+                            tracing::error!(
+                                target: LOG_TARGET,
+                                peer_id = %self.peer_id,
+                                "Inbound stream failed with None",
+                            );
+                            panic!("Inbound stream failed");
+                        }
+                    }
+                },
+
+                outbound = self.outbound.next(), if !self.outbound.is_empty() => {
+                    match outbound {
+                        Some(Ok(())) => {
+                            handled_substreams += 1;
+                        }
+                        Some(Err(err)) => {
+                            tracing::error!(
+                                target: LOG_TARGET,
+                                peer_id = %self.peer_id,
+                                "Outbound stream failed with error: {}",
+                                err
+                            );
+                            // Drop the tx sender.
+                            return Ok(());
+                        }
+                        None => {
+                            tracing::error!(
+                                target: LOG_TARGET,
+                                peer_id = %self.peer_id,
+                                "Outbound stream failed with None",
+                            );
+                            panic!("Outbound stream failed");
+                        }
+                    }
+                },
+            }
+        }
+    }
+}
+
+async fn stability_litep2p_transport(transport1: Transport, transport2: Transport) {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let (ping_config1, _ping_event_stream1) = PingConfig::default();
+    let keypair = Keypair::generate();
+    let peer_id = keypair.public().to_peer_id();
+    let (stability_protocol, mut exit1) = StabilityProtocol::new(1000, peer_id);
+    let config1 = ConfigBuilder::new()
+        .with_keypair(keypair)
+        .with_libp2p_ping(ping_config1)
+        .with_user_protocol(Box::new(stability_protocol));
+
+    let config1 = add_transport(config1, transport1).build();
+
+    let (ping_config2, _ping_event_stream2) = PingConfig::default();
+    let keypair = Keypair::generate();
+    let peer_id = keypair.public().to_peer_id();
+    let (stability_protocol, mut exit2) = StabilityProtocol::new(1000, peer_id);
+    let config2 = ConfigBuilder::new()
+        .with_keypair(keypair)
+        .with_libp2p_ping(ping_config2)
+        .with_user_protocol(Box::new(stability_protocol));
+
+    let config2 = add_transport(config2, transport2).build();
+
+    let mut litep2p1 = Litep2p::new(config1).unwrap();
+    let mut litep2p2 = Litep2p::new(config2).unwrap();
+
+    let address = litep2p2.listen_addresses().next().unwrap().clone();
+    litep2p1.dial_address(address).await.unwrap();
+
+    let mut litep2p1_exit = false;
+    let mut litep2p2_exit = false;
+    loop {
+        if litep2p1_exit && litep2p2_exit {
+            break;
+        }
+
+        tokio::select! {
+            // Wait for the stability protocols to finish, while keeping
+            // the peer connections alive.
+            event = &mut exit1, if !litep2p1_exit => {
+                if let Ok(()) = event {
+                    litep2p1_exit = true;
+                } else {
+                    panic!("StabilityProtocol 1 failed");
+                }
+            },
+            event = &mut exit2, if !litep2p2_exit => {
+                if let Ok(()) = event {
+                    litep2p2_exit = true;
+                } else {
+                    panic!("StabilityProtocol 2 failed");
+                }
+            },
+
+            // Drive litep2p backends.
+            event = litep2p1.next_event() => {
+                tracing::info!(target: LOG_TARGET, "litep2p1 event: {:?}", event);
+            }
+            event = litep2p2.next_event() => {
+                tracing::info!(target: LOG_TARGET, "litep2p2 event: {:?}", event);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn stability_tcp() {
+    let transport1 = Transport::Tcp(TcpConfig::default());
+    let transport2 = Transport::Tcp(TcpConfig::default());
+
+    stability_litep2p_transport(transport1, transport2).await;
+}
+
+#[cfg(feature = "websocket")]
+#[tokio::test]
+async fn stability_websocket() {
+    use litep2p::transport::websocket::config::Config as WebSocketConfig;
+
+    let transport1 = Transport::WebSocket(WebSocketConfig::default());
+    let transport2 = Transport::WebSocket(WebSocketConfig::default());
+
+    stability_litep2p_transport(transport1, transport2).await;
+}


### PR DESCRIPTION
This PR greatly improves the WebSocket connection stability by relying on the interval buffers of tungstenite instead of buffering at a higher level. The fix passes through the messages to the tungstenite socket directly. 

This is a long-lasting issue (reproducible on all older versions silently with IO errors) that manifested as a decryption error after the state fixes:
- https://github.com/paritytech/litep2p/pull/325
- https://github.com/paritytech/litep2p/pull/327

Issue context:
- node is under stress due to handling multiple substreams
- the issue affected only long running WebSocket substreams and manifested as an IO error from crypto/noise decoding
- tungstenite `WebSocketStream` already has a 128KiB buffer for writing
- litep2p has a **redundant** 8 KiB buffer for writing 
- litep2p buffered internally multiple packets, tunstenite accepted the batch. I expect this creates a wrongly framed packet that fails to decode at the crypto/noise level


## Investigation

We have noted several errors that manifested as crypto/nosie decoding failures on our Kusama validators:
- https://github.com/paritytech/polkadot-sdk/issues/8525

```rust
litep2p::crypto::noise: failed to decrypt message error=Decrypt
```

Upon further investigation, the errors affected only WebSocket connections. The issue could be reproduced by running a local node in Kusama with more than 500 peers in and out. As well as running subp2p-explorer with adjusted protocols:

```yaml
2025-05-15T14:58:08.095961Z ERROR {peer_id=peer_id=12D3KooWGsDvWrbApFTCpF8h7YCKHuvJbok6HAq5ZnPgE9LGWnsv}:
litep2p::crypto::noise: failed to decrypt message for bigger buffers error=Decrypt peer=PeerId("12D3KooWSa5SbCHGKpNeSs3Qak2TrM5gTkEBrPfvo6TyxhUpEHeu")

2025-05-15T14:58:08.096419Z DEBUG 
{peer_id=peer_id=12D3KooWGsDvWrbApFTCpF8h7YCKHuvJbok6HAq5ZnPgE9LGWnsv}:
litep2p::websocket::connection: connection closed with error peer=PeerId("12D3KooWSa5SbCHGKpNeSs3Qak2TrM5gTkEBrPfvo6TyxhUpEHeu") error=Decode(Io(Custom { kind: Other, error: "failed to decrypt message bigger buffers: decrypt error 12D3KooWSa5SbCHGKpNeSs3Qak2TrM5gTkEBrPfvo6TyxhUpEHeu" }))
```



The issue also reproduced on the zombinet PR, which uses litep2p:
- https://github.com/paritytech/polkadot-sdk/pull/8461

```yaml
2025-05-14 09:37:30.805  INFO tokio-runtime-worker sync: Warp sync is complete, continuing with state sync.    

2025-05-14 09:37:33.189 ERROR tokio-runtime-worker litep2p::crypto::noise: failed to decrypt message error=Decrypt
2025-05-14 09:37:33.283 ERROR tokio-runtime-worker litep2p::crypto::noise: failed to decrypt message error=Decrypt
2025-05-14 09:37:34.764 ERROR tokio-runtime-worker litep2p::crypto::noise: failed to decrypt message error=Decrypt
	
2025-05-14 09:37:35.656  INFO tokio-runtime-worker substrate: ⚙️  State sync, Downloading state, 22%, 2.21 Mib (0 peers), best: #0 (0xc5e7…d059), finalized #0 (0xc5e7…d059), ⬇ 707.8kiB/s ⬆ 0.5kiB/s    
	
2025-05-14 09:37:40.657  INFO tokio-runtime-worker substrate: ⚙️  State sync, Downloading state, 22%, 2.21 Mib (3 peers), best: #0 (0xc5e7…d059), finalized #0 (0xc5e7…d059), ⬇ 1.0kiB/s ⬆ 1.0kiB/s    
```

## Testing Done

### Performance

Tested the performance with litep2p-perf using the following branch:
- https://github.com/lexnv/litep2p-perf/compare/lexnv/websocket-tests?expand=1

| Status     | Data Size | Time (s) | Bandwidth (Mbit/s) |
|------------|-----------|----------|-------------------|
| **Before** |           |          |                   |
| Uploaded   | 256.00 MiB| 15.1152  | 135.49            |
| Downloaded | 256.00 MiB| 13.2296  | 154.80            |
| **After**  |           |          |                   |
| Uploaded   | 256.00 MiB| 15.7178  | 130.30            |
| Downloaded | 256.00 MiB| 13.2435  | 154.64            |

From the performance table, we are within 3% of the original buggy implementation. I would lean towards a normal variation in our results. Therefore, the performance remains unimpacted.

### Repro Case

Have added a custom user protocol as part of our testing to filter out these errors.

- The protocol opens 16 outbound substreams on the connection established event. Therefore, it will handle 16 outbound substreams and 16 inbound substreams
-  The outbound substreams will push a configurable number of packets, each of size 128 bytes, to the remote peer. While the inbound substreams will read the same number of packets from the remote peer.
 
Before this PR, the TCP was unaffected and the websocket reproduces the decrypt failure. After this PR, the test passes.


Closes: https://github.com/paritytech/polkadot-sdk/issues/8525