### PR TITLE
chore: Release litep2p version 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] - 2025-05-26
+
+This release primarily focuses on strengthening the stability of the websocket transport. We've resolved an issue where higher-level buffering was causing the Noise protocol to fail when decoding messages.
+
+We've also significantly improved connectivity between litep2p and Smoldot (the Substrate-based light client). Empty frames are now handled correctly, preventing handshake timeouts and ensuring smoother communication.
+
+Finally, we've carried out several dependency updates to keep the library current with the latest versions of its underlying components.
+
+### Fixed
+
+- substream/fix: Allow empty payloads with 0-length frame  ([#395](https://github.com/paritytech/litep2p/pull/395))
+- websocket: Fix connection stability on decrypt messages  ([#393](https://github.com/paritytech/litep2p/pull/393))
+
+### Changed
+
+- crypto/noise: Show peerIDs that fail to decode  ([#392](https://github.com/paritytech/litep2p/pull/392))
+- cargo: Bump yamux to 0.13.5 and tokio to 1.45.0  ([#396](https://github.com/paritytech/litep2p/pull/396))
+- ci: Enforce and apply clippy rules  ([#388](https://github.com/paritytech/litep2p/pull/388))
+- build(deps): bump ring from 0.16.20 to 0.17.14  ([#389](https://github.com/paritytech/litep2p/pull/389))
+- Update hickory-resolver 0.24.2 -> 0.25.2  ([#386](https://github.com/paritytech/litep2p/pull/386))
+
 ## [0.9.4] - 2025-05-01
 
 This release brings several improvements and fixes to litep2p, advancing its stability and readiness for production use.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litep2p"
 description = "Peer-to-peer networking library"
 license = "MIT"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 
 # cargo-machete does not detect serde_millis usage, so we ignore the warning


### PR DESCRIPTION
## [0.9.5] - 2025-05-26

This release primarily focuses on strengthening the stability of the websocket transport. We've resolved an issue where higher-level buffering was causing the Noise protocol to fail when decoding messages.

We've also significantly improved connectivity between litep2p and Smoldot (the Substrate-based light client). Empty frames are now handled correctly, preventing handshake timeouts and ensuring smoother communication.

Finally, we've carried out several dependency updates to keep the library current with the latest versions of its underlying components.

### Fixed

- substream/fix: Allow empty payloads with 0-length frame  ([#395](https://github.com/paritytech/litep2p/pull/395))
- websocket: Fix connection stability on decrypt messages  ([#393](https://github.com/paritytech/litep2p/pull/393))

### Changed

- crypto/noise: Show peerIDs that fail to decode  ([#392](https://github.com/paritytech/litep2p/pull/392))
- cargo: Bump yamux to 0.13.5 and tokio to 1.45.0  ([#396](https://github.com/paritytech/litep2p/pull/396))
- ci: Enforce and apply clippy rules  ([#388](https://github.com/paritytech/litep2p/pull/388))
- build(deps): bump ring from 0.16.20 to 0.17.14  ([#389](https://github.com/paritytech/litep2p/pull/389))
- Update hickory-resolver 0.24.2 -> 0.25.2  ([#386](https://github.com/paritytech/litep2p/pull/386))

cc @paritytech/networking 