### PR TITLE
kad: Expose memory store configuration

### DIFF
--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -770,6 +770,7 @@ fn parse_and_verify_peer_id(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HandshakeTransport {
     Tcp,
+    #[cfg(feature = "websocket")]
     WebSocket,
 }
 

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -29,7 +29,7 @@ use crate::{
             message::KademliaMessage,
             query::{QueryAction, QueryEngine},
             routing_table::RoutingTable,
-            store::{MemoryStore, MemoryStoreAction, MemoryStoreConfig},
+            store::{MemoryStore, MemoryStoreAction},
             types::{ConnectionType, KademliaPeer, Key},
         },
         Direction, TransportEvent, TransportService,
@@ -185,14 +185,7 @@ impl Kademlia {
             service.add_known_address(&peer, addresses.into_iter());
         }
 
-        let store = MemoryStore::with_config(
-            local_peer_id,
-            MemoryStoreConfig {
-                provider_refresh_interval: config.provider_refresh_interval,
-                provider_ttl: config.provider_ttl,
-                ..Default::default()
-            },
-        );
+        let store = MemoryStore::with_config(local_peer_id, config.memory_store_config);
 
         Self {
             service,
@@ -1311,8 +1304,7 @@ mod tests {
             update_mode: RoutingTableUpdateMode::Automatic,
             validation_mode: IncomingRecordValidationMode::Automatic,
             record_ttl: Duration::from_secs(36 * 60 * 60),
-            provider_ttl: Duration::from_secs(48 * 60 * 60),
-            provider_refresh_interval: Duration::from_secs(22 * 60 * 60),
+            memory_store_config: Default::default(),
             event_tx,
             cmd_rx,
             next_query_id,

--- a/src/protocol/libp2p/kademlia/store.rs
+++ b/src/protocol/libp2p/kademlia/store.rs
@@ -22,7 +22,11 @@
 
 use crate::{
     protocol::libp2p::kademlia::{
-        config::{DEFAULT_PROVIDER_REFRESH_INTERVAL, DEFAULT_PROVIDER_TTL},
+        config::{
+            DEFAULT_MAX_PROVIDERS_PER_KEY, DEFAULT_MAX_PROVIDER_ADDRESSES,
+            DEFAULT_MAX_PROVIDER_KEYS, DEFAULT_MAX_RECORDS, DEFAULT_MAX_RECORD_SIZE_BYTES,
+            DEFAULT_PROVIDER_REFRESH_INTERVAL, DEFAULT_PROVIDER_TTL,
+        },
         record::{ContentProvider, Key, ProviderRecord, Record},
         types::Key as KademliaKey,
     },
@@ -352,6 +356,7 @@ impl MemoryStore {
     }
 }
 
+#[derive(Debug)]
 pub struct MemoryStoreConfig {
     /// Maximum number of records to store.
     pub max_records: usize,
@@ -379,11 +384,11 @@ pub struct MemoryStoreConfig {
 impl Default for MemoryStoreConfig {
     fn default() -> Self {
         Self {
-            max_records: 1024,
-            max_record_size_bytes: 65 * 1024,
-            max_provider_keys: 1024,
-            max_provider_addresses: 30,
-            max_providers_per_key: 20,
+            max_records: DEFAULT_MAX_RECORDS,
+            max_record_size_bytes: DEFAULT_MAX_RECORD_SIZE_BYTES,
+            max_provider_keys: DEFAULT_MAX_PROVIDER_KEYS,
+            max_provider_addresses: DEFAULT_MAX_PROVIDER_ADDRESSES,
+            max_providers_per_key: DEFAULT_MAX_PROVIDERS_PER_KEY,
             provider_refresh_interval: DEFAULT_PROVIDER_REFRESH_INTERVAL,
             provider_ttl: DEFAULT_PROVIDER_TTL,
         }


### PR DESCRIPTION
Allow changing Kademlia memory store defaults.

Required for https://github.com/paritytech/litep2p/issues/405.