### PR TITLE
Identify: gracefully close substream after sending payload

### DIFF
--- a/src/protocol/libp2p/identify.rs
+++ b/src/protocol/libp2p/identify.rs
@@ -302,7 +302,9 @@ impl Identify {
                         "failed to send ipfs identify response",
                     );
                 }
-                Ok(_) => {}
+                Ok(_) => {
+                    substream.close().await;
+                }
             }
         }))
     }


### PR DESCRIPTION
This is needed for compatibility with `go-libp2p`, otherwise it gets confused by stream reset.