### PR TITLE
transport-manager: remove disconnected peers

### DIFF
--- a/src/transport/manager/handle.rs
+++ b/src/transport/manager/handle.rs
@@ -725,7 +725,10 @@ mod tests {
             peers.insert(
                 peer,
                 PeerContext {
-                    state: PeerState::Disconnected { dial_record: None },
+                    state: PeerState::Disconnected {
+                        dial_record: None,
+                        disconnected_at: std::time::Instant::now()
+                    },
                     addresses: AddressStore::new(),
                 },
             );
@@ -759,6 +762,7 @@ mod tests {
                                 .with(Protocol::P2p(Multihash::from(peer))),
                             ConnectionId::from(0),
                         )),
+                        disconnected_at: std::time::Instant::now()
                     },
 
                     addresses: AddressStore::from_iter(

--- a/src/transport/manager/types.rs
+++ b/src/transport/manager/types.rs
@@ -52,7 +52,10 @@ pub struct PeerContext {
 impl Default for PeerContext {
     fn default() -> Self {
         Self {
-            state: PeerState::Disconnected { dial_record: None },
+            state: PeerState::Disconnected {
+                dial_record: None,
+                disconnected_at: std::time::Instant::now()
+            },
             addresses: AddressStore::new(),
         }
     }


### PR DESCRIPTION
Rel: https://github.com/paritytech/litep2p/issues/268

### Changes
- Added the `disconnected_at` timestamp to `PeerState::Disconnected`.
- Updated all the places where `Disconnected` is used by adding the new `disconnected_at`.
- Added an `INTERVAL_DURATION` of 60 minutes.
- In the `next()` method: added a `tokio::time::interval` with `period` equal to this duration and the ticker.
- Added the `cleanup_disconnected_peers` method which keeps the peers:
   - that were disconnected more recently than the cutoff
   - that are in all rest of the states such as `Connected`, `Opening`, `Dialing`.

### Todos
- [ ] Add tests