### PR TITLE
Make `RemotePublicKey` public to enable signature verification

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -94,7 +94,7 @@ impl From<ed25519::PublicKey> for PublicKey {
 
 /// The public key of a remote node's identity keypair. Supports RSA keys additionally to ed25519.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum RemotePublicKey {
+pub enum RemotePublicKey {
     /// A public Ed25519 key.
     Ed25519(ed25519::PublicKey),
     /// A public RSA key.


### PR DESCRIPTION
This is needed to verify signatures made by remote peers using their network keys in polkadot-sdk.