### PR TITLE
substream/fix: Allow empty payloads with 0-length frame

### DIFF
--- a/src/substream/mod.rs
+++ b/src/substream/mod.rs
@@ -645,6 +645,13 @@ impl Stream for Substream {
                                                 }
 
                                                 this.offset = 0;
+                                                // Handle empty payloads detected as 0-length frame.
+                                                // The offset must be cleared to 0 to not interfere
+                                                // with next framing.
+                                                if size == 0 {
+                                                    return Poll::Ready(Some(Ok(BytesMut::new())));
+                                                }
+
                                                 this.current_frame_size = Some(size);
                                                 this.read_buffer = BytesMut::zeroed(size);
                                             }


### PR DESCRIPTION
This PR ensures that zero-length frames are propagated to higher levels.

An issue was noted with the compatibility between litep2p and smoldot, which resulted in smoldot not being accepted by substrate-based chains.

The issue stems from the litep2p substream (high level) implementation, which did not handle zero-length frames.

Smoldot sends during the notification handshake a zero-length frame (ie, `frame [0]`).
However, full nodes (litep2p and libp2p) send the node role `Role::Full` (ie, `frame [1, 1]`).
Substrate nodes expected the node `Role`, however zero-length frames were never punished.

This behavior causes the zero-length frames to go unnoticed and further call into `poll_read`.
In the case of smoldot, the connection is terminated after the handshake timeout of 10 seconds.

### Testing Done
- Reproduced the issue locally with zombinet and papi (https://github.com/polkadot-api/polkadot-api/tree/main/integration-tests/zombie-tests)
- The e2e tests were timing out, because litep2p rejected the `/transactions/1` substream with smoldot (however it accepted the /sync substream which sends a different payload)
- Added a new notification test to illustrate this behavior with different payloads (including empty ones)

Closes: https://github.com/smol-dot/smoldot/issues/2128

Thanks @josepot and @tomaka for repro-case and details 🙏 