### PR TITLE
webrtc: update str0m, fix multistream message decoding and encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "time",
 ]
 
@@ -1025,15 +1025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generator"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,7 +1161,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "ring 0.17.14",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1193,7 +1184,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -1918,7 +1909,7 @@ dependencies = [
  "snow",
  "socket2 0.5.10",
  "str0m",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -2213,7 +2204,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2237,7 +2228,7 @@ checksum = "862f41f1276e7148fb597fc55ed8666423bebe045199a1298c3515a73ec5cdd9"
 dependencies = [
  "cc",
  "libc",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "winapi",
 ]
 
@@ -2807,7 +2798,7 @@ dependencies = [
  "pin-project-lite 0.2.16",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.20.9",
  "thiserror 1.0.69",
  "tokio",
@@ -2824,7 +2815,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring 0.16.20",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.20.9",
  "slab",
  "thiserror 1.0.69",
@@ -3054,6 +3045,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,17 +3194,17 @@ dependencies = [
 
 [[package]]
 name = "sctp-proto"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dea4fe3384a24652f065296ac333c810dfd0c5b39b98a2214762c16aaadc3c"
+checksum = "423139d8cca3021b9d800f084a711ba2d23b508ae71b33dba167f11ca33e54c7"
 dependencies = [
  "bytes",
  "crc",
- "fxhash",
  "log",
- "rand 0.8.5",
+ "rand 0.9.2",
+ "rustc-hash 2.1.1",
  "slab",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3462,9 +3459,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str0m"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f9fdffeb677e1d5d2cf84993f865143680b8e5eece3396fa488d43b34c1245"
+version = "0.11.0"
+source = "git+https://github.com/algesten/str0m?rev=8058d4d66bc1ac465962f95ac30df3235e671612#8058d4d66bc1ac465962f95ac30df3235e671612"
 dependencies = [
  "combine",
  "crc",
@@ -3477,7 +3473,6 @@ dependencies = [
  "sctp-proto",
  "serde",
  "sha1",
- "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -3589,11 +3584,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -3609,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3896,7 +3891,7 @@ dependencies = [
  "rustls 0.23.29",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "url",
  "utf-8",
 ]
@@ -4701,7 +4696,7 @@ dependencies = [
  "nom",
  "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ rcgen = { version = "0.10.0", optional = true }
 # End of Quic related dependencies.
 
 # WebRTC related dependencies. WebRTC is an experimental feature flag. The dependencies must be updated.
-str0m = { version = "0.9.0", optional = true }
+str0m = { git = "https://github.com/algesten/str0m", rev = "8058d4d66bc1ac465962f95ac30df3235e671612", optional = true }
 # End of WebRTC related dependencies.
 
 # Fuzzing related dependencies.

--- a/src/transport/webrtc/opening.rs
+++ b/src/transport/webrtc/opening.rs
@@ -176,8 +176,8 @@ impl OpeningWebRtcConnection {
             .rtc
             .direct_api()
             .remote_dtls_fingerprint()
-            .clone()
-            .expect("fingerprint to exist");
+            .expect("fingerprint to exist")
+            .clone();
         Self::fingerprint_to_bytes(&fingerprint)
     }
 
@@ -268,8 +268,8 @@ impl OpeningWebRtcConnection {
             .rtc
             .direct_api()
             .remote_dtls_fingerprint()
-            .clone()
             .expect("fingerprint to exist")
+            .clone()
             .bytes;
 
         const MULTIHASH_SHA256_CODE: u64 = 0x12;


### PR DESCRIPTION
## Changes
- updates the str0m dependency to the commit which contains fixes I co-authored (PR [#1](https://github.com/algesten/str0m/pull/711), [#2](https://github.com/algesten/str0m/pull/712))
  - fixes str0m integration based on breaking public API changes
- fixes the decoding of multistream messages to support messages without trailing linebreak
- removes trailing linebreak when encoding multistream message used for WebRTC
- contributes to https://github.com/paritytech/litep2p/issues/420