### PR TITLE
substream/fix: Fix partial reads for ProtocolCodec::Identity

### DIFF
--- a/src/substream/mod.rs
+++ b/src/substream/mod.rs
@@ -548,7 +548,9 @@ impl Stream for Substream {
                                 return Poll::Ready(None);
                             }
 
-                            if nread == payload_size {
+                            this.offset = this.offset.saturating_add(nread);
+
+                            if this.offset == payload_size {
                                 let mut payload = std::mem::replace(
                                     &mut this.read_buffer,
                                     BytesMut::zeroed(payload_size),
@@ -557,8 +559,6 @@ impl Stream for Substream {
                                 this.offset = 0usize;
 
                                 return Poll::Ready(Some(Ok(payload)));
-                            } else {
-                                this.offset += read_buf.filled().len();
                             }
                         }
                         Err(error) => return Poll::Ready(Some(Err(error.into()))),


### PR DESCRIPTION
This PR fixes a fragmented read using the `Identity` protocol:
- Presume we want to read 1024 from the network
- The OS delivered the TCP reads in two chunks of 512 bytes
- The first read sets the nread to 512
- The second read sets the nread to 512
- At this point, we are comparing 512 with 1024, which is wrong, because we have drained from the OS socket 1024 bytes in total:
https://github.com/paritytech/litep2p/blob/b16c74c7c0e8666a9b91d7a93415d815f3a96a5f/src/substream/mod.rs#L551

Instead, this PR uses the `offset` variable to handle the packet correctly.

Closes: https://github.com/paritytech/litep2p/issues/489