### PR TITLE
update simple-dns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3368,9 +3368,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simple-dns"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
+checksum = "f8cba3b4c122239e3b4473674cb7c79ad2693f008f0746bfe2fc3fe1ffcd936a"
 dependencies = [
  "bitflags 2.10.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ prost = "0.13.5"
 rand = { version = "0.8.0", features = ["getrandom"] }
 serde = "1.0.158"
 sha2 = "0.10.9"
-simple-dns = "0.9.3"
+simple-dns = "0.11.0"
 smallvec = "1.15.0"
 snow = { version = "0.9.3", features = ["ring-resolver"], default-features = false }
 socket2 = { version = "0.5.9", features = ["all"] }


### PR DESCRIPTION
Upgrades simple-dns from 0.9.3 to 0.11.0. The reason being that we detected segfaults when using this version of simple-dns, here the backtrace

```
Thread 2 "tokio-runtime-w" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff71ff6c0 (LWP 662)]
0x00005555590fa234 in simple_dns::dns::packet::Packet::parse_section::hcaf780141803b06c ()
(gdb) bt
#0  0x00005555590fa234 in simple_dns::dns::packet::Packet::parse_section::hcaf780141803b06c ()
#1  0x0000555558586eb3 in litep2p::protocol::mdns::Mdns::start::{{closure}}::h9dfcac24f1cf526c ()
#2  0x0000555558582ff0 in litep2p::Litep2p::new::{{closure}}::h7e8ab961e0597d4d ()
#3  0x00005555568998cf in <tracing_futures::Instrumented<T> as core::future::future::Future>::poll::h14f8d5a4cd2280a5 ()
#4  0x0000555556623186 in tokio::runtime::task::raw::poll::h20b62065a828f381 ()
#5  0x00005555597c242e in tokio::runtime::scheduler::multi_thread::worker::Context::run_task::hd2657bfbfd77fdd7 ()
#6  0x00005555597c0a60 in tokio::runtime::scheduler::multi_thread::worker::run::hff59903bb30ee69e ()
#7  0x00005555597c6b05 in tokio::runtime::task::raw::poll::hd94431bf703a75c4 ()
#8  0x00005555597af0f8 in std::sys::backtrace::__rust_begin_short_backtrace::h5776829e2c5e1158 ()
#9  0x00005555597b3af8 in core::ops::function::FnOnce::call_once{{vtable.shim}}::hd2821905ea35840e ()
#10 0x00005555593e4abb in std::sys::pal::unix::thread::Thread::new::thread_start::h1822d22fde68314f ()
#11 0x00007ffff7c4d1f5 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#12 0x00007ffff7ccd8dc in ?? () from /lib/x86_64-linux-gnu/libc.so.6
```

We believe it is related to this PR at least partially https://github.com/balliegojr/simple-dns/pull/40 whose changes were introduced here: https://github.com/balliegojr/simple-dns/pull/41

we have confirmed that using 0.11.0 removes the issue.