### PR TITLE
cargo: Update tokio-tungstenite to 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,9 +3810,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
@@ -3957,9 +3957,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ zeroize = "1.8.1"
 yamux = "0.13.5"
 
 # Websocket related dependencies.
-tokio-tungstenite = { version = "0.26.2", features = ["rustls-tls-native-roots", "url"], optional = true }
+tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots", "url"], optional = true }
 # End of websocket related dependencies.
 
 # Quic related dependencies. Quic is an experimental feature flag. The dependencies must be updated.


### PR DESCRIPTION
This PR updates the tokio tunstenite (the crate we use for websocket connections) to the latest version.

I expect this not to improve things considerably for:
- https://github.com/paritytech/polkadot-sdk/issues/9169

