### PR TITLE
types: Re-export cid's multihash to construct CID V1

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -30,7 +30,7 @@ pub mod multihash {
     pub use multihash::{Code, Error, Multihash, MultihashDigest};
 }
 pub mod cid {
-    pub use cid::{Cid, CidGeneric, Error, Result, Version};
+    pub use cid::{multihash::Multihash, Cid, CidGeneric, Error, Result, Version};
 }
 
 pub mod protocol;


### PR DESCRIPTION
For example in polkadot-sdk

```diff
-	use litep2p::types::multihash::Code;
+	use litep2p::types::{cid::{Cid as LiteP2pCid, multihash::Multihash as LiteP2pMultihash}, multihash::Code as LiteP2pMultihashCode};
 

-							block: cid::Cid::new_v1(
+							block: LiteP2pCid::new_v1(
 								0x70,
-								cid::multihash::Multihash::wrap(
-									u64::from(Code::Blake2b256),
+								LiteP2pMultihash::wrap(
+									u64::from(LiteP2pMultihashCode::Blake2b256),
 									&[0u8; 32],
 								)
```