### PR TITLE
bitswap: Add protocol metrics

### DIFF
--- a/src/protocol/libp2p/bitswap/config.rs
+++ b/src/protocol/libp2p/bitswap/config.rs
@@ -20,7 +20,7 @@
 
 use crate::{
     codec::ProtocolCodec,
-    protocol::libp2p::bitswap::{BitswapCommand, BitswapEvent, BitswapHandle},
+    protocol::libp2p::bitswap::{BitswapCommand, BitswapEvent, BitswapHandle, BitswapMetrics},
     types::protocol::ProtocolName,
     DEFAULT_CHANNEL_SIZE,
 };
@@ -52,6 +52,9 @@ pub struct Config {
 
     /// RX channel for receiving commands from the user.
     pub(super) cmd_rx: Receiver<BitswapCommand>,
+
+    /// Protocol metrics.
+    pub(super) metrics: BitswapMetrics,
 }
 
 impl Config {
@@ -59,6 +62,7 @@ impl Config {
     pub fn new() -> (Self, BitswapHandle) {
         let (event_tx, event_rx) = channel(DEFAULT_CHANNEL_SIZE);
         let (cmd_tx, cmd_rx) = channel(DEFAULT_CHANNEL_SIZE);
+        let metrics = BitswapMetrics::new();
 
         (
             Self {
@@ -66,8 +70,9 @@ impl Config {
                 event_tx,
                 protocol: ProtocolName::from(PROTOCOL_NAME),
                 codec: ProtocolCodec::UnsignedVarint(Some(MAX_MESSAGE_SIZE)),
+                metrics: metrics.clone(),
             },
-            BitswapHandle::new(event_rx, cmd_tx),
+            BitswapHandle::new(event_rx, cmd_tx, metrics),
         )
     }
 }

--- a/src/protocol/libp2p/bitswap/handle.rs
+++ b/src/protocol/libp2p/bitswap/handle.rs
@@ -21,7 +21,7 @@
 //! Bitswap handle for communicating with the bitswap protocol implementation.
 
 use crate::{
-    protocol::libp2p::bitswap::{BlockPresenceType, WantType},
+    protocol::libp2p::bitswap::{BitswapMetrics, BlockPresenceType, WantType},
     PeerId,
 };
 
@@ -108,12 +108,28 @@ pub struct BitswapHandle {
 
     /// TX channel for sending commads to `Bitswap`.
     cmd_tx: Sender<BitswapCommand>,
+
+    /// Protocol metrics.
+    metrics: BitswapMetrics,
 }
 
 impl BitswapHandle {
     /// Create new [`BitswapHandle`].
-    pub(super) fn new(event_rx: Receiver<BitswapEvent>, cmd_tx: Sender<BitswapCommand>) -> Self {
-        Self { event_rx, cmd_tx }
+    pub(super) fn new(
+        event_rx: Receiver<BitswapEvent>,
+        cmd_tx: Sender<BitswapCommand>,
+        metrics: BitswapMetrics,
+    ) -> Self {
+        Self {
+            event_rx,
+            cmd_tx,
+            metrics,
+        }
+    }
+
+    /// Get a reference to the protocol metrics.
+    pub fn metrics(&self) -> &BitswapMetrics {
+        &self.metrics
     }
 
     /// Send `request` to `peer`.

--- a/src/protocol/libp2p/bitswap/metrics.rs
+++ b/src/protocol/libp2p/bitswap/metrics.rs
@@ -1,0 +1,148 @@
+// Copyright 2025 litep2p developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Bitswap protocol metrics.
+//!
+//! Provides atomic counters for bitswap operations, following the [`BandwidthSink`] pattern.
+//! Consumers can read these counters and export them to their metrics system (e.g., Prometheus).
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+/// Inner bitswap metrics.
+#[derive(Debug, Default)]
+struct Inner {
+    /// Number of incoming requests received.
+    requests_received: AtomicUsize,
+    /// Total CIDs requested across all incoming requests.
+    cids_requested: AtomicUsize,
+    /// Number of blocks sent in responses.
+    blocks_sent: AtomicUsize,
+    /// Total bytes of block data sent in responses.
+    blocks_sent_bytes: AtomicUsize,
+    /// Number of presence responses sent (Have + DontHave).
+    presences_sent: AtomicUsize,
+    /// Number of DontHave responses sent.
+    dont_have_sent: AtomicUsize,
+    /// Number of requests sent to remote peers.
+    requests_sent: AtomicUsize,
+    /// Number of responses received from remote peers.
+    responses_received: AtomicUsize,
+    /// Number of blocks received in responses.
+    blocks_received: AtomicUsize,
+    /// Total bytes of block data received in responses.
+    blocks_received_bytes: AtomicUsize,
+}
+
+/// Bitswap protocol metrics.
+///
+/// Provides atomic counters for monitoring bitswap protocol activity.
+/// Clone is cheap (Arc).
+#[derive(Debug, Clone, Default)]
+pub struct BitswapMetrics(Arc<Inner>);
+
+impl BitswapMetrics {
+    /// Create new [`BitswapMetrics`].
+    pub(crate) fn new() -> Self {
+        Self(Arc::new(Inner::default()))
+    }
+
+    /// Record an incoming request with the given number of CIDs.
+    pub(crate) fn on_request_received(&self, cid_count: usize) {
+        self.0.requests_received.fetch_add(1, Ordering::Relaxed);
+        self.0.cids_requested.fetch_add(cid_count, Ordering::Relaxed);
+    }
+
+    /// Record blocks sent in a response.
+    pub(crate) fn on_blocks_sent(&self, count: usize, bytes: usize) {
+        self.0.blocks_sent.fetch_add(count, Ordering::Relaxed);
+        self.0.blocks_sent_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Record presence responses sent.
+    pub(crate) fn on_presences_sent(&self, count: usize, dont_have_count: usize) {
+        self.0.presences_sent.fetch_add(count, Ordering::Relaxed);
+        self.0.dont_have_sent.fetch_add(dont_have_count, Ordering::Relaxed);
+    }
+
+    /// Record a request sent to a remote peer.
+    pub(crate) fn on_request_sent(&self) {
+        self.0.requests_sent.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a response received from a remote peer.
+    pub(crate) fn on_response_received(&self, block_count: usize, block_bytes: usize) {
+        self.0.responses_received.fetch_add(1, Ordering::Relaxed);
+        self.0.blocks_received.fetch_add(block_count, Ordering::Relaxed);
+        self.0.blocks_received_bytes.fetch_add(block_bytes, Ordering::Relaxed);
+    }
+
+    /// Total incoming requests received.
+    pub fn requests_received(&self) -> usize {
+        self.0.requests_received.load(Ordering::Relaxed)
+    }
+
+    /// Total CIDs requested across all incoming requests.
+    pub fn cids_requested(&self) -> usize {
+        self.0.cids_requested.load(Ordering::Relaxed)
+    }
+
+    /// Total blocks sent in responses.
+    pub fn blocks_sent(&self) -> usize {
+        self.0.blocks_sent.load(Ordering::Relaxed)
+    }
+
+    /// Total bytes of block data sent in responses.
+    pub fn blocks_sent_bytes(&self) -> usize {
+        self.0.blocks_sent_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Total presence responses sent (Have + DontHave).
+    pub fn presences_sent(&self) -> usize {
+        self.0.presences_sent.load(Ordering::Relaxed)
+    }
+
+    /// Total DontHave responses sent.
+    pub fn dont_have_sent(&self) -> usize {
+        self.0.dont_have_sent.load(Ordering::Relaxed)
+    }
+
+    /// Total requests sent to remote peers.
+    pub fn requests_sent(&self) -> usize {
+        self.0.requests_sent.load(Ordering::Relaxed)
+    }
+
+    /// Total responses received from remote peers.
+    pub fn responses_received(&self) -> usize {
+        self.0.responses_received.load(Ordering::Relaxed)
+    }
+
+    /// Total blocks received in responses.
+    pub fn blocks_received(&self) -> usize {
+        self.0.blocks_received.load(Ordering::Relaxed)
+    }
+
+    /// Total bytes of block data received in responses.
+    pub fn blocks_received_bytes(&self) -> usize {
+        self.0.blocks_received_bytes.load(Ordering::Relaxed)
+    }
+}

--- a/src/protocol/libp2p/bitswap/mod.rs
+++ b/src/protocol/libp2p/bitswap/mod.rs
@@ -47,6 +47,9 @@ use std::{
 
 mod config;
 mod handle;
+mod metrics;
+
+pub use metrics::BitswapMetrics;
 
 mod schema {
     pub(super) mod bitswap {
@@ -152,6 +155,9 @@ pub(crate) struct Bitswap {
 
     /// Peers waiting for dial.
     pending_dials: HashSet<PeerId>,
+
+    /// Protocol metrics.
+    metrics: BitswapMetrics,
 }
 
 impl Bitswap {
@@ -165,6 +171,7 @@ impl Bitswap {
             inbound: StreamMap::new(),
             outbound: HashMap::new(),
             pending_dials: HashSet::new(),
+            metrics: config.metrics,
         }
     }
 
@@ -212,6 +219,7 @@ impl Bitswap {
                     .collect::<Vec<_>>();
 
                 if !cids.is_empty() {
+                    self.metrics.on_request_received(cids.len());
                     let _ = self.event_tx.send(BitswapEvent::Request { peer, cids }).await;
                 }
             }
@@ -291,6 +299,16 @@ impl Bitswap {
             }
 
             if !responses.is_empty() {
+                let block_count =
+                    responses.iter().filter(|r| matches!(r, ResponseType::Block { .. })).count();
+                let block_bytes: usize = responses
+                    .iter()
+                    .filter_map(|r| match r {
+                        ResponseType::Block { block, .. } => Some(block.len()),
+                        _ => None,
+                    })
+                    .sum();
+                self.metrics.on_response_received(block_count, block_bytes);
                 let _ = self.event_tx.send(BitswapEvent::Response { peer, responses }).await;
             }
         }
@@ -315,14 +333,15 @@ impl Bitswap {
         for action in actions {
             match action {
                 SubstreamAction::SendRequest(cids) => {
-                    if let Err(error) = send_request(&mut substream, cids).await {
+                    if let Err(error) = send_request(&mut substream, cids, &self.metrics).await {
                         // Drop the substream and all actions in case of sending error.
                         tracing::debug!(target: LOG_TARGET, ?peer, ?error, "bitswap request failed");
                         return;
                     }
                 }
                 SubstreamAction::SendResponse(entries) => {
-                    if let Err(error) = send_response(&mut substream, entries).await {
+                    if let Err(error) = send_response(&mut substream, entries, &self.metrics).await
+                    {
                         // Drop the substream and all actions in case of sending error.
                         tracing::debug!(target: LOG_TARGET, ?peer, ?error, "bitswap response failed");
                         return;
@@ -398,7 +417,7 @@ impl Bitswap {
     async fn on_bitswap_request(&mut self, peer: PeerId, cids: Vec<(Cid, WantType)>) {
         // Try to send request over existing substream first.
         if let Entry::Occupied(mut entry) = self.outbound.entry(peer) {
-            if send_request(entry.get_mut(), cids.clone()).await.is_ok() {
+            if send_request(entry.get_mut(), cids.clone(), &self.metrics).await.is_ok() {
                 return;
             } else {
                 tracing::debug!(
@@ -428,7 +447,7 @@ impl Bitswap {
     async fn on_bitswap_response(&mut self, peer: PeerId, responses: Vec<ResponseType>) {
         // Try to send response over existing substream first.
         if let Entry::Occupied(mut entry) = self.outbound.entry(peer) {
-            if send_response(entry.get_mut(), responses.clone()).await.is_ok() {
+            if send_response(entry.get_mut(), responses.clone(), &self.metrics).await.is_ok() {
                 return;
             } else {
                 tracing::debug!(
@@ -509,7 +528,11 @@ impl Bitswap {
     }
 }
 
-async fn send_request(substream: &mut Substream, cids: Vec<(Cid, WantType)>) -> Result<(), Error> {
+async fn send_request(
+    substream: &mut Substream,
+    cids: Vec<(Cid, WantType)>,
+    metrics: &BitswapMetrics,
+) -> Result<(), Error> {
     let request = schema::bitswap::Message {
         wantlist: Some(schema::bitswap::Wantlist {
             entries: cids
@@ -531,12 +554,31 @@ async fn send_request(substream: &mut Substream, cids: Vec<(Cid, WantType)>) -> 
     match tokio::time::timeout(WRITE_TIMEOUT, substream.send_framed(message)).await {
         Err(_) => Err(Error::Timeout),
         Ok(Err(e)) => Err(Error::SubstreamError(e)),
-        Ok(Ok(())) => Ok(()),
+        Ok(Ok(())) => {
+            metrics.on_request_sent();
+            Ok(())
+        }
     }
 }
 
-async fn send_response(substream: &mut Substream, entries: Vec<ResponseType>) -> Result<(), Error> {
+async fn send_response(
+    substream: &mut Substream,
+    entries: Vec<ResponseType>,
+    metrics: &BitswapMetrics,
+) -> Result<(), Error> {
     // Send presences in a separate message to not deal with it when batching blocks below.
+    let dont_have_count = entries
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                ResponseType::Presence {
+                    presence: BlockPresenceType::DontHave,
+                    ..
+                }
+            )
+        })
+        .count();
     if let Some((message, cid_count)) =
         presences_message(entries.iter().filter_map(|entry| match entry {
             ResponseType::Presence { cid, presence } => Some((*cid, *presence)),
@@ -552,7 +594,9 @@ async fn send_response(substream: &mut Substream, entries: Vec<ResponseType>) ->
             match tokio::time::timeout(WRITE_TIMEOUT, substream.send_framed(message)).await {
                 Err(_) => return Err(Error::Timeout),
                 Ok(Err(e)) => return Err(Error::SubstreamError(e)),
-                Ok(Ok(())) => {}
+                Ok(Ok(())) => {
+                    metrics.on_presences_sent(cid_count, dont_have_count);
+                }
             }
         } else {
             // This should never happen in practice, but log a warning if the presence message
@@ -576,7 +620,10 @@ async fn send_response(substream: &mut Substream, entries: Vec<ResponseType>) ->
         .collect::<VecDeque<_>>();
 
     while let Some(batch) = extract_next_batch(&mut blocks, config::MAX_BATCH_SIZE) {
-        if let Some((message, block_count)) = blocks_message(batch) {
+        let batch_items: Vec<_> = batch.collect();
+        let batch_bytes: usize = batch_items.iter().map(|(_, b)| b.len()).sum();
+        let batch_count = batch_items.len();
+        if let Some((message, block_count)) = blocks_message(batch_items) {
             if message.len() <= config::MAX_MESSAGE_SIZE {
                 tracing::trace!(
                     target: LOG_TARGET,
@@ -586,7 +633,9 @@ async fn send_response(substream: &mut Substream, entries: Vec<ResponseType>) ->
                 match tokio::time::timeout(WRITE_TIMEOUT, substream.send_framed(message)).await {
                     Err(_) => return Err(Error::Timeout),
                     Ok(Err(e)) => return Err(Error::SubstreamError(e)),
-                    Ok(Ok(())) => {}
+                    Ok(Ok(())) => {
+                        metrics.on_blocks_sent(batch_count, batch_bytes);
+                    }
                 }
             } else {
                 // This should never happen in practice, but log a warning if the blocks message


### PR DESCRIPTION
## Summary

- Add atomic counters for monitoring bitswap protocol activity
- Follow the existing `BandwidthSink` pattern (Arc-shared `AtomicUsize` counters)
- Expose metrics via `BitswapHandle::metrics()` so consumers can read and export them

### Tracked metrics

| Counter | Description |
|---------|-------------|
| `requests_received` | Incoming bitswap requests |
| `cids_requested` | Total CIDs across all incoming requests |
| `blocks_sent` | Blocks sent in responses |
| `blocks_sent_bytes` | Bytes of block data sent |
| `presences_sent` | Presence responses sent (Have + DontHave) |
| `dont_have_sent` | DontHave responses sent |
| `requests_sent` | Requests sent to remote peers |
| `responses_received` | Responses received from remote peers |
| `blocks_received` | Blocks received in responses |
| `blocks_received_bytes` | Bytes of block data received |

### Motivation

The Bulletin Chain (Polkadot data storage chain) uses litep2p's bitswap to serve stored data over IPFS. There was no way to monitor bitswap activity — no request counts, no "not found" tracking. These counters let the node operator wire them to Prometheus or any other metrics system.

## Test plan

- [x] `cargo build` succeeds
- [x] Unit tests pass (`cargo test --lib -- bitswap`)
- [x] Integration test passes (`cargo test --test mod -- bitswap`)