### PR TITLE
chore: Release litep2p v0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3] - 2026-03-09
+
+This release bumps the rust yamux dependency to 0.13.10 to align with the latest upstream version, which includes important stability fixes.
+
 ## [0.13.2] - 2026-03-02
 
 This is a hotfix release fixing ping protocol panic in debug builds. The release also includes WebRTC fixes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1955,7 +1955,7 @@ dependencies = [
  "webpki",
  "x25519-dalek 2.0.1",
  "x509-parser 0.17.0",
- "yamux 0.13.9",
+ "yamux 0.13.10",
  "yasna",
  "zeroize",
 ]
@@ -4833,9 +4833,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c650efd29044140aa63caaf80129996a9e2659a2ab7045a7e061807d02fc8549"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,7 +1902,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "litep2p"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ x25519-dalek = "2.0.1"
 x509-parser = "0.17.0"
 yasna = "0.5.0"
 zeroize = "1.8.1"
-yamux = "0.13.9"
+yamux = "0.13.10"
 
 # Websocket related dependencies.
 tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots", "url"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "litep2p"
 description = "Peer-to-peer networking library"
 repository = "https://github.com/paritytech/litep2p"
 license = "MIT"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 
 # cargo-machete does not detect serde_millis usage, so we ignore the warning


### PR DESCRIPTION
## [0.13.3] - 2026-03-09

This release bumps the rust yamux dependency to 0.13.10 to align with the latest upstream version, which includes important stability fixes.

