### PR TITLE
manager: Expose option to forbid dialing private IP addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,6 +1943,7 @@ dependencies = [
  "hex-literal",
  "hickory-resolver",
  "indexmap",
+ "ip_network",
  "libc",
  "libp2p",
  "mockall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ x509-parser = "0.17.0"
 yasna = "0.5.0"
 zeroize = "1.8.1"
 yamux = "0.13.5"
+ip_network = { version = "0.4.1" }
 
 # Websocket related dependencies.
 tokio-tungstenite = { version = "0.26.2", features = ["rustls-tls-native-roots", "url"], optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,7 +126,7 @@ pub struct ConfigBuilder {
     keep_alive_timeout: Duration,
 
     /// True if litep2p should attempt to dial local addresses.
-    local_dialing: bool,
+    use_private_ip: bool,
 }
 
 impl Default for ConfigBuilder {
@@ -160,7 +160,7 @@ impl ConfigBuilder {
             known_addresses: Vec::new(),
             connection_limits: ConnectionLimitsConfig::default(),
             keep_alive_timeout: KEEP_ALIVE_TIMEOUT,
-            local_dialing: true,
+            use_private_ip: true,
         }
     }
 
@@ -282,19 +282,20 @@ impl ConfigBuilder {
         self
     }
 
-    /// Set the local dialing behavior.
+    /// Allow or forbid connecting to private IPv4/IPv6 addresses.
     ///
-    /// When the local dialing is enabled, litep2p will attempt to dial local addresses.
+    /// When the private IP is enabled, litep2p will attempt to dial local addresses.
     /// This is useful for testing or when you want to preserve local connections.
     ///
-    /// However, for production use, it is recommended to disable local dialing
+    /// However, for production use, it is recommended to disable the private IP dialing
     /// to avoid unnecessary local traffic. Furthermore, it is not recommended
-    /// to enable local dialing when running a validator in a cloud provider, as this behavior
+    /// to enable private IP dialing when running a validator in a cloud provider, as this behavior
     /// might be misinterpreted by the cloud provider's network policies as port scanning.
     ///
-    /// By default, local dialing is enabled.
-    pub fn with_local_dialing(mut self, enable: bool) -> Self {
-        self.local_dialing = enable;
+    /// Address allocation for private networks is specified by
+    /// [RFC1918](https://tools.ietf.org/html/rfc1918)).
+    pub fn with_private_ip(mut self, enable: bool) -> Self {
+        self.use_private_ip = enable;
         self
     }
 
@@ -327,7 +328,7 @@ impl ConfigBuilder {
             known_addresses: self.known_addresses,
             connection_limits: self.connection_limits,
             keep_alive_timeout: self.keep_alive_timeout,
-            local_dialing: self.local_dialing,
+            use_private_ip: self.use_private_ip,
         }
     }
 }
@@ -392,5 +393,5 @@ pub struct Litep2pConfig {
     pub(crate) keep_alive_timeout: Duration,
 
     /// True if litep2p should attempt to dial local addresses.
-    pub(crate) local_dialing: bool,
+    pub(crate) use_private_ip: bool,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,6 +124,9 @@ pub struct ConfigBuilder {
 
     /// Close the connection if no substreams are open within this time frame.
     keep_alive_timeout: Duration,
+
+    /// True if litep2p should attempt to dial local addresses.
+    local_dialing: bool,
 }
 
 impl Default for ConfigBuilder {
@@ -157,6 +160,7 @@ impl ConfigBuilder {
             known_addresses: Vec::new(),
             connection_limits: ConnectionLimitsConfig::default(),
             keep_alive_timeout: KEEP_ALIVE_TIMEOUT,
+            local_dialing: true,
         }
     }
 
@@ -278,6 +282,22 @@ impl ConfigBuilder {
         self
     }
 
+    /// Set the local dialing behavior.
+    ///
+    /// When the local dialing is enabled, litep2p will attempt to dial local addresses.
+    /// This is useful for testing or when you want to preserve local connections.
+    ///
+    /// However, for production use, it is recommended to disable local dialing
+    /// to avoid unnecessary local traffic. Furthermore, it is not recommended
+    /// to enable local dialing when running a validator in a cloud provider, as this behavior
+    /// might be misinterpreted by the cloud provider's network policies as port scanning.
+    ///
+    /// By default, local dialing is enabled.
+    pub fn with_local_dialing(mut self, enable: bool) -> Self {
+        self.local_dialing = enable;
+        self
+    }
+
     /// Build [`Litep2pConfig`].
     pub fn build(mut self) -> Litep2pConfig {
         let keypair = match self.keypair {
@@ -307,6 +327,7 @@ impl ConfigBuilder {
             known_addresses: self.known_addresses,
             connection_limits: self.connection_limits,
             keep_alive_timeout: self.keep_alive_timeout,
+            local_dialing: self.local_dialing,
         }
     }
 }
@@ -369,4 +390,7 @@ pub struct Litep2pConfig {
 
     /// Close the connection if no substreams are open within this time frame.
     pub(crate) keep_alive_timeout: Duration,
+
+    /// True if litep2p should attempt to dial local addresses.
+    pub(crate) local_dialing: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ impl Litep2p {
             bandwidth_sink.clone(),
             litep2p_config.max_parallel_dials,
             litep2p_config.connection_limits,
+            litep2p_config.use_private_ip,
         );
 
         // add known addresses to `TransportManager`, if any exist

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -1281,6 +1281,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true
         );
 
         let peer = PeerId::random();

--- a/src/protocol/mdns.rs
+++ b/src/protocol/mdns.rs
@@ -355,6 +355,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         let mdns1 = Mdns::new(
@@ -378,6 +379,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         let mdns2 = Mdns::new(

--- a/src/protocol/notification/tests/mod.rs
+++ b/src/protocol/notification/tests/mod.rs
@@ -57,6 +57,7 @@ fn make_notification_protocol() -> (
         BandwidthSink::new(),
         8usize,
         ConnectionLimitsConfig::default(),
+        true,
     );
 
     let peer = PeerId::random();

--- a/src/protocol/request_response/tests.rs
+++ b/src/protocol/request_response/tests.rs
@@ -55,6 +55,7 @@ fn protocol() -> (
         BandwidthSink::new(),
         8usize,
         ConnectionLimitsConfig::default(),
+        true,
     );
 
     let peer = PeerId::random();

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -217,6 +217,11 @@ impl AddressStore {
         self.addresses.is_empty()
     }
 
+    /// Remove the address record from [`AddressStore`] by its address.
+    pub fn remove(&mut self, address: &Multiaddr) -> Option<AddressRecord> {
+        self.addresses.remove(address)
+    }
+
     /// Insert the address record into [`AddressStore`] with the provided score.
     ///
     /// If the address is not in the store, it will be inserted.
@@ -258,6 +263,13 @@ impl AddressStore {
         let mut records = self.addresses.values().cloned().collect::<Vec<_>>();
         records.sort_by(|lhs, rhs| rhs.score.cmp(&lhs.score));
         records.into_iter().take(limit).map(|record| record.address).collect()
+    }
+
+    /// Similar to [`Self::addresses`], but returns an iterator over the addresses.
+    pub fn addresses_iter(&self) -> impl Iterator<Item = &Multiaddr> {
+        let mut records = self.addresses.values().collect::<Vec<_>>();
+        records.sort_by(|lhs, rhs| rhs.score.cmp(&lhs.score));
+        records.into_iter().map(|record| &record.address)
     }
 }
 

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -217,11 +217,6 @@ impl AddressStore {
         self.addresses.is_empty()
     }
 
-    /// Remove the address record from [`AddressStore`] by its address.
-    pub fn remove(&mut self, address: &Multiaddr) -> Option<AddressRecord> {
-        self.addresses.remove(address)
-    }
-
     /// Insert the address record into [`AddressStore`] with the provided score.
     ///
     /// If the address is not in the store, it will be inserted.

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -252,6 +252,9 @@ pub struct TransportManager {
 
     /// Opening connections errors.
     opening_errors: HashMap<ConnectionId, Vec<(Multiaddr, DialError)>>,
+
+    /// True if litep2p should attempt to dial local addresses.
+    use_private_ip: bool,
 }
 
 impl TransportManager {
@@ -263,6 +266,7 @@ impl TransportManager {
         bandwidth_sink: BandwidthSink,
         max_parallel_dials: usize,
         connection_limits_config: limits::ConnectionLimitsConfig,
+        use_private_ip: bool,
     ) -> (Self, TransportManagerHandle) {
         let local_peer_id = PeerId::from_public_key(&keypair.public().into());
         let peers = Arc::new(RwLock::new(HashMap::new()));
@@ -300,6 +304,7 @@ impl TransportManager {
                 next_connection_id: Arc::new(AtomicUsize::new(0usize)),
                 connection_limits: limits::ConnectionLimits::new(connection_limits_config),
                 opening_errors: HashMap::new(),
+                use_private_ip,
             },
             handle,
         )
@@ -1534,6 +1539,7 @@ mod tests {
             sink,
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         manager.register_protocol(
@@ -1561,6 +1567,7 @@ mod tests {
             sink,
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         manager.register_protocol(
@@ -1591,6 +1598,7 @@ mod tests {
             sink,
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         manager.register_protocol(
@@ -1624,6 +1632,7 @@ mod tests {
             sink,
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1641,6 +1650,7 @@ mod tests {
             sink,
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         assert!(manager.dial(local_peer_id).await.is_err());
@@ -1654,6 +1664,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1684,6 +1695,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -1746,6 +1758,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1777,6 +1790,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1822,6 +1836,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1841,6 +1856,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -1874,6 +1890,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         // ipv6
@@ -1936,6 +1953,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -2003,6 +2021,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -2090,6 +2109,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let _handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
@@ -2175,6 +2195,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2284,6 +2305,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2380,6 +2402,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2489,6 +2512,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2593,6 +2617,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -2737,6 +2762,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         manager.on_dial_failure(ConnectionId::random()).unwrap();
@@ -2756,6 +2782,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         manager.on_connection_closed(PeerId::random(), ConnectionId::random()).unwrap();
     }
@@ -2774,6 +2801,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         manager
             .on_connection_opened(
@@ -2798,6 +2826,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2822,6 +2851,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2849,6 +2879,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         manager
@@ -2870,6 +2901,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let connection_id = ConnectionId::random();
         let peer = PeerId::random();
@@ -2890,6 +2922,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         assert!(manager.next().await.is_none());
@@ -2903,6 +2936,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         let peer = {
@@ -2951,6 +2985,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         let peer = {
@@ -3014,6 +3049,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         let peer = {
@@ -3057,6 +3093,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         // transport doesn't start with ip/dns
@@ -3123,6 +3160,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
 
         async fn call_manager(manager: &mut TransportManager, address: Multiaddr) {
@@ -3177,6 +3215,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -3263,6 +3302,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -3516,6 +3556,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -3569,6 +3610,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         manager.register_transport(SupportedTransport::Tcp, Box::new(DummyTransport::new()));
 
@@ -3721,6 +3763,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let peer = PeerId::random();
         let dial_address = Multiaddr::empty()
@@ -3807,6 +3850,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let peer = PeerId::random();
         let connection_id = ConnectionId::from(0);

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -577,6 +577,11 @@ impl TransportManager {
             return Err(Error::TriedToDialSelf);
         }
 
+        if !self.use_private_ip && !Self::is_address_global(address_record.address()) {
+            tracing::debug!(target: LOG_TARGET, address = ?address_record.address(), "dial address is not global, skipping");
+            return Err(Error::AddressError(AddressError::AddressNotAvailable));
+        }
+
         tracing::debug!(target: LOG_TARGET, address = ?address_record.address(), "dial address");
 
         let mut protocol_stack = address_record.as_ref().iter();

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -980,6 +980,7 @@ mod tests {
             BandwidthSink::new(),
             8usize,
             ConnectionLimitsConfig::default(),
+            true,
         );
         let handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
         manager.register_transport(


### PR DESCRIPTION
This PR exposes an option to forbid or allow dialing private IP addresses.

For test networks started locally, it is recommended to use private IP addresses to establish connections.

However, for running production validators, the validator node should never attempt to dial a private IP address.
This behavior can be detected by some cloud providers as port scanning. The downstream effect of that depends on the cloud provider, but most likely, the node will become unreachable or the instance will be terminated.

Before this PR, litep2p might receive a local (private) IP address on either the Kademlia or the Identify protocol from a libp2p node. Now, the transport manager will not forward the dialing request to the installed protocols if the private IP option is disabled.

This may be the case of https://github.com/paritytech/polkadot-sdk/issues/8915, where a node operator running a validator using litep2p on the Polkadot network loses connectivity after a few days.


Closes: https://github.com/paritytech/polkadot-sdk/issues/8631

### Next Steps
- [ ] Wait for further information to be provided by the node operator
- [ ] Ensure the PR is properly tested locally, in versi-net and on kusama validators
