### PR TITLE
crypto/noise: Fix connection negotiation logic on partial writes

### DIFF
--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -797,7 +797,7 @@ pub async fn handshake<S: AsyncRead + AsyncWrite + Unpin>(
             Role::Dialer => {
                 // write initial message
                 let first_message = noise.first_message(Role::Dialer)?;
-                let _ = io.write(&first_message).await?;
+                io.write_all(&first_message).await?;
                 io.flush().await?;
 
                 // read back response which contains the remote peer id
@@ -812,7 +812,7 @@ pub async fn handshake<S: AsyncRead + AsyncWrite + Unpin>(
 
                 // send the final message which contains local peer id
                 let second_message = noise.second_message()?;
-                let _ = io.write(&second_message).await?;
+                io.write_all(&second_message).await?;
                 io.flush().await?;
 
                 payload
@@ -823,7 +823,7 @@ pub async fn handshake<S: AsyncRead + AsyncWrite + Unpin>(
 
                 // send local peer id.
                 let second_message = noise.second_message()?;
-                let _ = io.write(&second_message).await?;
+                io.write_all(&second_message).await?;
                 io.flush().await?;
 
                 // read remote's second message which contains their peer id


### PR DESCRIPTION
This PR replaces the `io.write` with `io.write_all` calls to ensure the negotiation messages are fully propagated.

- There was a bug in the `fn handshake` implementation, which might propagate only a part of the provided negotiation message (ie on partial writes the `write` call would return immediately)
- This would then be rejected by the other side, causing unnecessary negotiation errors while opening the connection
- The downstream effect of this is that higher level protocols (like notification protocols) would backoff the peer for ~5s.

