### PR TITLE
cargo: Bump yamux to 0.13.5 and tokio to 1.45.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,7 +636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1975,7 +1975,7 @@ dependencies = [
  "webpki",
  "x25519-dalek 2.0.1",
  "x509-parser 0.17.0",
- "yamux 0.13.4",
+ "yamux 0.13.5",
  "yasna",
  "zeroize",
 ]
@@ -4690,16 +4690,16 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17610762a1207ee816c6fadc29220904753648aba0a9ed61c7b8336e80a559c4"
+checksum = "3da1acad1c2dc53f0dde419115a38bd8221d8c3e47ae9aeceaf453266d29307e"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.9.0",
  "static_assertions",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,9 +3761,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ x25519-dalek = "2.0.1"
 x509-parser = "0.17.0"
 yasna = "0.5.0"
 zeroize = "1.8.1"
-yamux = "0.13.4"
+yamux = "0.13.5"
 
 # Websocket related dependencies.
 tokio-tungstenite = { version = "0.26.2", features = ["rustls-tls-native-roots", "url"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ socket2 = { version = "0.5.9", features = ["all"] }
 thiserror = "2.0.12"
 tokio-stream = "0.1.12"
 tokio-util = { version = "0.7.15", features = ["compat", "io", "codec"] }
-tokio = { version = "1.44.2", features = ["rt", "net", "io-util", "time", "macros", "sync", "parking_lot"] }
+tokio = { version = "1.45.0", features = ["rt", "net", "io-util", "time", "macros", "sync", "parking_lot"] }
 tracing = { version = "0.1.40", features = ["log"] }
 hickory-resolver = "0.25.2"
 uint = "0.10.0"


### PR DESCRIPTION
This PR updates the yamux crate to 0.13.5 and tokio to 1.45.0.

The yamux update resolves a panic on poisoned states of closed connections. While at it, have bumped tokio as well.