### PR TITLE
Make `cargo clippy` happy

### DIFF
--- a/src/crypto/tls/certificate.rs
+++ b/src/crypto/tls/certificate.rs
@@ -126,7 +126,7 @@ pub struct VerificationError(#[from] pub(crate) webpki::Error);
 /// Internal function that only parses but does not verify the certificate.
 ///
 /// Useful for testing but unsuitable for production.
-fn parse_unverified(der_input: &[u8]) -> Result<P2pCertificate, webpki::Error> {
+fn parse_unverified<'a>(der_input: &'a [u8]) -> Result<P2pCertificate<'a>, webpki::Error> {
     let x509 = X509Certificate::from_der(der_input)
         .map(|(_rest_input, x509)| x509)
         .map_err(|_| webpki::Error::BadDer)?;

--- a/src/transport/common/listener.rs
+++ b/src/transport/common/listener.rs
@@ -202,8 +202,10 @@ impl GetSocketAddr for TcpAddress {
 }
 
 /// WebSocket helper to convert between `Multiaddr` and `SocketAddr`.
+#[cfg(feature = "websocket")]
 pub struct WebSocketAddress;
 
+#[cfg(feature = "websocket")]
 impl GetSocketAddr for WebSocketAddress {
     fn multiaddr_to_socket_address(
         address: &Multiaddr,
@@ -339,6 +341,7 @@ enum SocketListenerType {
     /// Listener for TCP.
     Tcp,
     /// Listener for WebSocket.
+    #[cfg(feature = "websocket")]
     WebSocket,
 }
 
@@ -406,6 +409,7 @@ fn multiaddr_to_socket_address(
 
     match ty {
         SocketListenerType::Tcp => (),
+        #[cfg(feature = "websocket")]
         SocketListenerType::WebSocket => {
             // verify that `/ws`/`/wss` is part of the multi address
             match iter.next() {
@@ -518,6 +522,7 @@ mod tests {
         .is_err());
     }
 
+    #[cfg(feature = "websocket")]
     #[test]
     fn parse_multiaddresses_websocket() {
         assert!(multiaddr_to_socket_address(
@@ -618,6 +623,7 @@ mod tests {
         .await;
     }
 
+    #[cfg(feature = "websocket")]
     #[tokio::test]
     async fn no_listeners_websocket() {
         let (mut listener, _, _) = SocketListener::new::<WebSocketAddress>(Vec::new(), true, false);
@@ -646,6 +652,7 @@ mod tests {
         assert!(res1.unwrap().is_ok() && res2.is_ok());
     }
 
+    #[cfg(feature = "websocket")]
     #[tokio::test]
     async fn one_listener_websocket() {
         let address: Multiaddr = "/ip6/::1/tcp/0/ws".parse().unwrap();
@@ -689,6 +696,7 @@ mod tests {
         assert!(res1.is_ok() && res2.is_ok());
     }
 
+    #[cfg(feature = "websocket")]
     #[tokio::test]
     async fn two_listeners_websocket() {
         let address1: Multiaddr = "/ip6/::1/tcp/0/ws".parse().unwrap();

--- a/src/transport/dummy.rs
+++ b/src/transport/dummy.rs
@@ -42,7 +42,6 @@ pub(crate) struct DummyTransport {
 
 impl DummyTransport {
     /// Create new [`DummyTransport`].
-    #[cfg(test)]
     pub(crate) fn new() -> Self {
         Self {
             events: VecDeque::new(),
@@ -50,7 +49,6 @@ impl DummyTransport {
     }
 
     /// Inject event into `DummyTransport`.
-    #[cfg(test)]
     pub(crate) fn inject_event(&mut self, event: TransportEvent) {
         self.events.push_back(event);
     }

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -136,7 +136,7 @@ impl Eq for AddressRecord {}
 
 impl PartialOrd for AddressRecord {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.score.cmp(&other.score))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/transport/manager/handle.rs
+++ b/src/transport/manager/handle.rs
@@ -387,7 +387,7 @@ mod tests {
 
     #[tokio::test]
     async fn tcp_unsupported() {
-        let (mut handle, _rx) = make_transport_manager_handle();
+        let (handle, _rx) = make_transport_manager_handle();
 
         let address =
             "/dns4/google.com/tcp/24928/p2p/12D3KooWKrUnV42yDR7G6DewmgHtFaVCJWLjQRi2G9t5eJD3BvTy"
@@ -424,7 +424,7 @@ mod tests {
     #[cfg(feature = "websocket")]
     #[tokio::test]
     async fn websocket_unsupported() {
-        let (mut handle, _rx) = make_transport_manager_handle();
+        let (handle, _rx) = make_transport_manager_handle();
 
         let address =
             "/dns4/google.com/tcp/24928/ws/p2p/12D3KooWKrUnV42yDR7G6DewmgHtFaVCJWLjQRi2G9t5eJD3BvTy"
@@ -462,7 +462,7 @@ mod tests {
     #[cfg(feature = "websocket")]
     #[tokio::test]
     async fn wss_unsupported() {
-        let (mut handle, _rx) = make_transport_manager_handle();
+        let (handle, _rx) = make_transport_manager_handle();
 
         let address =
             "/dns4/google.com/tcp/24928/wss/p2p/12D3KooWKrUnV42yDR7G6DewmgHtFaVCJWLjQRi2G9t5eJD3BvTy"
@@ -500,7 +500,7 @@ mod tests {
     #[cfg(feature = "quic")]
     #[tokio::test]
     async fn quic_unsupported() {
-        let (mut handle, _rx) = make_transport_manager_handle();
+        let (handle, _rx) = make_transport_manager_handle();
 
         let address =
             "/dns4/google.com/udp/24928/quic-v1/p2p/12D3KooWKrUnV42yDR7G6DewmgHtFaVCJWLjQRi2G9t5eJD3BvTy"

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -1377,16 +1377,19 @@ mod tests {
         (dial_address, connection_id)
     }
 
+    #[cfg(feature = "websocket")]
     struct MockTransport {
         rx: tokio::sync::mpsc::Receiver<TransportEvent>,
     }
 
+    #[cfg(feature = "websocket")]
     impl MockTransport {
         fn new(rx: tokio::sync::mpsc::Receiver<TransportEvent>) -> Self {
             Self { rx }
         }
     }
 
+    #[cfg(feature = "websocket")]
     impl Transport for MockTransport {
         fn dial(&mut self, _connection_id: ConnectionId, _address: Multiaddr) -> crate::Result<()> {
             Ok(())
@@ -1422,6 +1425,8 @@ mod tests {
 
         fn cancel(&mut self, _connection_id: ConnectionId) {}
     }
+
+    #[cfg(feature = "websocket")]
     impl Stream for MockTransport {
         type Item = TransportEvent;
         fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -37,7 +37,9 @@ pub mod webrtc;
 #[cfg(feature = "websocket")]
 pub mod websocket;
 
+#[cfg(test)]
 pub(crate) mod dummy;
+
 pub(crate) mod manager;
 
 pub use manager::limits::{ConnectionLimitsConfig, ConnectionLimitsError};


### PR DESCRIPTION
Make `cargo clippy` & `cargo check` happy in default and `--all-features` configurations.

This is needed due to stable toolchain update and clippy now discovering more issues than before in https://github.com/paritytech/litep2p/pull/422.