### PR TITLE
Allow all the Bitswap CIDs (v1) to pass regardless of used hash

### DIFF
--- a/src/protocol/libp2p/bitswap/mod.rs
+++ b/src/protocol/libp2p/bitswap/mod.rs
@@ -29,7 +29,6 @@ use crate::{
 };
 
 use cid::Version;
-pub use multihash::Code as MultihashCode;
 use prost::Message;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_stream::{StreamExt, StreamMap};


### PR DESCRIPTION
Relates to the: https://github.com/paritytech/polkadot-sdk/issues/10301

Fully tested with https://github.com/paritytech/polkadot-bulletin-chain/pull/100

## Rationale

The only weak point is that `BitswapRequestHandler` expects a Blake2b hash (due to `BlockT`) here: [https://github.com/paritytech/polkadot-sdk/blob/e588acf5e12b14c68331d2e08afe7c12d6671df9/substrate/client/network/src/bitswap/mod.rs#L208-L209](https://github.com/paritytech/polkadot-sdk/blob/e588acf5e12b14c68331d2e08afe7c12d6671df9/substrate/client/network/src/bitswap/mod.rs#L208-L209). However, this is not a real problem, because we initially create a default 32-byte hash and then replace it with the 32-byte hash from the CID. Since we only claim to support 32-byte hashes, it just works. 😊

## Solution

[Proposed by](https://github.com/paritytech/litep2p/pull/482#pullrequestreview-3504227563) @dmitry-markin - remove CID filtering from litep2p and do filtering in PolkadotSDK - [see more](https://github.com/paritytech/litep2p/pull/482#issuecomment-3574854766).


## Follow-up


As a follow-up, I would refactor `fn indexed_transaction` / `fn has_indexed_transaction` here: [https://github.com/paritytech/polkadot-sdk/blob/e588acf5e12b14c68331d2e08afe7c12d6671df9/substrate/client/api/src/client.rs#L154-L163](https://github.com/paritytech/polkadot-sdk/blob/e588acf5e12b14c68331d2e08afe7c12d6671df9/substrate/client/api/src/client.rs#L154-L163), and make the following change:
```diff
+        type ContentHash = [u8; 32];

	/// Get single indexed transaction by content hash.
	///
	/// Note that this will only fetch transactions
	/// that are indexed by the runtime with `storage_index_transaction`.
-	fn indexed_transaction(&self, hash: Block::Hash) -> sp_blockchain::Result<Option<Vec<u8>>>;
+	fn indexed_transaction(&self, hash: ContentHash) -> sp_blockchain::Result<Option<Vec<u8>>>;

	/// Check if transaction index exists.
-	fn has_indexed_transaction(&self, hash: Block::Hash) -> sp_blockchain::Result<bool> {
-	fn has_indexed_transaction(&self, hash: ContentHash) -> sp_blockchain::Result<bool> {
```


Ultimately, we index transactions by their content hash, which is a `[u8; 32]` here:
[https://github.com/paritytech/polkadot-sdk/blob/e588acf5e12b14c68331d2e08afe7c12d6671df9/substrate/primitives/io/src/lib.rs#L1494](https://github.com/paritytech/polkadot-sdk/blob/e588acf5e12b14c68331d2e08afe7c12d6671df9/substrate/primitives/io/src/lib.rs#L1494),
and it is generated as a `[u8; 32]` here:
[https://github.com/paritytech/polkadot-sdk/blob/e588acf5e12b14c68331d2e08afe7c12d6671df9/substrate/frame/transaction-storage/src/lib.rs#L239-L242](https://github.com/paritytech/polkadot-sdk/blob/e588acf5e12b14c68331d2e08afe7c12d6671df9/substrate/frame/transaction-storage/src/lib.rs#L239-L242).

