### PR TITLE
kad: Ensure addresses are propagated only in automatic

### DIFF
--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -201,7 +201,7 @@ pub enum KademliaEvent {
     /// in order to add the peers to routing table.
     RoutingTableUpdate {
         /// Discovered peers.
-        peers: Vec<PeerId>,
+        peers: Vec<(PeerId, Vec<Multiaddr>)>,
     },
 
     /// `GET_VALUE` query succeeded.

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -435,7 +435,10 @@ impl Kademlia {
         let _ = self
             .event_tx
             .send(KademliaEvent::RoutingTableUpdate {
-                peers: peers.iter().map(|peer| peer.peer).collect::<Vec<PeerId>>(),
+                peers: peers
+                    .iter()
+                    .map(|peer| (peer.peer, peer.addresses()))
+                    .collect::<Vec<(PeerId, Vec<Multiaddr>)>>(),
             })
             .await;
 


### PR DESCRIPTION
This PR ensures that the addresses discovered by the Kademlia are propagated to the transport manager only in the `RoutingTableUpdateMode::Automatic`.

While at it, have extended the routing table updates with the addresses discovered on the DHT.