### PR TITLE
address: Add bucketed address store to improve CPU usage

### DIFF
--- a/src/protocol/libp2p/kademlia/message.rs
+++ b/src/protocol/libp2p/kademlia/message.rs
@@ -247,7 +247,7 @@ impl KademliaMessage {
                 4 => {
                     let peers = message
                         .closer_peers
-                        .iter()
+                        .into_iter()
                         .filter_map(|peer| KademliaPeer::try_from(peer).ok())
                         .take(replication_factor)
                         .collect();
@@ -285,7 +285,7 @@ impl KademliaMessage {
                         record,
                         peers: message
                             .closer_peers
-                            .iter()
+                            .into_iter()
                             .filter_map(|peer| KademliaPeer::try_from(peer).ok())
                             .take(replication_factor)
                             .collect(),
@@ -296,7 +296,7 @@ impl KademliaMessage {
                     let key = (!message.key.is_empty()).then_some(message.key.into())?;
                     let providers = message
                         .provider_peers
-                        .iter()
+                        .into_iter()
                         .filter_map(|peer| KademliaPeer::try_from(peer).ok())
                         .take(replication_factor)
                         .collect();
@@ -308,13 +308,13 @@ impl KademliaMessage {
                     let key = (!message.key.is_empty()).then_some(message.key.into());
                     let peers = message
                         .closer_peers
-                        .iter()
+                        .into_iter()
                         .filter_map(|peer| KademliaPeer::try_from(peer).ok())
                         .take(replication_factor)
                         .collect();
                     let providers = message
                         .provider_peers
-                        .iter()
+                        .into_iter()
                         .filter_map(|peer| KademliaPeer::try_from(peer).ok())
                         .take(replication_factor)
                         .collect();

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -408,7 +408,7 @@ impl Kademlia {
             .await;
 
         for info in peers {
-            let addresses = info.addresses();
+            let addresses: Vec<Multiaddr> = info.addresses().cloned().collect();
             self.service.add_known_address(&info.peer, addresses.clone().into_iter());
 
             if std::matches!(self.update_mode, RoutingTableUpdateMode::Automatic) {
@@ -544,7 +544,7 @@ impl Kademlia {
 
                 match (providers.len(), providers.pop()) {
                     (1, Some(provider)) => {
-                        let addresses = provider.addresses();
+                        let addresses: Vec<Multiaddr> = provider.addresses().cloned().collect();
 
                         if provider.peer == peer {
                             self.store.put_provider(
@@ -797,7 +797,7 @@ impl Kademlia {
                         query_id: query,
                         peers: peers
                             .into_iter()
-                            .map(|info| (info.peer, info.addresses()))
+                            .map(|info| (info.peer, info.addresses().cloned().collect()))
                             .collect(),
                     })
                     .await;

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -1431,7 +1431,10 @@ mod tests {
         // Check peer addresses.
         match kademlia.routing_table.entry(Key::from(peer)) {
             KBucketEntry::Occupied(entry) => {
-                assert_eq!(entry.addresses(), vec![address_a.clone()]);
+                assert_eq!(
+                    entry.addresses().cloned().collect::<Vec<_>>(),
+                    vec![address_a.clone()]
+                );
             }
             _ => panic!("Peer not found in routing table"),
         };
@@ -1450,7 +1453,7 @@ mod tests {
         match kademlia.routing_table.entry(Key::from(peer)) {
             KBucketEntry::Occupied(entry) => {
                 assert_eq!(
-                    entry.addresses(),
+                    entry.addresses().cloned().collect::<Vec<_>>(),
                     vec![address_b.clone(), address_a.clone()]
                 );
             }
@@ -1469,7 +1472,7 @@ mod tests {
         match kademlia.routing_table.entry(Key::from(peer)) {
             KBucketEntry::Occupied(entry) => {
                 assert_eq!(
-                    entry.addresses(),
+                    entry.addresses().cloned().collect::<Vec<_>>(),
                     vec![address_b.clone(), address_a.clone()]
                 );
             }
@@ -1483,7 +1486,7 @@ mod tests {
         match kademlia.routing_table.entry(Key::from(peer)) {
             KBucketEntry::Occupied(entry) => {
                 assert_eq!(
-                    entry.addresses(),
+                    entry.addresses().cloned().collect::<Vec<_>>(),
                     vec![address_a.clone(), address_b.clone()]
                 );
             }

--- a/src/protocol/libp2p/kademlia/query/get_providers.rs
+++ b/src/protocol/libp2p/kademlia/query/get_providers.rs
@@ -117,7 +117,10 @@ impl GetProvidersContext {
         // Merge addresses of different provider records of the same peer.
         let mut providers = HashMap::<PeerId, HashSet<Multiaddr>>::new();
         found_providers.into_iter().for_each(|provider| {
-            providers.entry(provider.peer).or_default().extend(provider.addresses())
+            providers
+                .entry(provider.peer)
+                .or_default()
+                .extend(provider.addresses().cloned())
         });
 
         // Convert into `Vec<KademliaPeer>`

--- a/src/protocol/libp2p/kademlia/record.rs
+++ b/src/protocol/libp2p/kademlia/record.rs
@@ -23,7 +23,7 @@ use crate::{
     protocol::libp2p::kademlia::types::{
         ConnectionType, Distance, KademliaPeer, Key as KademliaKey,
     },
-    transport::manager::address::{AddressRecord, AddressStore},
+    transport::manager::address::AddressStoreBuckets,
     Multiaddr, PeerId,
 };
 
@@ -170,15 +170,10 @@ pub struct ContentProvider {
 
 impl From<ContentProvider> for KademliaPeer {
     fn from(provider: ContentProvider) -> Self {
-        let mut address_store = AddressStore::new();
-        for address in provider.addresses.iter() {
-            address_store.insert(AddressRecord::from_raw_multiaddr(address.clone()));
-        }
-
         Self {
             key: KademliaKey::from(provider.peer),
             peer: provider.peer,
-            address_store,
+            address_store: AddressStoreBuckets::from_unknown(provider.addresses),
             connection: ConnectionType::NotConnected,
         }
     }

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -400,7 +400,7 @@ mod tests {
             KBucketEntry::Occupied(entry) => {
                 assert_eq!(entry.key, key);
                 assert_eq!(entry.peer, peer);
-                assert_eq!(entry.addresses(), addresses);
+                assert_eq!(entry.addresses().cloned().collect::<Vec<_>>(), addresses);
                 assert_eq!(entry.connection, ConnectionType::Connected);
             }
             state => panic!("invalid state for `KBucketEntry`: {state:?}"),
@@ -418,7 +418,7 @@ mod tests {
             KBucketEntry::Occupied(entry) => {
                 assert_eq!(entry.key, key);
                 assert_eq!(entry.peer, peer);
-                assert_eq!(entry.addresses(), addresses);
+                assert_eq!(entry.addresses().cloned().collect::<Vec<_>>(), addresses);
                 assert_eq!(entry.connection, ConnectionType::NotConnected);
             }
             state => panic!("invalid state for `KBucketEntry`: {state:?}"),
@@ -508,7 +508,7 @@ mod tests {
             KBucketEntry::Occupied(entry) => {
                 assert_eq!(entry.key, key);
                 assert_eq!(entry.peer, peer);
-                assert_eq!(entry.addresses(), addresses);
+                assert_eq!(entry.addresses().cloned().collect::<Vec<_>>(), addresses);
                 assert_eq!(entry.connection, ConnectionType::CanConnect);
             }
             state => panic!("invalid state for `KBucketEntry`: {state:?}"),

--- a/src/protocol/libp2p/kademlia/types.rs
+++ b/src/protocol/libp2p/kademlia/types.rs
@@ -284,10 +284,10 @@ impl KademliaPeer {
     }
 }
 
-impl TryFrom<&schema::kademlia::Peer> for KademliaPeer {
+impl TryFrom<schema::kademlia::Peer> for KademliaPeer {
     type Error = ();
 
-    fn try_from(record: &schema::kademlia::Peer) -> Result<Self, Self::Error> {
+    fn try_from(record: schema::kademlia::Peer) -> Result<Self, Self::Error> {
         let peer = PeerId::from_bytes(&record.id).map_err(|_| ())?;
         let addresses = record.addrs.into_iter().filter_map(|addr| Multiaddr::try_from(addr).ok());
 
@@ -307,7 +307,6 @@ impl From<&KademliaPeer> for schema::kademlia::Peer {
             addrs: peer
                 .address_store
                 .addresses(MAX_ADDRESSES)
-                .iter()
                 .map(|address| address.to_vec())
                 .collect(),
             connection: peer.connection.into(),

--- a/src/protocol/libp2p/kademlia/types.rs
+++ b/src/protocol/libp2p/kademlia/types.rs
@@ -26,7 +26,7 @@
 
 use crate::{
     protocol::libp2p::kademlia::schema,
-    transport::manager::address::{AddressRecord, AddressStore, AddressStoreBuckets},
+    transport::manager::address::{AddressRecord, AddressStoreBuckets},
     PeerId,
 };
 
@@ -279,7 +279,7 @@ impl KademliaPeer {
     }
 
     /// Returns the addresses of the peer.
-    pub fn addresses(&self) -> Vec<Multiaddr> {
+    pub fn addresses(&self) -> impl Iterator<Item = &Multiaddr> {
         self.address_store.addresses(MAX_ADDRESSES)
     }
 }

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -304,15 +304,10 @@ impl AddressStoreBuckets {
     /// If the addresses exceed the maximum capacity, they will be truncated.
     pub fn from_unknown(addresses: impl IntoIterator<Item = Multiaddr>) -> Self {
         let mut store = Self::new();
-        for address in addresses.take(MAX_UNKNOWN_ADDRESSES) {
+        for address in addresses.into_iter().take(MAX_UNKNOWN_ADDRESSES) {
             store.unknown.insert(address);
         }
         store
-    }
-
-    /// Get the score for a given error.
-    pub fn error_score(_error: &DialError) -> i32 {
-        scores::CONNECTION_FAILURE
     }
 
     /// Insert an address record into the appropriate bucket based on its score.

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -261,6 +261,25 @@ impl AddressStore {
     }
 }
 
+/// Buckets for storing addresses based on dial results.
+///
+/// This is a more optimized version of [`AddressStore`] that separates addresses
+/// based on their dial results (success, unknown, failure).
+///
+/// It allows for more efficient management of addresses based on their dial outcomes,
+/// reducing the need for sorting and filtering during address selection.
+#[derive(Debug, Clone, Default)]
+pub struct AddressStoreBuckets {
+    /// Addresses with successful dials.
+    pub success: HashMap<PeerId, AddressRecord>,
+
+    /// Addresses not yet dialed.
+    pub unknown: HashMap<PeerId, AddressRecord>,
+
+    /// Addresses with dial failures.
+    pub failure: HashMap<PeerId, AddressRecord>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::{

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -337,6 +337,15 @@ impl AddressStoreBuckets {
     pub fn is_empty(&self) -> bool {
         self.success.is_empty() && self.unknown.is_empty() && self.failure.is_empty()
     }
+
+    /// Return the available addresses from all buckets.
+    pub fn addresses(&self, limit: usize) -> impl Iterator<Item = &Multiaddr> {
+        self.success
+            .iter()
+            .chain(self.unknown.iter())
+            .chain(self.failure.iter())
+            .take(limit)
+    }
 }
 
 #[cfg(test)]

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -320,6 +320,7 @@ impl AddressStoreBuckets {
                 self.unknown.remove(&address);
                 self.failure.remove(&address);
 
+                Self::ensure_space(&mut self.success);
                 self.success.insert(address);
             }
             0 => {
@@ -327,6 +328,7 @@ impl AddressStoreBuckets {
                 self.success.remove(&address);
                 self.failure.remove(&address);
 
+                Self::ensure_space(&mut self.unknown);
                 self.unknown.insert(address);
             }
             _ => {
@@ -334,8 +336,21 @@ impl AddressStoreBuckets {
                 self.success.remove(&address);
                 self.unknown.remove(&address);
 
+                Self::ensure_space(&mut self.failure);
                 self.failure.insert(address);
             }
+        }
+    }
+
+    /// Ensure that there is space in the bucket.
+    fn ensure_space(bucket: &mut HashSet<Multiaddr>) {
+        if bucket.len() < bucket.capacity() {
+            return;
+        }
+
+        // Remove the first element to ensure space.
+        if let Some(first) = bucket.iter().next().cloned() {
+            bucket.remove(&first);
         }
     }
 

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -299,6 +299,17 @@ impl AddressStoreBuckets {
         }
     }
 
+    /// Create [`AddressStoreBuckets`] from a set of unknown addresses.
+    ///
+    /// If the addresses exceed the maximum capacity, they will be truncated.
+    pub fn from_unknown(addresses: impl IntoIterator<Item = Multiaddr>) -> Self {
+        let mut store = Self::new();
+        for address in addresses.take(MAX_UNKNOWN_ADDRESSES) {
+            store.unknown.insert(address);
+        }
+        store
+    }
+
     /// Get the score for a given error.
     pub fn error_score(_error: &DialError) -> i32 {
         scores::CONNECTION_FAILURE


### PR DESCRIPTION
This PR adds a new `AddressStoreBuckets` to hold the addresses of a kademlia peer.

The new structure contains 3 buckets:
- successfully dialed addresses
- not yet dialed addresses
- addresses that failed to dial

This has the main benefit of not sorting addresses by score while returning the peer addresses, which is a frequent operation needed to respond to FIND_NODE queries. The assumption is that the new address store, designed specifically for Kademlia, will improve CPU usage by roughly 5-7%.


## Next steps
Before reviewing this PR need to go through:

- [ ] versi net testing
- [ ] deployed on kusama validator to validate perf assumption
- [ ] if performance looks promising consider switching transport manager as well

Closes: https://github.com/paritytech/litep2p/issues/408

