### PR TITLE
Fix Bitswap protocol implementation

### DIFF
--- a/src/protocol/libp2p/bitswap/mod.rs
+++ b/src/protocol/libp2p/bitswap/mod.rs
@@ -178,6 +178,13 @@ impl Bitswap {
 
         let mut response = schema::bitswap::Message::default();
 
+        // `Wantlist` field must always be present. This is what the official Kubo IPFS
+        // implementation does.
+        response.wantlist = Some(schema::bitswap::Wantlist {
+            entries: Vec::new(),
+            full: false,
+        });
+
         for entry in entries {
             match entry {
                 ResponseType::Block { cid, block } => {
@@ -205,6 +212,8 @@ impl Bitswap {
 
         let message = response.encode_to_vec().into();
         let _ = tokio::time::timeout(WRITE_TIMEOUT, substream.send_framed(message)).await;
+
+        substream.close().await;
     }
 
     /// Handle bitswap response.


### PR DESCRIPTION
Fix two issues in the Bitswap protocol implementation:

1. Gracefully close the outbound substream — otherwise the underlying io object is dropped and the remote gets the "stream reset" error before having a chance to read the protobuf message.
2. Always set `Wantlist` protobuf field — even though in `proto3` schema all fields are optional, this one is required by the protocol.