### PR TITLE
deps: upgrade multiaddr 0.18, multihash 0.19, libp2p 0.56 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,11 +176,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v6
 
-      - name: Install Rust 1.85
-        run: rustup install 1.85.0-x86_64-unknown-linux-gnu
+      - name: Install Rust 1.88
+        run: rustup install 1.88.0-x86_64-unknown-linux-gnu
 
-      - name: Use Rust 1.85
-        run: rustup default 1.85.0-x86_64-unknown-linux-gnu
+      - name: Use Rust 1.88
+        run: rustup default 1.88.0-x86_64-unknown-linux-gnu
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- **Breaking:** `PeerId::from_bytes` now returns `ParseError` instead of
+  `multihash::Error`. The new error distinguishes malformed multihash bytes
+  from well-formed multihashes that are not valid peer IDs.
+
 ## [0.13.3] - 2026-03-09
 
 This release bumps the rust yamux dependency to 0.13.10 to align with the latest upstream version, which includes important stability fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking:** `PeerId::from_bytes` now returns `ParseError` instead of
-  `multihash::Error`. The new error distinguishes malformed multihash bytes
-  from well-formed multihashes that are not valid peer IDs.
+  - **Breaking:** `PeerId::from_bytes` now returns `ParseError` instead of
+    `multihash::Error`. Multihash decoding failures and multihashes that are not
+    valid peer IDs are reported as `ParseError::MultiHash`.
 
 ## [0.13.3] - 2026-03-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,12 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -26,7 +20,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -44,18 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -83,53 +65,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "asn1-rs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
-dependencies = [
- "asn1-rs-derive 0.4.0",
- "asn1-rs-impl 0.1.0",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
- "asn1-rs-derive 0.6.0",
- "asn1-rs-impl 0.2.0",
+ "asn1-rs-derive",
+ "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -141,18 +89,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "synstructure",
 ]
 
 [[package]]
@@ -197,15 +134,33 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
 dependencies = [
  "bytes",
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.17",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64",
+ "http",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -232,12 +187,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -250,15 +199,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -267,26 +210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -299,10 +222,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.4.0"
+name = "block-buffer"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "bs58"
@@ -336,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -351,6 +277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,7 +290,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -376,13 +308,13 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
 dependencies = [
- "core2",
  "multibase",
- "multihash 0.19.3",
+ "multihash",
+ "no_std_io2",
  "serde",
  "serde_bytes",
  "unsigned-varint 0.8.0",
@@ -394,7 +326,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -429,12 +361,6 @@ name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -472,19 +398,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -503,15 +429,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "critical-section"
@@ -561,6 +478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,25 +497,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -647,25 +560,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
-dependencies = [
- "asn1-rs 0.5.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -684,22 +583,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -741,11 +641,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -758,23 +658,11 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -802,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -812,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "env_filter",
  "log",
@@ -838,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
@@ -859,17 +747,6 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "libz-sys",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -909,9 +786,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "futures"
@@ -925,6 +805,16 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-bounded"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+dependencies = [
+ "futures-timer",
  "futures-util",
 ]
 
@@ -968,7 +858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.17",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -984,13 +874,13 @@ dependencies = [
 
 [[package]]
 name = "futures-rustls"
-version = "0.22.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.20.9",
- "webpki",
+ "rustls 0.23.38",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1024,7 +914,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.17",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -1052,24 +942,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1079,21 +960,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core 0.10.0",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1109,12 +992,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.13.2"
+name = "h2"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
- "ahash",
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1128,15 +1021,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
-name = "heck"
-version = "0.4.1"
+name = "hashlink"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -1171,15 +1067,16 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner 0.6.1",
+ "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 1.1.0",
+ "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring 0.17.14",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1200,12 +1097,21 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
 ]
 
 [[package]]
@@ -1228,19 +1134,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
+name = "hybrid-array"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1248,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1261,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1275,15 +1255,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1295,15 +1275,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1319,17 +1299,6 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -1354,19 +1323,19 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.10.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "if-watch"
-version = "3.2.1"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io",
  "core-foundation 0.9.4",
@@ -1386,13 +1355,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.13.0"
+name = "igd-next"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.9.4",
+ "tokio",
+ "url",
+ "xmltree",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1407,15 +1397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ip_network"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,21 +1404,22 @@ checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -1450,27 +1432,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures",
 ]
 
 [[package]]
@@ -1487,21 +1460,21 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libp2p"
-version = "0.51.4"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35eae38201a993ece6bdc823292d6abd1bffed1c4d0f4a3517d2bd8e1d917fe"
+checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
 dependencies = [
  "bytes",
+ "either",
  "futures",
  "futures-timer",
  "getrandom 0.2.17",
- "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
  "libp2p-core",
@@ -1511,382 +1484,365 @@ dependencies = [
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
- "libp2p-mplex",
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-quic",
  "libp2p-swarm",
  "libp2p-tcp",
+ "libp2p-upnp",
  "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
  "pin-project",
+ "rw-stream-sink",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.1.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510daa05efbc25184458db837f6f9a5143888f1caa742426d92e1833ddd38a50"
+checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.1.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa33f1d26ed664c4fe2cca81a08c8e07d4c1c04f2f4ac7655c2dd85467fda0"
+checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.39.2"
+version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1df63c0b582aa434fb09b2d86897fa2b419ffeccf934b36f87fcedc8e835c2"
+checksum = "249128cd37a2199aff30a7675dffa51caf073b51aa612d2f544b19932b9aebca"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
- "instant",
  "libp2p-identity",
- "log",
  "multiaddr",
- "multihash 0.17.0",
+ "multihash",
  "multistream-select",
- "once_cell",
  "parking_lot",
  "pin-project",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rw-stream-sink",
- "smallvec",
- "thiserror 1.0.69",
- "unsigned-varint 0.7.2",
- "void",
+ "thiserror 2.0.18",
+ "tracing",
+ "unsigned-varint 0.8.0",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.39.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146ff7034daae62077c415c2376b8057368042df6ab95f5432ad5e88568b1554"
+checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
 dependencies = [
+ "async-trait",
  "futures",
+ "hickory-resolver",
  "libp2p-core",
- "log",
+ "libp2p-identity",
  "parking_lot",
  "smallvec",
- "trust-dns-resolver",
+ "tracing",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.42.2"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5455f472243e63b9c497ff320ded0314254a9eb751799a39c283c6f20b793f3c"
+checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures",
+ "futures-bounded",
  "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "log",
- "lru",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 1.0.69",
- "void",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "libp2p-identity"
-version = "0.1.3"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
+checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
 dependencies = [
- "bs58 0.4.0",
+ "bs58",
  "ed25519-dalek",
- "log",
- "multiaddr",
- "multihash 0.17.0",
+ "hkdf",
+ "multihash",
  "quick-protobuf",
- "rand 0.8.5",
- "sha2",
- "thiserror 1.0.69",
+ "rand 0.8.6",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.43.3"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d5ef876a2b2323d63c258e63c2f8e36f205fe5a11f0b3095d59635650790ff"
+checksum = "13d3fd632a5872ec804d37e7413ceea20588f69d027a0fa3c46f82574f4dee60"
 dependencies = [
- "arrayvec",
  "asynchronous-codec",
  "bytes",
  "either",
  "fnv",
  "futures",
+ "futures-bounded",
  "futures-timer",
- "instant",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "log",
  "quick-protobuf",
- "rand 0.8.5",
- "sha2",
+ "quick-protobuf-codec",
+ "rand 0.8.6",
+ "sha2 0.10.9",
  "smallvec",
- "thiserror 1.0.69",
- "uint 0.9.5",
- "unsigned-varint 0.7.2",
- "void",
+ "thiserror 2.0.18",
+ "tracing",
+ "uint",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.43.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19983e1f949f979a928f2c603de1cf180cc0dc23e4ac93a62651ccb18341460b"
+checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
 dependencies = [
- "data-encoding",
  "futures",
+ "hickory-proto",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
- "trust-dns-proto",
- "void",
+ "tracing",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.12.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
+checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
 dependencies = [
+ "futures",
  "libp2p-core",
  "libp2p-identify",
+ "libp2p-identity",
  "libp2p-kad",
  "libp2p-ping",
  "libp2p-swarm",
+ "pin-project",
  "prometheus-client",
+ "web-time",
 ]
 
 [[package]]
-name = "libp2p-mplex"
-version = "0.39.0"
+name = "libp2p-noise"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d34780b514b159e6f3fd70ba3e72664ec89da28dca2d1e7856ee55e2c7031ba"
+checksum = "bc73eacbe6462a0eb92a6527cac6e63f02026e5407f8831bde8293f19217bfbf"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
  "libp2p-core",
- "log",
- "nohash-hasher",
- "parking_lot",
- "rand 0.8.5",
- "smallvec",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "libp2p-noise"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3673da89d29936bc6435bafc638e2f184180d554ce844db65915113f86ec5e"
-dependencies = [
- "bytes",
- "curve25519-dalek 3.2.0",
- "futures",
- "libp2p-core",
  "libp2p-identity",
- "log",
- "once_cell",
+ "multiaddr",
+ "multihash",
  "quick-protobuf",
- "rand 0.8.5",
- "sha2",
+ "rand 0.8.6",
  "snow",
  "static_assertions",
- "thiserror 1.0.69",
- "x25519-dalek 1.1.1",
+ "thiserror 2.0.18",
+ "tracing",
+ "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-ping"
-version = "0.42.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e57759c19c28a73ef1eb3585ca410cefb72c1a709fcf6de1612a378e4219202"
+checksum = "74bb7fcdfd9fead4144a3859da0b49576f171a8c8c7c0bfc7c541921d25e60d3"
 dependencies = [
- "either",
  "futures",
  "futures-timer",
- "instant",
  "libp2p-core",
+ "libp2p-identity",
  "libp2p-swarm",
- "log",
- "rand 0.8.5",
- "void",
+ "rand 0.8.6",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-quic"
-version = "0.7.0-alpha.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b26abd81cd2398382a1edfe739b539775be8a90fa6914f39b2ab49571ec735"
+checksum = "8dc448b2de9f4745784e3751fe8bc6c473d01b8317edd5ababcb0dec803d843f"
 dependencies = [
- "bytes",
  "futures",
  "futures-timer",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
- "log",
- "parking_lot",
- "quinn-proto",
- "rand 0.8.5",
- "rustls 0.20.9",
- "thiserror 1.0.69",
+ "quinn 0.11.9",
+ "rand 0.8.6",
+ "ring 0.17.14",
+ "rustls 0.23.38",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.42.2"
+version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903b3d592d7694e56204d211f29d31bc004be99386644ba8731fc3e3ef27b296"
+checksum = "ce88c6c4bf746c8482480345ea3edfd08301f49e026889d1cbccfa1808a9ed9e"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
- "instant",
+ "hashlink",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "log",
- "rand 0.8.5",
+ "multistream-select",
+ "rand 0.8.6",
  "smallvec",
  "tokio",
- "void",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.32.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fba456131824ab6acd4c7bf61e9c0f0a3014b5fc9868ccb8e10d344594cdc4f"
+checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.39.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d33698596d7722d85d3ab0c86c2c322254fce1241e91208e3679b4eb3026cf"
+checksum = "fb6585b9309699f58704ec9ab0bb102eca7a3777170fa91a8678d73ca9cafa93"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "log",
- "socket2 0.4.10",
+ "socket2 0.6.3",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "libp2p-tls"
-version = "0.1.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08d13d0dc66e5e9ba6279c1de417b84fa0d0adc3b03e5732928c180ec02781"
+checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
 dependencies = [
  "futures",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
- "rcgen 0.10.0",
- "ring 0.16.20",
- "rustls 0.20.9",
- "thiserror 1.0.69",
- "webpki",
- "x509-parser 0.14.0",
+ "rcgen 0.13.2",
+ "ring 0.17.14",
+ "rustls 0.23.38",
+ "rustls-webpki",
+ "thiserror 2.0.18",
+ "x509-parser 0.17.0",
  "yasna",
 ]
 
 [[package]]
-name = "libp2p-websocket"
-version = "0.41.0"
+name = "libp2p-upnp"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111273f7b3d3510524c752e8b7a5314b7f7a1fee7e68161c01a7d72cbb06db9f"
+checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "igd-next",
+ "libp2p-core",
+ "libp2p-swarm",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520e29066a48674c007bc11defe5dce49908c24cafd8fad2f5e1a6a8726ced53"
 dependencies = [
  "either",
  "futures",
  "futures-rustls",
  "libp2p-core",
- "log",
+ "libp2p-identity",
  "parking_lot",
- "quicksink",
+ "pin-project-lite",
  "rw-stream-sink",
  "soketto",
+ "thiserror 2.0.18",
+ "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.43.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd21d950662700a385d4c6d68e2f5f54d778e97068cdd718522222ef513bda"
+checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
 dependencies = [
+ "either",
  "futures",
  "libp2p-core",
- "log",
- "thiserror 1.0.69",
- "yamux 0.10.2",
+ "thiserror 2.0.18",
+ "tracing",
+ "yamux 0.12.1",
+ "yamux 0.13.10",
 ]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1896,16 +1852,16 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litep2p"
 version = "0.13.3"
 dependencies = [
  "async-trait",
- "bs58 0.5.1",
+ "bs58",
  "bytes",
  "cid",
  "ed25519-dalek",
@@ -1919,25 +1875,25 @@ dependencies = [
  "ip_network",
  "libc",
  "libp2p",
- "libp2p-quic",
  "mockall",
  "multiaddr",
- "multihash 0.17.0",
+ "multihash",
+ "multihash-codetable",
  "network-interface",
  "parking_lot",
  "pin-project",
  "prost 0.13.5",
  "prost-build",
  "quickcheck",
- "quinn",
- "rand 0.8.5",
+ "quinn 0.9.4",
+ "rand 0.8.6",
  "rcgen 0.14.7",
  "ring 0.17.14",
  "rustls 0.20.9",
  "serde",
  "serde_json",
  "serde_millis",
- "sha2",
+ "sha2 0.10.9",
  "simple-dns",
  "smallvec",
  "snow",
@@ -1950,11 +1906,11 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "uint 0.10.0",
+ "uint",
  "unsigned-varint 0.8.0",
  "url",
  "webpki",
- "x25519-dalek 2.0.1",
+ "x25519-dalek",
  "x509-parser 0.17.0",
  "yamux 0.13.10",
  "yasna",
@@ -1977,22 +1933,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "lru-cache"
+name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "match-lookup"
@@ -2015,12 +1959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,23 +1971,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -2081,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2098,20 +2026,20 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
- "log",
+ "libp2p-identity",
  "multibase",
- "multihash 0.17.0",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
  "url",
 ]
 
@@ -2129,43 +2057,49 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.17.0"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
- "blake2b_simd",
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "serde",
- "sha2",
- "sha3",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
-dependencies = [
- "core2",
+ "no_std_io2",
  "serde",
  "unsigned-varint 0.8.0",
 ]
 
 [[package]]
-name = "multihash-derive"
-version = "0.8.1"
+name = "multihash-codetable"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+checksum = "facfe64780489b29aae20d32d0245219f4a8167f91193f7061589f5dae9ba307"
+dependencies = [
+ "digest 0.11.2",
+ "multihash-derive",
+ "no_std_io2",
+ "sha2 0.11.0",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0576e09c49157d1910e522e595d2b32749b029dd0bc10ff6967d588490c30348"
+dependencies = [
+ "multihash",
+ "multihash-derive-impl",
+ "no_std_io2",
+]
+
+[[package]]
+name = "multihash-derive-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3dc7141bd06405929948754f0628d247f5ca1865be745099205e5086da957cb"
 dependencies = [
  "proc-macro-crate",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -2176,9 +2110,9 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "multistream-select"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
 dependencies = [
  "bytes",
  "futures",
@@ -2190,46 +2124,30 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags",
  "libc",
+ "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures",
@@ -2266,13 +2184,23 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
+ "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2312,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2336,27 +2264,18 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
-dependencies = [
- "asn1-rs 0.5.2",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -2370,11 +2289,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2402,18 +2321,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2459,20 +2378,11 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -2515,12 +2425,6 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
-
-[[package]]
-name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
@@ -2537,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
@@ -2550,7 +2454,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
- "pin-project-lite 0.2.17",
+ "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
 ]
@@ -2561,7 +2465,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2573,7 +2477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2586,9 +2490,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2646,36 +2550,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "thiserror 1.0.69",
- "toml",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2689,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.19.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
 dependencies = [
  "dtoa",
  "itoa",
@@ -2736,7 +2615,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools",
  "log",
  "multimap",
@@ -2795,15 +2674,15 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1693116345026436eb2f10b677806169c1a1260c1c60eaaffe3fb5a29ae23d8b"
+checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
  "thiserror 1.0.69",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -2814,18 +2693,7 @@ checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.10.0",
-]
-
-[[package]]
-name = "quicksink"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77de3c815e5a160b1539c6592796801df2043ae35e123b46d73380cfa57af858"
-dependencies = [
- "futures-core",
- "futures-sink",
- "pin-project-lite 0.1.12",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2835,9 +2703,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8b432585672228923edbbf64b8b12c14e1112f62e88737655b4a083dbcd78e"
 dependencies = [
  "bytes",
- "pin-project-lite 0.2.17",
- "quinn-proto",
- "quinn-udp",
+ "pin-project-lite",
+ "quinn-proto 0.9.6",
+ "quinn-udp 0.3.2",
  "rustc-hash 1.1.0",
  "rustls 0.20.9",
  "thiserror 1.0.69",
@@ -2847,13 +2715,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "futures-io",
+ "pin-project-lite",
+ "quinn-proto 0.11.14",
+ "quinn-udp 0.5.14",
+ "rustc-hash 2.1.2",
+ "rustls 0.23.38",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
 name = "quinn-proto"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ring 0.16.20",
  "rustc-hash 1.1.0",
  "rustls 0.20.9",
@@ -2865,23 +2754,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring 0.17.14",
+ "rustc-hash 2.1.2",
+ "rustls 0.23.38",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
 name = "quinn-udp"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
  "libc",
- "quinn-proto",
+ "quinn-proto 0.9.6",
  "socket2 0.4.10",
  "tracing",
  "windows-sys 0.42.0",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.44"
+name = "quinn-udp"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2893,10 +2817,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2905,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2915,12 +2845,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "getrandom 0.4.1",
- "rand_core 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2945,15 +2875,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -2972,18 +2893,19 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rcgen"
-version = "0.10.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
- "pem 1.1.1",
- "ring 0.16.20",
+ "pem",
+ "ring 0.17.14",
+ "rustls-pki-types",
  "time",
  "yasna",
 ]
@@ -2994,7 +2916,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
- "pem 3.0.6",
+ "pem",
  "ring 0.17.14",
  "rustls-pki-types",
  "time",
@@ -3008,7 +2930,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3086,15 +3008,15 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.13.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
  "nix",
@@ -3110,9 +3032,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3138,7 +3060,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3151,7 +3073,6 @@ version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
- "log",
  "ring 0.16.20",
  "sct",
  "webpki",
@@ -3159,11 +3080,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3188,14 +3110,15 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",
@@ -3210,9 +3133,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rw-stream-sink"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
 dependencies = [
  "futures",
  "pin-project",
@@ -3221,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3253,8 +3176,8 @@ dependencies = [
  "bytes",
  "crc",
  "log",
- "rand 0.9.2",
- "rustc-hash 2.1.1",
+ "rand 0.9.4",
+ "rustc-hash 2.1.2",
  "slab",
  "thiserror 2.0.18",
 ]
@@ -3265,7 +3188,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3284,9 +3207,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3351,26 +3274,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
  "sha1-asm",
 ]
@@ -3391,18 +3301,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
+name = "sha2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "digest 0.10.7",
- "keccak",
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3430,18 +3341,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
 name = "simple-dns"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df350943049174c4ae8ced56c604e28270258faec12a6a48637a7655287c9ce0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3465,11 +3370,11 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "rand_core 0.6.4",
  "ring 0.17.14",
  "rustc_version",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
 ]
 
@@ -3495,28 +3400,27 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "soketto"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bytes",
- "flate2",
  "futures",
  "httparse",
  "log",
- "rand 0.8.5",
- "sha-1",
+ "rand 0.8.6",
+ "sha1",
 ]
 
 [[package]]
@@ -3597,18 +3501,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -3620,11 +3512,11 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3647,12 +3539,12 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3715,9 +3607,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3730,15 +3622,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3746,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3756,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3771,25 +3663,25 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "parking_lot",
- "pin-project-lite 0.2.17",
- "socket2 0.6.2",
+ "pin-project-lite",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3802,7 +3694,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -3813,7 +3705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.17",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3825,7 +3717,7 @@ checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -3843,18 +3735,45 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.17",
+ "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "serde",
+ "serde_core",
 ]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3863,7 +3782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
- "pin-project-lite 0.2.17",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3902,9 +3821,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3919,50 +3838,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
+name = "try-lock"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner 0.5.1",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand 0.8.5",
- "smallvec",
- "socket2 0.4.10",
- "thiserror 1.0.69",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "lru-cache",
- "parking_lot",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -3975,8 +3854,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
- "rustls 0.23.37",
+ "rand 0.9.4",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -3986,21 +3865,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uint"
@@ -4015,31 +3882,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -4053,7 +3905,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -4062,10 +3914,6 @@ name = "unsigned-varint"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-dependencies = [
- "asynchronous-codec",
- "bytes",
-]
 
 [[package]]
 name = "unsigned-varint"
@@ -4096,7 +3944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna 1.1.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -4115,11 +3963,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4143,16 +3991,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "void"
-version = "1.0.2"
+name = "want"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -4162,11 +4007,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4175,14 +4020,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4193,9 +4038,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4203,9 +4048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4216,9 +4061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4251,7 +4096,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4259,9 +4104,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4289,11 +4134,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.6"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4326,22 +4180,69 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.53.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.53.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4351,12 +4252,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -4372,15 +4303,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4408,21 +4330,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4459,16 +4366,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4490,12 +4400,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4511,12 +4415,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4550,12 +4448,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4571,12 +4463,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4598,12 +4484,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4622,12 +4502,6 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -4639,13 +4513,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "winnow"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "memchr",
 ]
 
 [[package]]
@@ -4658,13 +4531,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -4675,7 +4554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
@@ -4706,7 +4585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -4738,20 +4617,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "x25519-dalek"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "rand_core 0.5.1",
- "zeroize",
-]
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
@@ -4759,28 +4627,10 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
-dependencies = [
- "asn1-rs 0.5.2",
- "base64 0.13.1",
- "data-encoding",
- "der-parser 8.2.0",
- "lazy_static",
- "nom",
- "oid-registry 0.6.1",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
 ]
 
 [[package]]
@@ -4789,12 +4639,12 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "data-encoding",
- "der-parser 10.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.8.1",
+ "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
@@ -4806,12 +4656,12 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs 0.7.1",
+ "asn1-rs",
  "data-encoding",
- "der-parser 10.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.8.1",
+ "oid-registry",
  "ring 0.17.14",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -4819,16 +4669,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "yamux"
-version = "0.10.2"
+name = "xml-rs"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
+name = "yamux"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot",
- "rand 0.8.5",
+ "pin-project",
+ "rand 0.8.6",
  "static_assertions",
 ]
 
@@ -4843,7 +4709,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "static_assertions",
  "web-time",
 ]
@@ -4859,9 +4725,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4870,30 +4736,30 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4902,23 +4768,23 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -4943,9 +4809,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4954,9 +4820,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4965,9 +4831,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ prost-build = "0.14"
 async-trait = "0.1.88"
 bs58 = "0.5.1"
 bytes = "1.11.1"
-cid = "0.11.1"
+cid = "0.11.2"
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 futures = "0.3.27"
 futures-timer = "3.0.3"
@@ -25,8 +25,11 @@ indexmap = { version = "2.9.0", features = ["std"] }
 ip_network = "0.4"
 libc = "0.2.158"
 mockall = "0.13.1"
-multiaddr = "0.17.0"
-multihash = { version = "0.17.0", default-features = false, features = ["std", "multihash-impl", "identity", "sha2", "sha3", "blake2b"] }
+multiaddr = "0.18.2"
+multihash = { version = "0.19.4", default-features = false, features = ["std"] }
+multihash-codetable = { version = "0.2.1", default-features = false, features = [
+    "sha2",
+] }
 network-interface = "2.0.1"
 parking_lot = "0.12.3"
 pin-project = "1.1.10"
@@ -36,12 +39,22 @@ serde = "1.0.158"
 sha2 = "0.10.9"
 simple-dns = "0.11.0"
 smallvec = "1.15.0"
-snow = { version = "0.9.3", features = ["ring-resolver"], default-features = false }
+snow = { version = "0.9.3", features = [
+    "ring-resolver",
+], default-features = false }
 socket2 = { version = "0.5.9", features = ["all"] }
 thiserror = "2.0.12"
 tokio-stream = "0.1.17"
 tokio-util = { version = "0.7.15", features = ["compat", "io", "codec"] }
-tokio = { version = "1.45.0", features = ["rt", "net", "io-util", "time", "macros", "sync", "parking_lot"] }
+tokio = { version = "1.45.0", features = [
+    "rt",
+    "net",
+    "io-util",
+    "time",
+    "macros",
+    "sync",
+    "parking_lot",
+] }
 tracing = { version = "0.1.40", features = ["log"] }
 hickory-resolver = "0.25.2"
 uint = "0.10.0"
@@ -54,12 +67,20 @@ zeroize = "1.8.1"
 yamux = "0.13.10"
 
 # Websocket related dependencies.
-tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots", "url"], optional = true }
+tokio-tungstenite = { version = "0.27.0", features = [
+    "rustls-tls-native-roots",
+    "url",
+], optional = true }
 # End of websocket related dependencies.
 
 # Quic related dependencies. Quic is an experimental feature flag. The dependencies must be updated.
-quinn = { version = "0.9.3", default-features = false, features = ["tls-rustls", "runtime-tokio"], optional = true }
-rustls = { version = "0.20.7", default-features = false, features = ["dangerous_configuration"], optional = true }
+quinn = { version = "0.9.3", default-features = false, features = [
+    "tls-rustls",
+    "runtime-tokio",
+], optional = true }
+rustls = { version = "0.20.7", default-features = false, features = [
+    "dangerous_configuration",
+], optional = true }
 ring = { version = "0.17.14", optional = true }
 webpki = { version = "0.22.4", optional = true }
 rcgen = { version = "0.14.5", optional = true }
@@ -70,25 +91,24 @@ str0m = { version = "0.11.1", optional = true }
 # End of WebRTC related dependencies.
 
 # Fuzzing related dependencies.
-serde_millis = {version = "0.1", optional = true}
+serde_millis = { version = "0.1", optional = true }
 enum-display = "0.1.4"
 # End of fuzzing related dependencies.
 
 [dev-dependencies]
-libp2p = { version = "0.51.4", features = [
+libp2p = { version = "0.56.0", features = [
     "tokio",
     "dns",
     "identify",
     "macros",
-    "mplex",
     "noise",
     "ping",
     "tcp",
     "kad",
     "websocket",
     "yamux",
+    "quic",
 ]}
-libp2p-quic = { version = "0.7.0-alpha.3", features = ["tokio"] }
 quickcheck = "1.0.3"
 serde_json = "1.0.140"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
@@ -100,7 +120,14 @@ hex-literal = "1.0.0"
 websocket = ["dep:tokio-tungstenite"]
 
 # Fuzzing feature flags.
-fuzz = ["serde/derive", "serde/rc", "bytes/serde", "dep:serde_millis", "cid/serde", "multihash/serde"]
+fuzz = [
+    "serde/derive",
+    "serde/rc",
+    "bytes/serde",
+    "dep:serde_millis",
+    "cid/serde",
+    "multihash/serde",
+]
 
 # Unstable / experimental feature flags. These features are not guaranteed to be stable and may change in the future.
 # They are not yet suitable for production use-cases and should be used with caution.

--- a/fuzz/simple/Cargo.lock
+++ b/fuzz/simple/Cargo.lock
@@ -30,12 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +41,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror",
  "time",
 ]
 
@@ -60,7 +54,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]
@@ -110,23 +104,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
-name = "blake2b_simd"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -173,14 +165,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cid"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
 dependencies = [
- "core2",
  "multibase",
- "multihash 0.19.3",
- "unsigned-varint 0.8.0",
+ "multihash",
+ "no_std_io2",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -188,12 +180,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -221,19 +207,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -285,15 +271,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -376,8 +371,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -417,7 +423,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -672,6 +678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,7 +713,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.0",
  "ring",
- "thiserror 2.0.12",
+ "thiserror",
  "tinyvec",
  "tokio",
  "tracing",
@@ -724,9 +736,27 @@ dependencies = [
  "rand 0.9.0",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -756,6 +786,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -904,13 +943,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -963,15 +1003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1019,20 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+dependencies = [
+ "bs58",
+ "hkdf",
+ "multihash",
+ "sha2 0.10.9",
+ "thiserror",
+ "tracing",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1019,7 +1064,8 @@ dependencies = [
  "libc",
  "mockall",
  "multiaddr",
- "multihash 0.17.0",
+ "multihash",
+ "multihash-codetable",
  "network-interface",
  "parking_lot",
  "pin-project",
@@ -1027,19 +1073,19 @@ dependencies = [
  "prost-build",
  "rand 0.8.5",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "simple-dns",
  "smallvec",
  "snow",
  "socket2 0.5.9",
- "thiserror 2.0.12",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "uint",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "url",
  "x25519-dalek",
  "x509-parser",
@@ -1132,20 +1178,20 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
- "log",
+ "libp2p-identity",
  "multibase",
- "multihash 0.17.0",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.2",
+ "unsigned-varint",
  "url",
 ]
 
@@ -1162,41 +1208,48 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.17.0"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
- "blake2b_simd",
- "core2",
- "digest",
- "multihash-derive",
- "sha2",
- "sha3",
- "unsigned-varint 0.7.2",
+ "no_std_io2",
+ "unsigned-varint",
 ]
 
 [[package]]
-name = "multihash"
-version = "0.19.3"
+name = "multihash-codetable"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "facfe64780489b29aae20d32d0245219f4a8167f91193f7061589f5dae9ba307"
 dependencies = [
- "core2",
- "unsigned-varint 0.8.0",
+ "digest 0.11.2",
+ "multihash-derive",
+ "no_std_io2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.8.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+checksum = "0576e09c49157d1910e522e595d2b32749b029dd0bc10ff6967d588490c30348"
+dependencies = [
+ "multihash",
+ "multihash-derive-impl",
+ "no_std_io2",
+]
+
+[[package]]
+name = "multihash-derive-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3dc7141bd06405929948754f0628d247f5ca1865be745099205e5086da957cb"
 dependencies = [
  "proc-macro-crate",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
+ "syn 2.0.100",
+ "synstructure",
 ]
 
 [[package]]
@@ -1213,8 +1266,17 @@ checksum = "4ddcb8865ad3d9950f22f42ffa0ef0aecbfbf191867b3122413602b0a360b2a6"
 dependencies = [
  "cc",
  "libc",
- "thiserror 2.0.12",
+ "thiserror",
  "winapi",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1328,7 +1390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
- "hashbrown",
+ "hashbrown 0.15.2",
  "indexmap",
 ]
 
@@ -1433,36 +1495,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "thiserror 1.0.69",
- "toml",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1857,8 +1894,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1868,18 +1905,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
+name = "sha2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "digest",
- "keccak",
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2027,18 +2065,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
@@ -2075,31 +2101,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2249,12 +2255,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2304,7 +2331,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror",
  "url",
  "utf-8",
 ]
@@ -2344,12 +2371,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "unsigned-varint"
@@ -2533,7 +2554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
- "hashbrown",
+ "hashbrown 0.15.2",
  "indexmap",
  "semver",
 ]
@@ -2833,6 +2854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2976,7 +3006,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror",
  "time",
 ]
 
@@ -3023,7 +3053,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]
@@ -3064,7 +3094,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]

--- a/fuzz/simple/src/main.rs
+++ b/fuzz/simple/src/main.rs
@@ -19,7 +19,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 mod protocol;
-use futures::StreamExt;
 use litep2p::{
     Litep2p, ProtocolName,
     config::ConfigBuilder,

--- a/fuzz/simple/src/protocol.rs
+++ b/fuzz/simple/src/protocol.rs
@@ -25,7 +25,7 @@ use litep2p::{
     types::protocol::ProtocolName,
 };
 
-use bytes::{Buf, BytesMut};
+use bytes::BytesMut;
 use futures::{SinkExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
 use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio_util::codec::{Decoder, Encoder, Framed};
@@ -40,7 +40,7 @@ impl Decoder for FuzzCodec {
     type Error = litep2p::Error;
 
     /// We do not need to decode.
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+    fn decode(&mut self, _src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         Ok(None)
     }
 }

--- a/fuzz/structure-aware/Cargo.lock
+++ b/fuzz/structure-aware/Cargo.lock
@@ -30,12 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +41,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror",
  "time",
 ]
 
@@ -60,7 +54,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]
@@ -119,23 +113,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
-name = "blake2b_simd"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -161,9 +153,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -185,16 +177,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cid"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
 dependencies = [
- "core2",
  "multibase",
- "multihash 0.19.3",
+ "multihash",
+ "no_std_io2",
  "serde",
  "serde_bytes",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -202,12 +194,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -235,19 +221,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -299,15 +285,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -390,8 +385,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -431,7 +437,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -708,7 +714,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.0",
  "ring",
- "thiserror 2.0.12",
+ "thiserror",
  "tinyvec",
  "tokio",
  "tracing",
@@ -731,9 +737,27 @@ dependencies = [
  "rand 0.9.0",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -763,6 +787,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -914,6 +947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,15 +996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1006,20 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+dependencies = [
+ "bs58",
+ "hkdf",
+ "multihash",
+ "sha2 0.10.9",
+ "thiserror",
+ "tracing",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -991,7 +1035,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.12.3"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "bs58",
@@ -1003,10 +1047,12 @@ dependencies = [
  "futures-timer",
  "hickory-resolver",
  "indexmap",
+ "ip_network",
  "libc",
  "mockall",
  "multiaddr",
- "multihash 0.17.0",
+ "multihash",
+ "multihash-codetable",
  "network-interface",
  "parking_lot",
  "pin-project",
@@ -1015,19 +1061,19 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_millis",
- "sha2",
+ "sha2 0.10.9",
  "simple-dns",
  "smallvec",
  "snow",
  "socket2 0.5.9",
- "thiserror 2.0.12",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "uint",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "url",
  "x25519-dalek",
  "x509-parser",
@@ -1120,20 +1166,20 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b36f567c7099511fa8612bbbb52dda2419ce0bdbacf31714e3a5ffdb766d3bd"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
- "log",
+ "libp2p-identity",
  "multibase",
- "multihash 0.17.0",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.2",
+ "unsigned-varint",
  "url",
 ]
 
@@ -1150,43 +1196,49 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.17.0"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
- "blake2b_simd",
- "core2",
- "digest",
- "multihash-derive",
+ "no_std_io2",
  "serde",
- "sha2",
- "sha3",
- "unsigned-varint 0.7.2",
+ "unsigned-varint",
 ]
 
 [[package]]
-name = "multihash"
-version = "0.19.3"
+name = "multihash-codetable"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "facfe64780489b29aae20d32d0245219f4a8167f91193f7061589f5dae9ba307"
 dependencies = [
- "core2",
- "serde",
- "unsigned-varint 0.8.0",
+ "digest 0.11.2",
+ "multihash-derive",
+ "no_std_io2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.8.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+checksum = "0576e09c49157d1910e522e595d2b32749b029dd0bc10ff6967d588490c30348"
+dependencies = [
+ "multihash",
+ "multihash-derive-impl",
+ "no_std_io2",
+]
+
+[[package]]
+name = "multihash-derive-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3dc7141bd06405929948754f0628d247f5ca1865be745099205e5086da957cb"
 dependencies = [
  "proc-macro-crate",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
+ "syn 2.0.100",
+ "synstructure",
 ]
 
 [[package]]
@@ -1203,8 +1255,17 @@ checksum = "4ddcb8865ad3d9950f22f42ffa0ef0aecbfbf191867b3122413602b0a360b2a6"
 dependencies = [
  "cc",
  "libc",
- "thiserror 2.0.12",
+ "thiserror",
  "winapi",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1423,36 +1484,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "thiserror 1.0.69",
- "toml",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1799,10 +1835,11 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1816,10 +1853,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1842,8 +1888,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1853,18 +1899,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.8"
+name = "sha2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "digest",
- "keccak",
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2011,18 +2058,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
@@ -2059,31 +2094,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2233,12 +2248,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2288,7 +2324,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror",
  "url",
  "utf-8",
 ]
@@ -2322,18 +2358,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "unsigned-varint"
@@ -2765,6 +2789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,15 +2853,15 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror",
  "time",
 ]
 
 [[package]]
 name = "yamux"
-version = "0.13.8"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deab71f2e20691b4728b349c6cee8fc7223880fa67b6b4f92225ec32225447e5"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
 dependencies = [
  "futures",
  "log",
@@ -2867,7 +2900,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]
@@ -2908,7 +2941,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "synstructure 0.13.1",
+ "synstructure",
 ]
 
 [[package]]

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,9 +30,9 @@ use crate::{
     PeerId,
 };
 
-use multiaddr::Multiaddr;
-use multihash::{Multihash, MultihashGeneric};
+type Multihash = multihash::Multihash<64>;
 
+use multiaddr::Multiaddr;
 use std::io::{self, ErrorKind};
 
 // TODO: https://github.com/paritytech/litep2p/issues/204 clean up the overarching error.
@@ -426,8 +426,8 @@ pub enum DnsError {
     IpVersionMismatch,
 }
 
-impl From<MultihashGeneric<64>> for Error {
-    fn from(hash: MultihashGeneric<64>) -> Self {
+impl From<Multihash> for Error {
+    fn from(hash: Multihash) -> Self {
         Error::AddressError(AddressError::InvalidPeerId(hash))
     }
 }
@@ -498,8 +498,8 @@ impl From<ParseError> for Error {
     }
 }
 
-impl From<MultihashGeneric<64>> for AddressError {
-    fn from(hash: MultihashGeneric<64>) -> Self {
+impl From<Multihash> for AddressError {
+    fn from(hash: Multihash) -> Self {
         AddressError::InvalidPeerId(hash)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ use types::ConnectionId;
 
 pub use bandwidth::BandwidthSink;
 pub use error::Error;
-pub use peer_id::PeerId;
+pub use peer_id::{ParseError, PeerId};
 use std::{collections::HashSet, sync::Arc};
 pub use types::protocol::ProtocolName;
 
@@ -340,7 +340,7 @@ impl Litep2p {
 
             for address in transport_listen_addresses {
                 transport_manager.register_listen_address(address.clone());
-                listen_addresses.push(address.with(Protocol::P2p(*local_peer_id.as_ref())));
+                listen_addresses.push(address.with(Protocol::P2p(local_peer_id.into())));
             }
 
             transport_manager.register_transport(SupportedTransport::Tcp, Box::new(transport));
@@ -355,7 +355,7 @@ impl Litep2p {
 
             for address in transport_listen_addresses {
                 transport_manager.register_listen_address(address.clone());
-                listen_addresses.push(address.with(Protocol::P2p(*local_peer_id.as_ref())));
+                listen_addresses.push(address.with(Protocol::P2p(local_peer_id.into())));
             }
 
             transport_manager.register_transport(SupportedTransport::Quic, Box::new(transport));
@@ -370,7 +370,7 @@ impl Litep2p {
 
             for address in transport_listen_addresses {
                 transport_manager.register_listen_address(address.clone());
-                listen_addresses.push(address.with(Protocol::P2p(*local_peer_id.as_ref())));
+                listen_addresses.push(address.with(Protocol::P2p(local_peer_id.into())));
             }
 
             transport_manager.register_transport(SupportedTransport::WebRtc, Box::new(transport));
@@ -386,7 +386,7 @@ impl Litep2p {
 
             for address in transport_listen_addresses {
                 transport_manager.register_listen_address(address.clone());
-                listen_addresses.push(address.with(Protocol::P2p(*local_peer_id.as_ref())));
+                listen_addresses.push(address.with(Protocol::P2p(local_peer_id.into())));
             }
 
             transport_manager
@@ -542,7 +542,6 @@ mod tests {
         Litep2p, Litep2pEvent, PeerId,
     };
     use multiaddr::{Multiaddr, Protocol};
-    use multihash::Multihash;
     use std::net::Ipv4Addr;
 
     #[tokio::test]
@@ -659,9 +658,7 @@ mod tests {
         let address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(255, 254, 253, 252)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         let mut litep2p = Litep2p::new(config).unwrap();
         litep2p.dial_address(address.clone()).await.unwrap();

--- a/src/peer_id.rs
+++ b/src/peer_id.rs
@@ -259,7 +259,8 @@ impl FromStr for PeerId {
 mod tests {
     use crate::{crypto::ed25519::Keypair, PeerId};
     use multiaddr::{Multiaddr, Protocol};
-    use multihash::Multihash;
+    use multihash::{Code, Multihash};
+    use super::MAX_INLINE_KEY_LENGTH;
 
     #[test]
     fn peer_id_is_public_key() {
@@ -350,5 +351,112 @@ mod tests {
             PeerId::from_multihash(Multihash::from_bytes(&bytes).unwrap()).map_err(From::from)
         }
         let _error = test().unwrap_err();
+    }
+
+    // --- from_public_key_protobuf ---
+
+    #[test]
+    fn from_public_key_protobuf_small_key_uses_identity_hash() {
+        let key = Keypair::generate();
+        let enc = crate::crypto::PublicKey::from(key.public()).to_protobuf_encoding();
+        assert!(enc.len() <= MAX_INLINE_KEY_LENGTH, "ed25519 protobuf key must fit inline");
+
+        let peer_id = PeerId::from_public_key_protobuf(&enc);
+        assert_eq!(peer_id.as_ref().code(), u64::from(Code::Identity));
+    }
+
+    #[test]
+    fn from_public_key_protobuf_identity_hash_stores_raw_bytes_not_rehash() {
+        // The identity multihash must store the key bytes verbatim, not hash them.
+        let key = Keypair::generate();
+        let enc = crate::crypto::PublicKey::from(key.public()).to_protobuf_encoding();
+
+        let peer_id = PeerId::from_public_key_protobuf(&enc);
+        assert_eq!(peer_id.as_ref().digest(), enc.as_slice());
+    }
+
+    #[test]
+    fn from_public_key_protobuf_large_key_uses_sha256() {
+        // Any encoding longer than MAX_INLINE_KEY_LENGTH (42) must use SHA-256.
+        let enc = vec![0u8; MAX_INLINE_KEY_LENGTH + 1];
+        let peer_id = PeerId::from_public_key_protobuf(&enc);
+        assert_eq!(peer_id.as_ref().code(), u64::from(Code::Sha2_256));
+    }
+
+    #[test]
+    fn from_public_key_protobuf_sha256_digest_is_hash_of_key_not_key_itself() {
+        // SHA-256 path must hash the key, not store it verbatim.
+        let enc = vec![0u8; MAX_INLINE_KEY_LENGTH + 1];
+        let peer_id = PeerId::from_public_key_protobuf(&enc);
+        // digest is 32 bytes (SHA-256 output), not the original key length
+        assert_eq!(peer_id.as_ref().digest().len(), 32);
+        assert_ne!(peer_id.as_ref().digest(), enc.as_slice());
+    }
+
+    // --- is_public_key ---
+
+    #[test]
+    fn is_public_key_returns_false_for_different_key() {
+        let key1 = Keypair::generate().public();
+        let key2 = Keypair::generate().public();
+        let peer_id = key1.to_peer_id();
+        assert_eq!(peer_id.is_public_key(&key2.into()), Some(false));
+    }
+
+    // --- from_multihash ---
+
+    #[test]
+    fn from_multihash_rejects_unsupported_code() {
+        // Code 0x16 (sha3-256) is not a valid peer ID hash.
+        let bytes = [
+            0x16, 0x20, 0x64, 0x4b, 0xcc, 0x7e, 0x56, 0x43, 0x73, 0x04, 0x09, 0x99, 0xaa, 0xc8,
+            0x9e, 0x76, 0x22, 0xf3, 0xca, 0x71, 0xfb, 0xa1, 0xd9, 0x72, 0xfd, 0x94, 0xa3, 0x1c,
+            0x3b, 0xfb, 0xf2, 0x4e, 0x39, 0x38,
+        ];
+        let mh = Multihash::from_bytes(&bytes).unwrap();
+        assert!(PeerId::from_multihash(mh).is_err());
+    }
+
+    // --- from_bytes ---
+
+    #[test]
+    fn from_bytes_rejects_unsupported_multihash_code() {
+        let bytes = [
+            0x16, 0x20, 0x64, 0x4b, 0xcc, 0x7e, 0x56, 0x43, 0x73, 0x04, 0x09, 0x99, 0xaa, 0xc8,
+            0x9e, 0x76, 0x22, 0xf3, 0xca, 0x71, 0xfb, 0xa1, 0xd9, 0x72, 0xfd, 0x94, 0xa3, 0x1c,
+            0x3b, 0xfb, 0xf2, 0x4e, 0x39, 0x38,
+        ];
+        assert!(PeerId::from_bytes(&bytes).is_err());
+    }
+
+    // --- identity and sha256 peer IDs roundtrip ---
+
+    #[test]
+    fn identity_peer_id_roundtrip_through_multiaddr() {
+        // PeerId::random() uses identity hash; verify it survives a multiaddr roundtrip.
+        let peer = PeerId::random();
+        assert_eq!(peer.as_ref().code(), u64::from(Code::Identity));
+
+        let addr = Multiaddr::empty()
+            .with(Protocol::Ip4("127.0.0.1".parse().unwrap()))
+            .with(Protocol::Tcp(1234))
+            .with(Protocol::P2p(Multihash::from(peer)));
+
+        assert_eq!(peer, PeerId::try_from_multiaddr(&addr).unwrap());
+    }
+
+    #[test]
+    fn sha256_peer_id_roundtrip_through_multiaddr() {
+        // Use a large synthetic key encoding to force sha256.
+        let enc = vec![42u8; MAX_INLINE_KEY_LENGTH + 1];
+        let peer = PeerId::from_public_key_protobuf(&enc);
+        assert_eq!(peer.as_ref().code(), u64::from(Code::Sha2_256));
+
+        let addr = Multiaddr::empty()
+            .with(Protocol::Ip4("127.0.0.1".parse().unwrap()))
+            .with(Protocol::Tcp(1234))
+            .with(Protocol::P2p(Multihash::from(peer)));
+
+        assert_eq!(peer, PeerId::try_from_multiaddr(&addr).unwrap());
     }
 }

--- a/src/peer_id.rs
+++ b/src/peer_id.rs
@@ -24,7 +24,7 @@
 use crate::crypto::PublicKey;
 
 use multiaddr::{Multiaddr, Protocol};
-use multihash::{Code, Error, Multihash, MultihashDigest};
+use multihash_codetable::{Code, MultihashDigest};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -34,6 +34,8 @@ use std::{convert::TryFrom, fmt, str::FromStr};
 /// Public keys with byte-lengths smaller than `MAX_INLINE_KEY_LENGTH` will be
 /// automatically used as the peer id using an identity multihash.
 const MAX_INLINE_KEY_LENGTH: usize = 42;
+pub(crate) const MULTIHASH_IDENTITY_CODE: u64 = 0x00;
+type Multihash = multihash::Multihash<64>;
 
 /// Identifier of a peer of the network.
 ///
@@ -64,21 +66,20 @@ impl PeerId {
 
     /// Builds a `PeerId` from a public key in protobuf encoding.
     pub fn from_public_key_protobuf(key_enc: &[u8]) -> PeerId {
-        let hash_algorithm = if key_enc.len() <= MAX_INLINE_KEY_LENGTH {
-            Code::Identity
+        let multihash = if key_enc.len() <= MAX_INLINE_KEY_LENGTH {
+            Multihash::wrap(MULTIHASH_IDENTITY_CODE, key_enc)
+                .expect("key_enc.len() <= MAX_INLINE_KEY_LENGTH which fits in Multihash<64>")
         } else {
-            Code::Sha2_256
+            Code::Sha2_256.digest(key_enc)
         };
-
-        let multihash = hash_algorithm.digest(key_enc);
 
         PeerId { multihash }
     }
 
     /// Parses a `PeerId` from bytes.
-    pub fn from_bytes(data: &[u8]) -> Result<PeerId, Error> {
+    pub fn from_bytes(data: &[u8]) -> Result<PeerId, ParseError> {
         PeerId::from_multihash(Multihash::from_bytes(data)?)
-            .map_err(|mh| Error::UnsupportedCode(mh.code()))
+            .map_err(|mh| ParseError::UnsupportedCode(mh.code()))
     }
 
     /// Tries to turn a `Multihash` into a `PeerId`.
@@ -86,10 +87,15 @@ impl PeerId {
     /// If the multihash does not use a valid hashing algorithm for peer IDs,
     /// or the hash value does not satisfy the constraints for a hashed
     /// peer ID, it is returned as an `Err`.
-    pub fn from_multihash(multihash: Multihash) -> Result<PeerId, Multihash> {
-        match Code::try_from(multihash.code()) {
-            Ok(Code::Sha2_256) => Ok(PeerId { multihash }),
-            Ok(Code::Identity) if multihash.digest().len() <= MAX_INLINE_KEY_LENGTH =>
+    ///
+    /// Accepts anything that converts into `multihash::Multihash<64>`,
+    /// including `multiaddr::PeerId` which implements that conversion.
+    pub fn from_multihash(multihash: impl Into<Multihash>) -> Result<PeerId, Multihash> {
+        let multihash = multihash.into();
+
+        match multihash.code() {
+            code if code == u64::from(Code::Sha2_256) => Ok(PeerId { multihash }),
+            MULTIHASH_IDENTITY_CODE if multihash.digest().len() <= MAX_INLINE_KEY_LENGTH =>
                 Ok(PeerId { multihash }),
             _ => Err(multihash),
         }
@@ -101,7 +107,7 @@ impl PeerId {
     /// will return the encapsulated [`PeerId`], otherwise it will return `None`.
     pub fn try_from_multiaddr(address: &Multiaddr) -> Option<PeerId> {
         address.iter().last().and_then(|p| match p {
-            Protocol::P2p(hash) => PeerId::from_multihash(hash).ok(),
+            Protocol::P2p(peer_id) => PeerId::from_multihash(peer_id).ok(),
             _ => None,
         })
     }
@@ -112,7 +118,7 @@ impl PeerId {
     pub fn random() -> PeerId {
         let peer_id = rand::thread_rng().gen::<[u8; 32]>();
         PeerId {
-            multihash: Multihash::wrap(Code::Identity.into(), &peer_id)
+            multihash: Multihash::wrap(MULTIHASH_IDENTITY_CODE, &peer_id)
                 .expect("The digest size is never too large"),
         }
     }
@@ -132,10 +138,26 @@ impl PeerId {
     /// Returns `None` if this `PeerId`s hash algorithm is not supported when encoding the
     /// given public key, otherwise `Some` boolean as the result of an equality check.
     pub fn is_public_key(&self, public_key: &PublicKey) -> Option<bool> {
-        let alg = Code::try_from(self.multihash.code())
-            .expect("Internal multihash is always a valid `Code`");
         let enc = public_key.to_protobuf_encoding();
-        Some(alg.digest(&enc) == self.multihash)
+
+        let expected = match self.multihash.code() {
+            code if code == u64::from(Code::Sha2_256) => Code::Sha2_256.digest(&enc),
+            MULTIHASH_IDENTITY_CODE => Multihash::wrap(MULTIHASH_IDENTITY_CODE, &enc).expect(
+                "identity key enc fits in Multihash<64> since it passed from_public_key_protobuf",
+            ),
+            _ => return None,
+        };
+
+        Some(expected == self.multihash)
+    }
+
+    /// Converts this peer ID into a `multiaddr` peer ID.
+    ///
+    /// This is a fallible conversion for callers that want to avoid relying on
+    /// the internal invariant that litep2p and multiaddr peer IDs accept the
+    /// same multihash forms.
+    pub fn to_multiaddr_peer_id(&self) -> Result<multiaddr::PeerId, Multihash> {
+        multiaddr::PeerId::try_from(*self.as_ref())
     }
 }
 
@@ -182,6 +204,21 @@ impl From<PeerId> for Multihash {
 impl From<PeerId> for Vec<u8> {
     fn from(peer_id: PeerId) -> Self {
         peer_id.to_bytes()
+    }
+}
+
+impl From<PeerId> for multiaddr::PeerId {
+    /// Converts this peer ID into a `multiaddr` peer ID.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if `PeerId`'s internal invariant has been violated. Safe
+    /// constructors accept the same multihash forms that `multiaddr::PeerId`
+    /// accepts, so this conversion should not fail for any valid `PeerId`.
+    fn from(peer_id: PeerId) -> Self {
+        peer_id
+            .to_multiaddr_peer_id()
+            .expect("litep2p PeerId is always a valid multiaddr PeerId")
     }
 }
 
@@ -241,8 +278,10 @@ impl<'de> Deserialize<'de> for PeerId {
 pub enum ParseError {
     #[error("base-58 decode error: {0}")]
     B58(#[from] bs58::decode::Error),
-    #[error("decoding multihash failed")]
-    MultiHash,
+    #[error("unsupported multihash code '{0}'")]
+    UnsupportedCode(u64),
+    #[error("invalid multihash")]
+    InvalidMultihash(#[from] multihash::Error),
 }
 
 impl FromStr for PeerId {
@@ -251,16 +290,17 @@ impl FromStr for PeerId {
     #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes = bs58::decode(s).into_vec()?;
-        PeerId::from_bytes(&bytes).map_err(|_| ParseError::MultiHash)
+        PeerId::from_bytes(&bytes)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::{MAX_INLINE_KEY_LENGTH, MULTIHASH_IDENTITY_CODE};
     use crate::{crypto::ed25519::Keypair, PeerId};
     use multiaddr::{Multiaddr, Protocol};
-    use multihash::{Code, Multihash};
-    use super::MAX_INLINE_KEY_LENGTH;
+    use multihash::Multihash;
+    use multihash_codetable::Code;
 
     #[test]
     fn peer_id_is_public_key() {
@@ -298,7 +338,7 @@ mod tests {
         let address = Multiaddr::empty()
             .with(Protocol::from(address.ip()))
             .with(Protocol::Tcp(address.port()))
-            .with(Protocol::P2p(Multihash::from(peer)));
+            .with(Protocol::P2p(peer.into()));
 
         assert_eq!(peer, PeerId::try_from_multiaddr(&address).unwrap());
     }
@@ -359,10 +399,13 @@ mod tests {
     fn from_public_key_protobuf_small_key_uses_identity_hash() {
         let key = Keypair::generate();
         let enc = crate::crypto::PublicKey::from(key.public()).to_protobuf_encoding();
-        assert!(enc.len() <= MAX_INLINE_KEY_LENGTH, "ed25519 protobuf key must fit inline");
+        assert!(
+            enc.len() <= MAX_INLINE_KEY_LENGTH,
+            "ed25519 protobuf key must fit inline"
+        );
 
         let peer_id = PeerId::from_public_key_protobuf(&enc);
-        assert_eq!(peer_id.as_ref().code(), u64::from(Code::Identity));
+        assert_eq!(peer_id.as_ref().code(), MULTIHASH_IDENTITY_CODE);
     }
 
     #[test]
@@ -435,12 +478,12 @@ mod tests {
     fn identity_peer_id_roundtrip_through_multiaddr() {
         // PeerId::random() uses identity hash; verify it survives a multiaddr roundtrip.
         let peer = PeerId::random();
-        assert_eq!(peer.as_ref().code(), u64::from(Code::Identity));
+        assert_eq!(peer.as_ref().code(), MULTIHASH_IDENTITY_CODE);
 
         let addr = Multiaddr::empty()
             .with(Protocol::Ip4("127.0.0.1".parse().unwrap()))
             .with(Protocol::Tcp(1234))
-            .with(Protocol::P2p(Multihash::from(peer)));
+            .with(Protocol::P2p(peer.into()));
 
         assert_eq!(peer, PeerId::try_from_multiaddr(&addr).unwrap());
     }
@@ -455,7 +498,7 @@ mod tests {
         let addr = Multiaddr::empty()
             .with(Protocol::Ip4("127.0.0.1".parse().unwrap()))
             .with(Protocol::Tcp(1234))
-            .with(Protocol::P2p(Multihash::from(peer)));
+            .with(Protocol::P2p(peer.into()));
 
         assert_eq!(peer, PeerId::try_from_multiaddr(&addr).unwrap());
     }

--- a/src/peer_id.rs
+++ b/src/peer_id.rs
@@ -78,8 +78,19 @@ impl PeerId {
 
     /// Parses a `PeerId` from bytes.
     pub fn from_bytes(data: &[u8]) -> Result<PeerId, ParseError> {
-        PeerId::from_multihash(Multihash::from_bytes(data)?)
-            .map_err(|mh| ParseError::UnsupportedCode(mh.code()))
+        let multihash = Multihash::from_bytes(data).map_err(|error| {
+            tracing::debug!(?error, "failed to decode peer ID bytes as multihash",);
+            ParseError::MultiHash
+        })?;
+
+        PeerId::from_multihash(multihash).map_err(|multihash| {
+            tracing::debug!(
+                code = multihash.code(),
+                digest_len = multihash.digest().len(),
+                "decoded multihash is not a valid peer ID",
+            );
+            ParseError::MultiHash
+        })
     }
 
     /// Tries to turn a `Multihash` into a `PeerId`.
@@ -278,10 +289,8 @@ impl<'de> Deserialize<'de> for PeerId {
 pub enum ParseError {
     #[error("base-58 decode error: {0}")]
     B58(#[from] bs58::decode::Error),
-    #[error("unsupported multihash code '{0}'")]
-    UnsupportedCode(u64),
-    #[error("invalid multihash")]
-    InvalidMultihash(#[from] multihash::Error),
+    #[error("decoding multihash failed")]
+    MultiHash,
 }
 
 impl FromStr for PeerId {
@@ -296,7 +305,7 @@ impl FromStr for PeerId {
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_INLINE_KEY_LENGTH, MULTIHASH_IDENTITY_CODE};
+    use super::{ParseError, MAX_INLINE_KEY_LENGTH, MULTIHASH_IDENTITY_CODE};
     use crate::{crypto::ed25519::Keypair, PeerId};
     use multiaddr::{Multiaddr, Protocol};
     use multihash::Multihash;
@@ -463,13 +472,32 @@ mod tests {
     // --- from_bytes ---
 
     #[test]
-    fn from_bytes_rejects_unsupported_multihash_code() {
+    fn from_bytes_rejects_invalid_peer_id_multihash() {
         let bytes = [
             0x16, 0x20, 0x64, 0x4b, 0xcc, 0x7e, 0x56, 0x43, 0x73, 0x04, 0x09, 0x99, 0xaa, 0xc8,
             0x9e, 0x76, 0x22, 0xf3, 0xca, 0x71, 0xfb, 0xa1, 0xd9, 0x72, 0xfd, 0x94, 0xa3, 0x1c,
             0x3b, 0xfb, 0xf2, 0x4e, 0x39, 0x38,
         ];
-        assert!(PeerId::from_bytes(&bytes).is_err());
+        assert!(matches!(
+            PeerId::from_bytes(&bytes),
+            Err(ParseError::MultiHash)
+        ));
+    }
+
+    #[test]
+    fn from_bytes_rejects_invalid_multihash_bytes() {
+        assert!(matches!(
+            PeerId::from_bytes(&[0xff]),
+            Err(ParseError::MultiHash)
+        ));
+    }
+
+    #[test]
+    fn from_str_rejects_invalid_base58() {
+        assert!(matches!(
+            "not base58: 0".parse::<PeerId>(),
+            Err(ParseError::B58(_))
+        ));
     }
 
     // --- identity and sha256 peer IDs roundtrip ---

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -1424,7 +1424,6 @@ mod tests {
         ConnectionId,
     };
     use multiaddr::Protocol;
-    use multihash::Multihash;
     use std::str::FromStr;
     use tokio::sync::mpsc::channel;
 
@@ -1566,15 +1565,15 @@ mod tests {
         let (mut kademlia, _context, _manager) = make_kademlia();
 
         let peer = PeerId::random();
-        let address_a = Multiaddr::from_str("/dns/domain1.com/tcp/30333").unwrap().with(
-            Protocol::P2p(Multihash::from_bytes(&peer.to_bytes()).unwrap()),
-        );
-        let address_b = Multiaddr::from_str("/dns/domain1.com/tcp/30334").unwrap().with(
-            Protocol::P2p(Multihash::from_bytes(&peer.to_bytes()).unwrap()),
-        );
-        let address_c = Multiaddr::from_str("/dns/domain1.com/tcp/30339").unwrap().with(
-            Protocol::P2p(Multihash::from_bytes(&peer.to_bytes()).unwrap()),
-        );
+        let address_a = Multiaddr::from_str("/dns/domain1.com/tcp/30333")
+            .unwrap()
+            .with(Protocol::P2p(peer.into()));
+        let address_b = Multiaddr::from_str("/dns/domain1.com/tcp/30334")
+            .unwrap()
+            .with(Protocol::P2p(peer.into()));
+        let address_c = Multiaddr::from_str("/dns/domain1.com/tcp/30339")
+            .unwrap()
+            .with(Protocol::P2p(peer.into()));
 
         // Added only with address a.
         kademlia.routing_table.add_known_peer(

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -900,10 +900,12 @@ impl QueryEngine {
 
 #[cfg(test)]
 mod tests {
-    use multihash::{Code, Multihash};
+    use multihash::Multihash;
 
     use super::*;
-    use crate::protocol::libp2p::kademlia::types::ConnectionType;
+    use crate::{
+        peer_id::MULTIHASH_IDENTITY_CODE, protocol::libp2p::kademlia::types::ConnectionType,
+    };
 
     // make fixed peer id
     fn make_peer_id(first: u8, second: u8) -> PeerId {
@@ -912,7 +914,7 @@ mod tests {
         peer_id[1] = second;
 
         PeerId::from_bytes(
-            &Multihash::wrap(Code::Identity.into(), &peer_id)
+            &Multihash::<64>::wrap(MULTIHASH_IDENTITY_CODE, &peer_id)
                 .expect("The digest size is never too large")
                 .to_bytes(),
         )

--- a/src/protocol/libp2p/kademlia/record.rs
+++ b/src/protocol/libp2p/kademlia/record.rs
@@ -28,9 +28,9 @@ use crate::{
 };
 
 use bytes::Bytes;
-use multihash::Multihash;
-
 use std::{borrow::Borrow, time::Instant};
+
+type Multihash = multihash::Multihash<64>;
 
 /// The (opaque) key of a record.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/protocol/libp2p/kademlia/routing_table.rs
+++ b/src/protocol/libp2p/kademlia/routing_table.rs
@@ -34,7 +34,6 @@ use crate::{
 };
 
 use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
 
 /// Number of k-buckets.
 const NUM_BUCKETS: usize = 256;
@@ -190,12 +189,12 @@ impl RoutingTable {
         // TODO: https://github.com/paritytech/litep2p/issues/337 this has to be moved elsewhere at some point
         let addresses: Vec<Multiaddr> = addresses
             .into_iter()
-            .filter_map(|address| {
+            .map(|address| {
                 let last = address.iter().last();
                 if std::matches!(last, Some(Protocol::P2p(_))) {
-                    Some(address)
+                    address
                 } else {
-                    Some(address.with(Protocol::P2p(Multihash::from_bytes(&peer.to_bytes()).ok()?)))
+                    address.with(Protocol::P2p(peer.into()))
                 }
             })
             .collect();
@@ -259,7 +258,7 @@ enum ClosestBucketsIterState {
     /// The starting state of the iterator yields the first bucket index and
     /// then transitions to `ZoomIn`.
     Start(BucketIndex),
-    /// The iterator "zooms in" to to yield the next bucket cotaining nodes that
+    /// The iterator "zooms in" to to yield the next bucket containing nodes that
     /// are incrementally closer to the local node but further from the `target`.
     /// These buckets are identified by a `1` in the corresponding bit position
     /// of the distance bit string. When bucket `0` is reached, the iterator

--- a/src/protocol/transport_service.rs
+++ b/src/protocol/transport_service.rs
@@ -29,7 +29,6 @@ use crate::{
 
 use futures::{future::BoxFuture, stream::FuturesUnordered, Stream, StreamExt};
 use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use std::{
@@ -543,11 +542,11 @@ impl TransportService {
     /// The list is filtered for duplicates and unsupported transports.
     pub fn add_known_address(&mut self, peer: &PeerId, addresses: impl Iterator<Item = Multiaddr>) {
         let addresses: HashSet<Multiaddr> = addresses
-            .filter_map(|address| {
+            .map(|address| {
                 if !std::matches!(address.iter().last(), Some(Protocol::P2p(_))) {
-                    Some(address.with(Protocol::P2p(Multihash::from_bytes(&peer.to_bytes()).ok()?)))
+                    address.with(Protocol::P2p((*peer).into()))
                 } else {
-                    Some(address)
+                    address
                 }
             })
             .collect();

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -605,8 +605,6 @@ mod tests {
         assert_eq!(store.addresses.get(&address).unwrap().score, failure_score);
     }
 
-    // --- AddressRecord::new peer ID handling ---
-
     #[test]
     fn address_record_new_appends_peer_id_when_missing() {
         let peer = PeerId::random();

--- a/src/transport/manager/address.rs
+++ b/src/transport/manager/address.rs
@@ -22,7 +22,6 @@ use crate::{error::DialError, PeerId};
 
 use ip_network::IpNetwork;
 use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
 
 use std::collections::{hash_map::Entry, HashMap};
 
@@ -70,9 +69,7 @@ impl AddressRecord {
     /// append the provided `PeerId` to the address.
     pub fn new(peer: &PeerId, address: Multiaddr, score: i32) -> Self {
         let address = if !std::matches!(address.iter().last(), Some(Protocol::P2p(_))) {
-            address.with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).expect("valid peer id"),
-            ))
+            address.with(Protocol::P2p((*peer).into()))
         } else {
             address
         };
@@ -536,9 +533,7 @@ mod tests {
         let address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(8, 8, 8, 8)))
             .with(Protocol::Tcp(9999))
-            .with(Protocol::P2p(
-                multihash::Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         let record = AddressRecord::from_multiaddr(address.clone()).unwrap();
         assert_eq!(record.score, 0);
@@ -584,9 +579,7 @@ mod tests {
         let address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(8, 8, 8, 8)))
             .with(Protocol::Tcp(9999))
-            .with(Protocol::P2p(
-                multihash::Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         // First, add the address normally.
         let record = AddressRecord::from_multiaddr(address.clone()).unwrap();
@@ -610,6 +603,31 @@ mod tests {
 
         // Score should still reflect the failure, not 0.
         assert_eq!(store.addresses.get(&address).unwrap().score, failure_score);
+    }
+
+    // --- AddressRecord::new peer ID handling ---
+
+    #[test]
+    fn address_record_new_appends_peer_id_when_missing() {
+        let peer = PeerId::random();
+        let address: Multiaddr = "/ip4/1.2.3.4/tcp/8080".parse().unwrap();
+
+        let record = AddressRecord::new(&peer, address, 0);
+
+        assert_eq!(PeerId::try_from_multiaddr(record.address()), Some(peer));
+    }
+
+    #[test]
+    fn address_record_new_keeps_address_unchanged_when_peer_id_present() {
+        let peer: PeerId = "12D3KooWT2ouvz5uMmCvHJGzAGRHiqDts5hzXR7NdoQ27pGdzp9Q".parse().unwrap();
+        let address: Multiaddr =
+            "/ip4/1.2.3.4/tcp/8080/p2p/12D3KooWT2ouvz5uMmCvHJGzAGRHiqDts5hzXR7NdoQ27pGdzp9Q"
+                .parse()
+                .unwrap();
+
+        let record = AddressRecord::new(&peer, address.clone(), 0);
+
+        assert_eq!(record.address(), &address);
     }
 
     #[test]

--- a/src/transport/manager/handle.rs
+++ b/src/transport/manager/handle.rs
@@ -251,7 +251,7 @@ impl TransportManagerHandle {
             // Check the peer ID if present.
             if let Some(Protocol::P2p(multihash)) = address.iter().last() {
                 // This can correspond to the provided peerID or to a different one.
-                if multihash != *peer.as_ref() {
+                if multihash.as_ref() != peer.as_ref() {
                     tracing::debug!(
                         target: LOG_TARGET,
                         ?peer,
@@ -265,7 +265,7 @@ impl TransportManagerHandle {
                 peer_addresses.insert(address);
             } else {
                 // Add the provided peer ID to the address.
-                let address = address.with(Protocol::P2p(multihash::Multihash::from(*peer)));
+                let address = address.with(Protocol::P2p((*peer).into()));
                 peer_addresses.insert(address);
             }
         }
@@ -402,7 +402,6 @@ mod tests {
     };
 
     use super::*;
-    use multihash::Multihash;
     use parking_lot::lock_api::RwLock;
     use tokio::sync::mpsc::{channel, Receiver};
 
@@ -580,9 +579,8 @@ mod tests {
         let (handle, _rx) = make_transport_manager_handle();
 
         // only peer id (used by Polkadot sometimes)
-        assert!(!handle.supported_transport(
-            &Multiaddr::empty().with(Protocol::P2p(Multihash::from(PeerId::random())))
-        ));
+        assert!(!handle
+            .supported_transport(&Multiaddr::empty().with(Protocol::P2p(PeerId::random().into()))));
 
         // only one transport
         assert!(!handle.supported_transport(
@@ -645,7 +643,7 @@ mod tests {
                             address: Multiaddr::empty()
                                 .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                                 .with(Protocol::Tcp(8888))
-                                .with(Protocol::P2p(Multihash::from(peer))),
+                                .with(Protocol::P2p(peer.into())),
                             connection_id: ConnectionId::from(0),
                         },
                         secondary: None,
@@ -655,7 +653,7 @@ mod tests {
                         vec![Multiaddr::empty()
                             .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                             .with(Protocol::Tcp(8888))
-                            .with(Protocol::P2p(Multihash::from(peer)))]
+                            .with(Protocol::P2p(peer.into()))]
                         .into_iter(),
                     ),
                 },
@@ -688,7 +686,7 @@ mod tests {
                             address: Multiaddr::empty()
                                 .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                                 .with(Protocol::Tcp(8888))
-                                .with(Protocol::P2p(Multihash::from(peer))),
+                                .with(Protocol::P2p(peer.into())),
                             connection_id: ConnectionId::from(0),
                         },
                     },
@@ -697,7 +695,7 @@ mod tests {
                         vec![Multiaddr::empty()
                             .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                             .with(Protocol::Tcp(8888))
-                            .with(Protocol::P2p(Multihash::from(peer)))]
+                            .with(Protocol::P2p(peer.into()))]
                         .into_iter(),
                     ),
                 },
@@ -756,7 +754,7 @@ mod tests {
                             Multiaddr::empty()
                                 .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                                 .with(Protocol::Tcp(8888))
-                                .with(Protocol::P2p(Multihash::from(peer))),
+                                .with(Protocol::P2p(peer.into())),
                             ConnectionId::from(0),
                         )),
                     },
@@ -765,7 +763,7 @@ mod tests {
                         vec![Multiaddr::empty()
                             .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                             .with(Protocol::Tcp(8888))
-                            .with(Protocol::P2p(Multihash::from(peer)))]
+                            .with(Protocol::P2p(peer.into()))]
                         .into_iter(),
                     ),
                 },
@@ -871,5 +869,37 @@ mod tests {
             .is_local_address(&"/ip4/127.0.0.1/tcp/9999".parse().expect("valid multiaddress")));
         assert!(!handle
             .is_local_address(&"/ip4/127.0.0.1/tcp/7777".parse().expect("valid multiaddress")));
+    }
+
+    // --- add_known_address peer ID handling ---
+
+    #[test]
+    fn add_known_address_rejects_address_with_wrong_peer_id() {
+        let (mut handle, _rx) = make_transport_manager_handle();
+        handle.supported_transport.insert(SupportedTransport::Tcp);
+
+        let peer: PeerId = "12D3KooWT2ouvz5uMmCvHJGzAGRHiqDts5hzXR7NdoQ27pGdzp9Q".parse().unwrap();
+        let address: Multiaddr =
+            "/ip4/1.2.3.4/tcp/8080/p2p/12D3KooWPGxxxQiBEBZ52RY31Z2chn4xsDrGCMouZ88izJrak2T1"
+                .parse()
+                .unwrap();
+
+        let added = handle.add_known_address(&peer, vec![address].into_iter());
+        assert_eq!(added, 0);
+    }
+
+    #[test]
+    fn add_known_address_accepts_address_with_correct_peer_id() {
+        let (mut handle, _rx) = make_transport_manager_handle();
+        handle.supported_transport.insert(SupportedTransport::Tcp);
+
+        let peer: PeerId = "12D3KooWT2ouvz5uMmCvHJGzAGRHiqDts5hzXR7NdoQ27pGdzp9Q".parse().unwrap();
+        let address: Multiaddr =
+            "/ip4/1.2.3.4/tcp/8080/p2p/12D3KooWT2ouvz5uMmCvHJGzAGRHiqDts5hzXR7NdoQ27pGdzp9Q"
+                .parse()
+                .unwrap();
+
+        let added = handle.add_known_address(&peer, vec![address].into_iter());
+        assert_eq!(added, 1);
     }
 }

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -42,7 +42,6 @@ use address::{scores, AddressStore};
 use futures::{future::BoxFuture, stream::FuturesUnordered, Stream, StreamExt};
 use indexmap::IndexMap;
 use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
 use parking_lot::RwLock;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
@@ -485,9 +484,7 @@ impl TransportManager {
         let mut listen_addresses = self.listen_addresses.write();
 
         listen_addresses.insert(address.clone());
-        listen_addresses.insert(address.with(Protocol::P2p(
-            Multihash::from_bytes(&self.local_peer_id.to_bytes()).unwrap(),
-        )));
+        listen_addresses.insert(address.with(Protocol::P2p(self.local_peer_id.into())));
     }
 
     /// Add one or more known addresses for `peer`.
@@ -1468,8 +1465,6 @@ mod tests {
     use crate::transport::manager::{address::AddressStore, peer_state::SecondaryOrDialing};
     use limits::ConnectionLimitsConfig;
 
-    use multihash::Multihash;
-
     use super::*;
     use crate::{
         crypto::ed25519::Keypair,
@@ -1488,9 +1483,7 @@ mod tests {
         let dial_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888 + connection_id))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let connection_id = ConnectionId::from(connection_id as usize);
 
         (dial_address, connection_id)
@@ -1796,9 +1789,7 @@ mod tests {
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Udp(8888))
             .with(Protocol::QuicV1)
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(PeerId::random().into()));
 
         assert!(std::matches!(
             manager.dial_address(address).await,
@@ -1817,9 +1808,7 @@ mod tests {
         let dial_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         let transport = Box::new({
             let mut transport = DummyTransport::new();
@@ -1876,9 +1865,7 @@ mod tests {
         let dial_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         assert!(manager.dial_address(dial_address.clone()).await.is_ok());
         assert_eq!(manager.pending_connections.len(), 1);
@@ -1904,9 +1891,7 @@ mod tests {
                 Multiaddr::empty()
                     .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
                     .with(Protocol::Tcp(8888))
-                    .with(Protocol::P2p(
-                        Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-                    ))
+                    .with(Protocol::P2p(peer.into(),))
             )
             .await
             .is_ok());
@@ -1917,9 +1902,7 @@ mod tests {
                 Multiaddr::empty()
                     .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
                     .with(Protocol::Tcp(8888))
-                    .with(Protocol::P2p(
-                        Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-                    ))
+                    .with(Protocol::P2p(peer.into(),))
             )
             .await
             .is_ok());
@@ -1980,18 +1963,14 @@ mod tests {
         let address = Multiaddr::empty()
             .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(PeerId::random().into()));
         assert!(handle.supported_transport(&address));
 
         // ipv4
         let address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(PeerId::random().into()));
         assert!(handle.supported_transport(&address));
 
         // quic
@@ -1999,9 +1978,7 @@ mod tests {
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Udp(8888))
             .with(Protocol::QuicV1)
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(PeerId::random().into()));
         #[cfg(feature = "quic")]
         assert!(handle.supported_transport(&address));
         #[cfg(not(feature = "quic"))]
@@ -2038,15 +2015,11 @@ mod tests {
         let dial_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let connect_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 173)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         assert!(manager.dial_address(dial_address.clone()).await.is_ok());
         assert_eq!(manager.pending_connections.len(), 1);
 
@@ -2099,15 +2072,11 @@ mod tests {
         let dial_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let connect_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 173)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         assert!(manager.dial_address(dial_address.clone()).await.is_ok());
         assert_eq!(manager.pending_connections.len(), 1);
 
@@ -2180,15 +2149,11 @@ mod tests {
         let dial_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let connect_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 173)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         assert!(manager.dial_address(dial_address.clone()).await.is_ok());
         assert_eq!(manager.pending_connections.len(), 1);
 
@@ -2258,21 +2223,15 @@ mod tests {
         let address1 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let address2 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 173)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let address3 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 10, 64)))
             .with(Protocol::Tcp(9999))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         // remote peer connected to local node
         let established_result = manager
@@ -2361,15 +2320,11 @@ mod tests {
         let address1 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let address2 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 173)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         // remote peer connected to local node
         let established_result = manager
@@ -2451,15 +2406,11 @@ mod tests {
         let address1 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let address2 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 173)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         // remote peer connected to local node
         let emit_event = manager
@@ -2554,15 +2505,11 @@ mod tests {
         let address1 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let address2 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 173)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         // remote peer connected to local node
         let emit_event = manager
@@ -2652,21 +2599,15 @@ mod tests {
         let address1 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let address2 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 173)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let address3 = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 173)))
             .with(Protocol::Tcp(9999))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         // remote peer connected to local node
         let emit_event = manager
@@ -2915,7 +2856,7 @@ mod tests {
                             address: Multiaddr::empty()
                                 .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                                 .with(Protocol::Tcp(8888))
-                                .with(Protocol::P2p(Multihash::from(peer))),
+                                .with(Protocol::P2p(peer.into())),
                             connection_id: ConnectionId::from(0usize),
                         },
                         secondary: None,
@@ -2925,7 +2866,7 @@ mod tests {
                         vec![Multiaddr::empty()
                             .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                             .with(Protocol::Tcp(8888))
-                            .with(Protocol::P2p(Multihash::from(peer)))]
+                            .with(Protocol::P2p(peer.into()))]
                         .into_iter(),
                     ),
                 },
@@ -2957,7 +2898,7 @@ mod tests {
                             address: Multiaddr::empty()
                                 .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                                 .with(Protocol::Tcp(8888))
-                                .with(Protocol::P2p(Multihash::from(peer))),
+                                .with(Protocol::P2p(peer.into())),
                             connection_id: ConnectionId::from(0usize),
                         },
                     },
@@ -2966,7 +2907,7 @@ mod tests {
                         vec![Multiaddr::empty()
                             .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                             .with(Protocol::Tcp(8888))
-                            .with(Protocol::P2p(Multihash::from(peer)))]
+                            .with(Protocol::P2p(peer.into()))]
                         .into_iter(),
                     ),
                 },
@@ -2990,7 +2931,7 @@ mod tests {
                         Multiaddr::empty()
                             .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                             .with(Protocol::Tcp(8888))
-                            .with(Protocol::P2p(Multihash::from(peer)))
+                            .with(Protocol::P2p(peer.into()))
                     );
                 }
                 state => panic!("invalid state: {state:?}"),
@@ -3015,7 +2956,7 @@ mod tests {
                             Multiaddr::empty()
                                 .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                                 .with(Protocol::Tcp(8888))
-                                .with(Protocol::P2p(Multihash::from(peer))),
+                                .with(Protocol::P2p(peer.into())),
                             ConnectionId::from(0),
                         )),
                     },
@@ -3041,7 +2982,7 @@ mod tests {
 
         // transport doesn't start with ip/dns
         {
-            let address = Multiaddr::empty().with(Protocol::P2p(Multihash::from(PeerId::random())));
+            let address = Multiaddr::empty().with(Protocol::P2p(PeerId::random().into()));
             match manager.dial_address(address.clone()).await {
                 Err(Error::TransportNotSupported(dial_address)) => {
                     assert_eq!(dial_address, address);
@@ -3056,7 +2997,7 @@ mod tests {
                 .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                 .with(Protocol::Udp(8888))
                 .with(Protocol::Utp)
-                .with(Protocol::P2p(Multihash::from(PeerId::random())));
+                .with(Protocol::P2p(PeerId::random().into()));
             match manager.dial_address(address.clone()).await {
                 Err(Error::TransportNotSupported(dial_address)) => {
                     assert_eq!(dial_address, address);
@@ -3070,7 +3011,7 @@ mod tests {
             let address = Multiaddr::empty()
                 .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                 .with(Protocol::Sctp(8888))
-                .with(Protocol::P2p(Multihash::from(PeerId::random())));
+                .with(Protocol::P2p(PeerId::random().into()));
             match manager.dial_address(address.clone()).await {
                 Err(Error::TransportNotSupported(dial_address)) => {
                     assert_eq!(dial_address, address);
@@ -3085,7 +3026,7 @@ mod tests {
                 .with(Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
                 .with(Protocol::Tcp(8888))
                 .with(Protocol::Utp)
-                .with(Protocol::P2p(Multihash::from(PeerId::random())));
+                .with(Protocol::P2p(PeerId::random().into()));
             match manager.dial_address(address.clone()).await {
                 Err(Error::TransportNotSupported(dial_address)) => {
                     assert_eq!(dial_address, address);
@@ -3150,9 +3091,7 @@ mod tests {
         let dial_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         let connection_id = ConnectionId::random();
         let transport = Box::new({
@@ -3169,7 +3108,7 @@ mod tests {
             vec![Multiaddr::empty()
                 .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 5)))
                 .with(Protocol::Tcp(8888))
-                .with(Protocol::P2p(Multihash::from(peer)))]
+                .with(Protocol::P2p(peer.into()))]
             .into_iter(),
         );
 
@@ -3230,9 +3169,7 @@ mod tests {
         let dial_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         let connection_id = ConnectionId::random();
         let transport = Box::new({
@@ -3249,7 +3186,7 @@ mod tests {
             vec![Multiaddr::empty()
                 .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
                 .with(Protocol::Tcp(8888))
-                .with(Protocol::P2p(Multihash::from(peer)))]
+                .with(Protocol::P2p(peer.into()))]
             .into_iter(),
         );
 
@@ -3525,9 +3462,7 @@ mod tests {
             let dial_address = Multiaddr::empty()
                 .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
                 .with(Protocol::Tcp(8888 + connection_id))
-                .with(Protocol::P2p(
-                    Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-                ));
+                .with(Protocol::P2p(peer.into()));
             let connection_id = ConnectionId::from(connection_id as usize);
 
             (dial_address, connection_id)
@@ -3666,9 +3601,7 @@ mod tests {
         let dial_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         let connection_id = ConnectionId::from(0);
         let transport = Box::new({
@@ -3704,9 +3637,7 @@ mod tests {
         let second_address = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8889))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         // Second dial attempt with different address.
         manager.dial_address(second_address.clone()).await.unwrap();
@@ -3749,9 +3680,7 @@ mod tests {
         let dial_address_tcp = Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         let transport = Box::new({
             let mut transport = DummyTransport::new();
             transport.inject_event(TransportEvent::OpenFailure {
@@ -3766,7 +3695,7 @@ mod tests {
             vec![Multiaddr::empty()
                 .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 5)))
                 .with(Protocol::Tcp(8888))
-                .with(Protocol::P2p(Multihash::from(peer)))]
+                .with(Protocol::P2p(peer.into()))]
             .into_iter(),
         );
 
@@ -3775,9 +3704,7 @@ mod tests {
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Tcp(8889))
             .with(Protocol::Ws(Cow::Borrowed("/")))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         let transport = Box::new({
             let mut transport = DummyTransport::new();
@@ -3794,9 +3721,7 @@ mod tests {
                 .with(Protocol::Ip4(Ipv4Addr::new(192, 168, 1, 5)))
                 .with(Protocol::Tcp(8889))
                 .with(Protocol::Ws(Cow::Borrowed("/")))
-                .with(Protocol::P2p(
-                    Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-                ))]
+                .with(Protocol::P2p(peer.into()))]
             .into_iter(),
         );
 

--- a/src/transport/manager/peer_state.rs
+++ b/src/transport/manager/peer_state.rs
@@ -942,4 +942,46 @@ mod tests {
             }
         );
     }
+
+    // --- ensure_peer_id (tested via ConnectionRecord::new) ---
+
+    #[test]
+    fn ensure_peer_id_appended_when_missing() {
+        let peer = PeerId::random();
+        // Address without /p2p component.
+        let address: Multiaddr = "/ip4/1.2.3.4/tcp/8080".parse().unwrap();
+
+        let record = ConnectionRecord::new(peer, address, ConnectionId::from(0));
+
+        // The stored address must end with the correct /p2p peer ID.
+        assert_eq!(PeerId::try_from_multiaddr(&record.address), Some(peer));
+    }
+
+    #[test]
+    fn ensure_peer_id_unchanged_when_correct() {
+        let peer = PeerId::random();
+        let address: Multiaddr = format!("/ip4/1.2.3.4/tcp/8080/p2p/{peer}")
+            .parse()
+            .unwrap();
+
+        let record = ConnectionRecord::new(peer, address.clone(), ConnectionId::from(0));
+
+        // Address must be identical — no modification.
+        assert_eq!(record.address, address);
+    }
+
+    #[test]
+    fn ensure_peer_id_replaced_when_wrong() {
+        let peer = PeerId::random();
+        let wrong_peer = PeerId::random();
+        // Address ends with a *different* peer's ID.
+        let address: Multiaddr = format!("/ip4/1.2.3.4/tcp/8080/p2p/{wrong_peer}")
+            .parse()
+            .unwrap();
+
+        let record = ConnectionRecord::new(peer, address, ConnectionId::from(0));
+
+        // The wrong peer ID must have been replaced with the correct one.
+        assert_eq!(PeerId::try_from_multiaddr(&record.address), Some(peer));
+    }
 }

--- a/src/transport/manager/peer_state.rs
+++ b/src/transport/manager/peer_state.rs
@@ -945,8 +945,6 @@ mod tests {
         );
     }
 
-    // --- ensure_peer_id (tested via ConnectionRecord::new) ---
-
     #[test]
     fn ensure_peer_id_appended_when_missing() {
         let peer = PeerId::random();

--- a/src/transport/manager/peer_state.rs
+++ b/src/transport/manager/peer_state.rs
@@ -467,8 +467,10 @@ impl ConnectionRecord {
 
     /// Ensures the peer ID is present in the address.
     fn ensure_peer_id(peer: PeerId, mut address: Multiaddr) -> Multiaddr {
+        let multiaddr_peer_id: multiaddr::PeerId = peer.into();
+
         if let Some(Protocol::P2p(multihash)) = address.iter().last() {
-            if multihash != *peer.as_ref() {
+            if multihash != multiaddr_peer_id {
                 tracing::warn!(
                     target: LOG_TARGET,
                     ?address,
@@ -477,12 +479,12 @@ impl ConnectionRecord {
                 );
 
                 address.pop();
-                address.push(Protocol::P2p(*peer.as_ref()));
+                address.push(Protocol::P2p(multiaddr_peer_id));
             }
 
             address
         } else {
-            address.with(Protocol::P2p(*peer.as_ref()))
+            address.with(Protocol::P2p(multiaddr_peer_id))
         }
     }
 }
@@ -959,10 +961,11 @@ mod tests {
 
     #[test]
     fn ensure_peer_id_unchanged_when_correct() {
-        let peer = PeerId::random();
-        let address: Multiaddr = format!("/ip4/1.2.3.4/tcp/8080/p2p/{peer}")
-            .parse()
-            .unwrap();
+        let peer: PeerId = "12D3KooWT2ouvz5uMmCvHJGzAGRHiqDts5hzXR7NdoQ27pGdzp9Q".parse().unwrap();
+        let address: Multiaddr =
+            "/ip4/1.2.3.4/tcp/8080/p2p/12D3KooWT2ouvz5uMmCvHJGzAGRHiqDts5hzXR7NdoQ27pGdzp9Q"
+                .parse()
+                .unwrap();
 
         let record = ConnectionRecord::new(peer, address.clone(), ConnectionId::from(0));
 
@@ -972,12 +975,12 @@ mod tests {
 
     #[test]
     fn ensure_peer_id_replaced_when_wrong() {
-        let peer = PeerId::random();
-        let wrong_peer = PeerId::random();
+        let peer: PeerId = "12D3KooWT2ouvz5uMmCvHJGzAGRHiqDts5hzXR7NdoQ27pGdzp9Q".parse().unwrap();
         // Address ends with a *different* peer's ID.
-        let address: Multiaddr = format!("/ip4/1.2.3.4/tcp/8080/p2p/{wrong_peer}")
-            .parse()
-            .unwrap();
+        let address: Multiaddr =
+            "/ip4/1.2.3.4/tcp/8080/p2p/12D3KooWPGxxxQiBEBZ52RY31Z2chn4xsDrGCMouZ88izJrak2T1"
+                .parse()
+                .unwrap();
 
         let record = ConnectionRecord::new(peer, address, ConnectionId::from(0));
 

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -611,7 +611,6 @@ mod tests {
         types::protocol::ProtocolName,
         BandwidthSink,
     };
-    use multihash::Multihash;
     use tokio::sync::mpsc::channel;
 
     #[tokio::test]
@@ -675,9 +674,7 @@ mod tests {
             QuicTransport::new(handle2, Default::default(), resolver).unwrap();
         let peer1: PeerId = PeerId::from_public_key(&keypair1.public().into());
         let _peer2: PeerId = PeerId::from_public_key(&keypair2.public().into());
-        let listen_address = listen_address.with(Protocol::P2p(
-            Multihash::from_bytes(&peer1.to_bytes()).unwrap(),
-        ));
+        let listen_address = listen_address.with(Protocol::P2p(peer1.into()));
 
         transport2.dial(ConnectionId::new(), listen_address).unwrap();
 

--- a/src/transport/s2n-quic/mod.rs
+++ b/src/transport/s2n-quic/mod.rs
@@ -201,7 +201,7 @@ impl QuicTransport {
                             .with(Protocol::Udp(address.port()))
                             .with(Protocol::QuicV1)
                             .with(Protocol::P2p(
-                                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
+                                peer.into(),
                             ))
                     }
                 };
@@ -506,9 +506,7 @@ mod tests {
             .with(Protocol::from(std::net::Ipv4Addr::new(255, 254, 253, 252)))
             .with(Protocol::Udp(8888))
             .with(Protocol::QuicV1)
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
         manager.dial_address(address.clone()).await.unwrap();
 
         assert!(transport.pending_dials.is_empty());
@@ -551,9 +549,7 @@ mod tests {
             .with(Protocol::from(std::net::Ipv4Addr::new(255, 254, 253, 252)))
             .with(Protocol::Udp(8888))
             .with(Protocol::QuicV1)
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer.into()));
 
         assert!(transport.pending_dials.is_empty());
 

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -736,7 +736,6 @@ mod tests {
         BandwidthSink, PeerId,
     };
     use multiaddr::Protocol;
-    use multihash::Multihash;
     use std::sync::Arc;
     use tokio::sync::mpsc::channel;
 
@@ -1008,9 +1007,7 @@ mod tests {
                 0, 0, 0, 0, 0, 0, 0, 1,
             )))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer1.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer1.into()));
 
         transport2.dial(ConnectionId::new(), address).unwrap();
 
@@ -1051,9 +1048,7 @@ mod tests {
         let multiaddr = Multiaddr::empty()
             .with(Protocol::Ip4(std::net::Ipv4Addr::new(255, 254, 253, 252)))
             .with(Protocol::Tcp(8888))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer_id.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer_id.into()));
         manager.dial_address(multiaddr.clone()).await.unwrap();
 
         assert!(transport.pending_dials.is_empty());

--- a/src/transport/webrtc/opening.rs
+++ b/src/transport/webrtc/opening.rs
@@ -189,7 +189,7 @@ impl OpeningWebRtcConnection {
 
     /// Convert `Fingerprint` to bytes.
     fn fingerprint_to_bytes(fingerprint: &Fingerprint) -> Vec<u8> {
-        multihash::Multihash::<64>::wrap(u64::from(Code::Sha2_256), &fingerprint.bytes)
+        multihash::Multihash::<64>::wrap(Code::Sha2_256.into(), &fingerprint.bytes)
             .expect("fingerprint's len to be 32 bytes")
             .to_bytes()
     }
@@ -273,7 +273,7 @@ impl OpeningWebRtcConnection {
             .bytes;
 
         let certificate =
-            multihash::Multihash::<64>::wrap(u64::from(Code::Sha2_256), &remote_fingerprint)
+            multihash::Multihash::<64>::wrap(Code::Sha2_256.into(), &remote_fingerprint)
                 .expect("fingerprint's len to be 32 bytes");
 
         let address = Multiaddr::empty()

--- a/src/transport/webrtc/opening.rs
+++ b/src/transport/webrtc/opening.rs
@@ -28,7 +28,8 @@ use crate::{
     Error, PeerId,
 };
 
-use multiaddr::{multihash::Multihash, Multiaddr, Protocol};
+use multiaddr::{Multiaddr, Protocol};
+use multihash_codetable::Code;
 use str0m::{
     channel::ChannelId,
     config::Fingerprint,
@@ -188,8 +189,7 @@ impl OpeningWebRtcConnection {
 
     /// Convert `Fingerprint` to bytes.
     fn fingerprint_to_bytes(fingerprint: &Fingerprint) -> Vec<u8> {
-        const MULTIHASH_SHA256_CODE: u64 = 0x12;
-        Multihash::wrap(MULTIHASH_SHA256_CODE, &fingerprint.bytes)
+        multihash::Multihash::<64>::wrap(u64::from(Code::Sha2_256), &fingerprint.bytes)
             .expect("fingerprint's len to be 32 bytes")
             .to_bytes()
     }
@@ -272,9 +272,9 @@ impl OpeningWebRtcConnection {
             .clone()
             .bytes;
 
-        const MULTIHASH_SHA256_CODE: u64 = 0x12;
-        let certificate = Multihash::wrap(MULTIHASH_SHA256_CODE, &remote_fingerprint)
-            .expect("fingerprint's len to be 32 bytes");
+        let certificate =
+            multihash::Multihash::<64>::wrap(u64::from(Code::Sha2_256), &remote_fingerprint)
+                .expect("fingerprint's len to be 32 bytes");
 
         let address = Multiaddr::empty()
             .with(Protocol::from(self.peer_address.ip()))

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 use futures::{future::BoxFuture, stream::FuturesUnordered, AsyncRead, AsyncWrite, StreamExt};
-use multiaddr::{multihash::Multihash, Multiaddr, Protocol};
+use multiaddr::{Multiaddr, Protocol};
 use tokio::net::TcpStream;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
@@ -359,7 +359,7 @@ impl WebSocketConnection {
 
         let address = match role {
             Role::Dialer => address,
-            Role::Listener => address.with(Protocol::P2p(Multihash::from(peer))),
+            Role::Listener => address.with(Protocol::P2p(peer.into())),
         };
 
         Ok(NegotiatedConnection {

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,7 +27,8 @@ pub mod multiaddr {
     pub use multiaddr::{Error, Iter, Multiaddr, Onion3Addr, Protocol};
 }
 pub mod multihash {
-    pub use multihash::{Code, Error, Multihash, MultihashDigest};
+    pub use multihash::{Error, Multihash};
+    pub use multihash_codetable::{Code, MultihashDigest};
 }
 pub mod cid {
     pub use cid::{multihash::Multihash, Cid, CidGeneric, Error, Result, Version};

--- a/tests/conformance/rust/identify.rs
+++ b/tests/conformance/rust/identify.rs
@@ -23,9 +23,9 @@
 
 use futures::{Stream, StreamExt};
 use libp2p::{
-    identify, identity, ping,
-    swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent},
-    PeerId, Swarm,
+    identify, identity, noise, ping,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, yamux, Swarm, SwarmBuilder,
 };
 use litep2p::{
     config::ConfigBuilder,
@@ -92,19 +92,28 @@ fn initialize_litep2p() -> (
 
 fn initialize_libp2p() -> Swarm<MyBehaviour> {
     let local_key = identity::Keypair::generate_ed25519();
-    let local_peer_id = PeerId::from(local_key.public());
 
-    tracing::debug!("Local peer id: {local_peer_id:?}");
+    tracing::debug!("Local peer id: {:?}", local_key.public().to_peer_id());
 
-    let transport = libp2p::tokio_development_transport(local_key.clone()).unwrap();
-    let behaviour = MyBehaviour {
-        identify: identify::Behaviour::new(
-            identify::Config::new("/ipfs/1.0.0".into(), local_key.public())
-                .with_agent_version("libp2p agent".to_string()),
-        ),
-        ping: Default::default(),
-    };
-    let mut swarm = SwarmBuilder::with_tokio_executor(transport, behaviour, local_peer_id).build();
+    let mut swarm = SwarmBuilder::with_existing_identity(local_key)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .unwrap()
+        .with_dns()
+        .unwrap()
+        .with_behaviour(|key| MyBehaviour {
+            identify: identify::Behaviour::new(
+                identify::Config::new("/ipfs/1.0.0".into(), key.public())
+                    .with_agent_version("libp2p agent".to_string()),
+            ),
+            ping: Default::default(),
+        })
+        .unwrap()
+        .build();
 
     swarm.listen_on("/ip6/::1/tcp/0".parse().unwrap()).unwrap();
 

--- a/tests/conformance/rust/kademlia.rs
+++ b/tests/conformance/rust/kademlia.rs
@@ -23,11 +23,12 @@ use futures::StreamExt;
 use libp2p::{
     identify, identity,
     kad::{
-        self, store::RecordStore, AddProviderOk, GetProvidersOk, InboundRequest,
-        KademliaEvent as Libp2pKademliaEvent, QueryResult,
+        self, store::RecordStore, AddProviderOk, Event as Libp2pKademliaEvent, GetProvidersOk,
+        InboundRequest, QueryResult,
     },
-    swarm::{keep_alive, AddressScore, NetworkBehaviour, SwarmBuilder, SwarmEvent},
-    PeerId, Swarm,
+    noise,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, yamux, PeerId, Swarm, SwarmBuilder,
 };
 use litep2p::{
     config::ConfigBuilder as Litep2pConfigBuilder,
@@ -43,8 +44,7 @@ use std::time::Duration;
 
 #[derive(NetworkBehaviour)]
 struct Behaviour {
-    keep_alive: keep_alive::Behaviour,
-    kad: kad::Kademlia<kad::store::MemoryStore>,
+    kad: kad::Behaviour<kad::store::MemoryStore>,
     identify: identify::Behaviour,
 }
 
@@ -70,25 +70,35 @@ fn initialize_litep2p() -> (Litep2p, KademliaHandle) {
 
 fn initialize_libp2p() -> Swarm<Behaviour> {
     let local_key = identity::Keypair::generate_ed25519();
-    let local_peer_id = PeerId::from(local_key.public());
 
-    tracing::debug!("Local peer id: {local_peer_id:?}");
+    tracing::debug!("Local peer id: {:?}", local_key.public().to_peer_id());
 
-    let transport = libp2p::tokio_development_transport(local_key.clone()).unwrap();
-    let behaviour = {
-        let config = kad::KademliaConfig::default();
-        let store = kad::store::MemoryStore::new(local_peer_id);
-
-        Behaviour {
-            kad: kad::Kademlia::with_config(local_peer_id, store, config),
-            keep_alive: Default::default(),
-            identify: identify::Behaviour::new(identify::Config::new(
-                "/ipfs/1.0.0".into(),
-                local_key.public(),
-            )),
-        }
-    };
-    let mut swarm = SwarmBuilder::with_tokio_executor(transport, behaviour, local_peer_id).build();
+    let mut swarm = SwarmBuilder::with_existing_identity(local_key)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .unwrap()
+        .with_dns()
+        .unwrap()
+        .with_behaviour(|key| {
+            let local_peer_id = PeerId::from(key.public());
+            let config = kad::Config::default();
+            let store = kad::store::MemoryStore::new(local_peer_id);
+            let mut kad = kad::Behaviour::with_config(local_peer_id, store, config);
+            kad.set_mode(Some(kad::Mode::Server));
+            Behaviour {
+                kad,
+                identify: identify::Behaviour::new(identify::Config::new(
+                    "/ipfs/1.0.0".into(),
+                    key.public(),
+                )),
+            }
+        })
+        .unwrap()
+        .build();
 
     swarm.listen_on("/ip6/::1/tcp/0".parse().unwrap()).unwrap();
 
@@ -141,7 +151,7 @@ async fn find_node() {
     let mut listen_addr = None;
     let peer_id = *libp2p.local_peer_id();
 
-    tracing::error!("local peer id: {peer_id}");
+    tracing::debug!("local peer id: {peer_id}");
 
     loop {
         if let SwarmEvent::NewListenAddr { address, .. } = libp2p.select_next_some().await {
@@ -157,7 +167,7 @@ async fn find_node() {
     });
 
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-    let listen_addr = listen_addr.unwrap().with(Protocol::P2p(peer_id.into()));
+    let listen_addr = listen_addr.unwrap().with(Protocol::P2p(peer_id));
 
     kad_handle
         .add_known_peer(
@@ -213,7 +223,7 @@ async fn put_record() {
                     _ = libp2p.select_next_some() => {}
                     _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
                         let store = libp2p.behaviour_mut().kad.store_mut();
-                        if store.get(&libp2p::kad::record::Key::new(&vec![1, 2, 3, 4])).is_some() && !record_found {
+                        if store.get(&libp2p::kad::RecordKey::new(&vec![1, 2, 3, 4])).is_some() && !record_found {
                             counter_copy.fetch_add(1usize, std::sync::atomic::Ordering::SeqCst);
                             record_found = true;
                         }
@@ -243,7 +253,7 @@ async fn put_record() {
     let mut listen_addr = None;
     let peer_id = *libp2p.local_peer_id();
 
-    tracing::error!("local peer id: {peer_id}");
+    tracing::debug!("local peer id: {peer_id}");
 
     loop {
         if let SwarmEvent::NewListenAddr { address, .. } = libp2p.select_next_some().await {
@@ -261,7 +271,7 @@ async fn put_record() {
                 _ = libp2p.select_next_some() => {}
                 _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
                     let store = libp2p.behaviour_mut().kad.store_mut();
-                    if store.get(&libp2p::kad::record::Key::new(&vec![1, 2, 3, 4])).is_some() && !record_found {
+                    if store.get(&libp2p::kad::RecordKey::new(&vec![1, 2, 3, 4])).is_some() && !record_found {
                         counter_copy.fetch_add(1usize, std::sync::atomic::Ordering::SeqCst);
                         record_found = true;
                     }
@@ -272,7 +282,7 @@ async fn put_record() {
 
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
-    let listen_addr = listen_addr.unwrap().with(Protocol::P2p(peer_id.into()));
+    let listen_addr = listen_addr.unwrap().with(Protocol::P2p(peer_id));
 
     kad_handle
         .add_known_peer(
@@ -325,7 +335,7 @@ async fn get_record() {
                     _ = libp2p.select_next_some() => {}
                     _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
                         let store = libp2p.behaviour_mut().kad.store_mut();
-                        if store.get(&libp2p::kad::record::Key::new(&vec![1, 2, 3, 4])).is_some() && !record_found {
+                        if store.get(&libp2p::kad::RecordKey::new(&vec![1, 2, 3, 4])).is_some() && !record_found {
                             counter_copy.fetch_add(1usize, std::sync::atomic::Ordering::SeqCst);
                             record_found = true;
                         }
@@ -387,7 +397,7 @@ async fn get_record() {
 
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
-    let listen_addr = listen_addr.unwrap().with(Protocol::P2p(peer_id.into()));
+    let listen_addr = listen_addr.unwrap().with(Protocol::P2p(peer_id));
 
     kad_handle
         .add_known_peer(
@@ -476,7 +486,7 @@ async fn libp2p_add_provider_to_litep2p() {
 
     let libp2p_peerid = litep2p::PeerId::from_bytes(&libp2p.local_peer_id().to_bytes()).unwrap();
     let libp2p_public_addr: Multiaddr = "/ip4/1.1.1.1/tcp/10000".parse().unwrap();
-    libp2p.add_external_address(libp2p_public_addr.clone(), AddressScore::Infinite);
+    libp2p.add_external_address(libp2p_public_addr.clone());
 
     let litep2p_peerid = PeerId::from_bytes(&litep2p.local_peer_id().to_bytes()).unwrap();
     let litep2p_address = litep2p.listen_addresses().next().unwrap().clone();
@@ -513,7 +523,7 @@ async fn litep2p_get_providers_from_libp2p() {
 
     let libp2p_peerid = litep2p::PeerId::from_bytes(&libp2p.local_peer_id().to_bytes()).unwrap();
     let libp2p_public_addr: Multiaddr = "/ip4/1.1.1.1/tcp/10000".parse().unwrap();
-    libp2p.add_external_address(libp2p_public_addr.clone(), AddressScore::Infinite);
+    libp2p.add_external_address(libp2p_public_addr.clone());
 
     // Start providing
     let key = vec![1u8, 2u8, 3u8];

--- a/tests/conformance/rust/ping.rs
+++ b/tests/conformance/rust/ping.rs
@@ -21,9 +21,9 @@
 
 use futures::{Stream, StreamExt};
 use libp2p::{
-    identity, ping,
-    swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent},
-    PeerId, Swarm,
+    identity, noise, ping,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, yamux, Swarm, SwarmBuilder,
 };
 use litep2p::{
     config::ConfigBuilder,
@@ -35,7 +35,6 @@ use litep2p::{
 
 #[derive(NetworkBehaviour, Default)]
 struct Behaviour {
-    keep_alive: keep_alive::Behaviour,
     ping: ping::Behaviour,
 }
 
@@ -60,13 +59,22 @@ fn initialize_litep2p() -> (Litep2p, Box<dyn Stream<Item = PingEvent> + Send + U
 
 fn initialize_libp2p() -> Swarm<Behaviour> {
     let local_key = identity::Keypair::generate_ed25519();
-    let local_peer_id = PeerId::from(local_key.public());
 
-    tracing::debug!("Local peer id: {local_peer_id:?}");
+    tracing::debug!("Local peer id: {:?}", local_key.public().to_peer_id());
 
-    let transport = libp2p::tokio_development_transport(local_key).unwrap();
-    let mut swarm =
-        SwarmBuilder::with_tokio_executor(transport, Behaviour::default(), local_peer_id).build();
+    let mut swarm = SwarmBuilder::with_existing_identity(local_key)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .unwrap()
+        .with_dns()
+        .unwrap()
+        .with_behaviour(|_| Behaviour::default())
+        .unwrap()
+        .build();
 
     swarm.listen_on("/ip6/::1/tcp/0".parse().unwrap()).unwrap();
 

--- a/tests/conformance/rust/quic_ping.rs
+++ b/tests/conformance/rust/quic_ping.rs
@@ -19,14 +19,12 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use futures::{future::Either, Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use libp2p::{
-    core::{muxing::StreamMuxerBox, transport::OrTransport},
-    identity, ping,
-    swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent},
-    PeerId, Swarm, Transport,
+    identity, noise, ping,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, yamux, Swarm, SwarmBuilder,
 };
-use libp2p_quic as quic;
 use litep2p::{
     config::ConfigBuilder,
     crypto::ed25519::Keypair,
@@ -37,7 +35,6 @@ use litep2p::{
 
 #[derive(NetworkBehaviour, Default)]
 struct Behaviour {
-    keep_alive: keep_alive::Behaviour,
     ping: ping::Behaviour,
 }
 
@@ -62,22 +59,23 @@ fn initialize_litep2p() -> (Litep2p, Box<dyn Stream<Item = PingEvent> + Send + U
 
 fn initialize_libp2p() -> Swarm<Behaviour> {
     let local_key = identity::Keypair::generate_ed25519();
-    let local_peer_id = PeerId::from(local_key.public());
 
-    tracing::debug!("Local peer id: {local_peer_id:?}");
+    tracing::debug!("Local peer id: {:?}", local_key.public().to_peer_id());
 
-    let tcp_transport = libp2p::tokio_development_transport(local_key.clone()).unwrap();
-
-    let quic_transport = quic::tokio::Transport::new(quic::Config::new(&local_key));
-    let transport = OrTransport::new(quic_transport, tcp_transport)
-        .map(|either_output, _| match either_output {
-            Either::Left((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
-            Either::Right((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
-        })
-        .boxed();
-
-    let mut swarm =
-        SwarmBuilder::with_tokio_executor(transport, Behaviour::default(), local_peer_id).build();
+    let mut swarm = SwarmBuilder::with_existing_identity(local_key)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .unwrap()
+        .with_quic()
+        .with_dns()
+        .unwrap()
+        .with_behaviour(|_| Behaviour::default())
+        .unwrap()
+        .build();
 
     swarm.listen_on("/ip6/::1/tcp/0".parse().unwrap()).unwrap();
     swarm.listen_on("/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap()).unwrap();

--- a/tests/connection/failed_addresses_on_success.rs
+++ b/tests/connection/failed_addresses_on_success.rs
@@ -33,7 +33,6 @@ use litep2p::{
 };
 
 use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
 use std::time::Duration;
 use tokio::net::TcpListener;
 
@@ -72,9 +71,7 @@ async fn failed_addresses_reported_on_successful_connection() {
         let address = Multiaddr::empty()
             .with(Protocol::from(addr.ip()))
             .with(Protocol::Tcp(addr.port()))
-            .with(Protocol::P2p(
-                Multihash::from_bytes(&peer2.to_bytes()).unwrap(),
-            ));
+            .with(Protocol::P2p(peer2.into()));
 
         tracing::info!(index = i, ?address, "created failing listener");
 

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -34,7 +34,6 @@ use litep2p::{error::AddressError, transport::quic::config::Config as QuicConfig
 
 use futures::{Stream, StreamExt};
 use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use tokio::net::TcpListener;
 #[cfg(feature = "quic")]
@@ -210,9 +209,7 @@ async fn dial_failure(transport1: Transport, transport2: Transport, dial_address
     let mut litep2p1 = Litep2p::new(config1).unwrap();
     let mut litep2p2 = Litep2p::new(config2).unwrap();
 
-    let address = dial_address.with(Protocol::P2p(
-        Multihash::from_bytes(&litep2p2.local_peer_id().to_bytes()).unwrap(),
-    ));
+    let address = dial_address.with(Protocol::P2p((*litep2p2.local_peer_id()).into()));
 
     litep2p1.dial_address(address).await.unwrap();
 
@@ -268,9 +265,7 @@ async fn connect_over_dns() {
     let mut new_address = Multiaddr::empty();
     new_address.push(Protocol::Dns("localhost".into()));
     new_address.push(tcp);
-    new_address.push(Protocol::P2p(
-        Multihash::from_bytes(&peer2.to_bytes()).unwrap(),
-    ));
+    new_address.push(Protocol::P2p(peer2.into()));
 
     litep2p1.dial_address(new_address).await.unwrap();
     let (res1, res2) = tokio::join!(litep2p1.next_event(), litep2p2.next_event());
@@ -293,9 +288,7 @@ async fn connection_timeout_tcp() {
     let address = Multiaddr::empty()
         .with(Protocol::from(address.ip()))
         .with(Protocol::Tcp(address.port()))
-        .with(Protocol::P2p(
-            Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-        ));
+        .with(Protocol::P2p(PeerId::random().into()));
 
     connection_timeout(
         Transport::Tcp(TcpConfig {
@@ -317,9 +310,7 @@ async fn connection_timeout_quic() {
         .with(Protocol::from(address.ip()))
         .with(Protocol::Udp(address.port()))
         .with(Protocol::QuicV1)
-        .with(Protocol::P2p(
-            Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-        ));
+        .with(Protocol::P2p(PeerId::random().into()));
 
     connection_timeout(Transport::Quic(Default::default()), address).await;
 }
@@ -334,9 +325,7 @@ async fn connection_timeout_websocket() {
         .with(Protocol::from(address.ip()))
         .with(Protocol::Tcp(address.port()))
         .with(Protocol::Ws(std::borrow::Cow::Owned("/".to_string())))
-        .with(Protocol::P2p(
-            Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-        ));
+        .with(Protocol::P2p(PeerId::random().into()));
 
     connection_timeout(
         Transport::WebSocket(WebSocketConfig {
@@ -474,9 +463,7 @@ async fn attempt_to_dial_using_unsupported_transport_tcp() {
         .with(Protocol::from(std::net::Ipv4Addr::new(127, 0, 0, 1)))
         .with(Protocol::Tcp(8888))
         .with(Protocol::Ws(std::borrow::Cow::Borrowed("/")))
-        .with(Protocol::P2p(
-            Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-        ));
+        .with(Protocol::P2p(PeerId::random().into()));
 
     assert!(std::matches!(
         litep2p.dial_address(address.clone()).await,
@@ -502,9 +489,7 @@ async fn attempt_to_dial_using_unsupported_transport_quic() {
     let address = Multiaddr::empty()
         .with(Protocol::from(std::net::Ipv4Addr::new(127, 0, 0, 1)))
         .with(Protocol::Tcp(8888))
-        .with(Protocol::P2p(
-            Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-        ));
+        .with(Protocol::P2p(PeerId::random().into()));
 
     assert!(std::matches!(
         litep2p.dial_address(address.clone()).await,
@@ -857,9 +842,7 @@ async fn tcp_dns_resolution() {
     let mut new_address = Multiaddr::empty();
     new_address.push(Protocol::Dns("localhost".into()));
     new_address.push(tcp);
-    new_address.push(Protocol::P2p(
-        Multihash::from_bytes(&peer2.to_bytes()).unwrap(),
-    ));
+    new_address.push(Protocol::P2p(peer2.into()));
     litep2p1.dial_address(new_address).await.unwrap();
 
     let mut ping_received1 = false;
@@ -920,9 +903,7 @@ async fn websocket_dns_resolution() {
     new_address.push(Protocol::Dns("localhost".into()));
     new_address.push(tcp);
     new_address.push(Protocol::Ws(std::borrow::Cow::Owned("/".to_string())));
-    new_address.push(Protocol::P2p(
-        Multihash::from_bytes(&peer2.to_bytes()).unwrap(),
-    ));
+    new_address.push(Protocol::P2p(peer2.into()));
     litep2p1.dial_address(new_address).await.unwrap();
 
     let mut ping_received1 = false;
@@ -1231,7 +1212,7 @@ async fn unspecified_listen_address_tcp() {
                         Multiaddr::empty()
                             .with(Protocol::Ip4(record.ip))
                             .with(Protocol::Tcp(ip4_port.unwrap()))
-                            .with(Protocol::P2p(Multihash::from(peer1))),
+                            .with(Protocol::P2p(peer1.into())),
                     )
                 }
                 network_interface::Addr::V6(record) => {
@@ -1246,7 +1227,7 @@ async fn unspecified_listen_address_tcp() {
                         Multiaddr::empty()
                             .with(Protocol::Ip6(record.ip))
                             .with(Protocol::Tcp(ip6_port.unwrap()))
-                            .with(Protocol::P2p(Multihash::from(peer1))),
+                            .with(Protocol::P2p(peer1.into())),
                     )
                 }
             };
@@ -1333,7 +1314,7 @@ async fn unspecified_listen_address_websocket() {
                             .with(Protocol::Ip4(record.ip))
                             .with(Protocol::Tcp(ip4_port.unwrap()))
                             .with(Protocol::Ws(std::borrow::Cow::Owned("/".to_string())))
-                            .with(Protocol::P2p(Multihash::from(peer1))),
+                            .with(Protocol::P2p(peer1.into())),
                     )
                 }
                 network_interface::Addr::V6(record) => {
@@ -1349,7 +1330,7 @@ async fn unspecified_listen_address_websocket() {
                             .with(Protocol::Ip6(record.ip))
                             .with(Protocol::Tcp(ip6_port.unwrap()))
                             .with(Protocol::Ws(std::borrow::Cow::Owned("/".to_string())))
-                            .with(Protocol::P2p(Multihash::from(peer1))),
+                            .with(Protocol::P2p(peer1.into())),
                     )
                 }
             };
@@ -1525,7 +1506,7 @@ async fn check_multi_dial() {
     // Replace the PeerId in the multiaddrs with random PeerId to simulate invalid addresses.
     litep2p_addresses.iter_mut().for_each(|addr| {
         addr.pop();
-        addr.push(Protocol::P2p(Multihash::from(random_peer)));
+        addr.push(Protocol::P2p(random_peer.into()));
     });
 
     let dialed_addresses: HashSet<_> = litep2p_addresses.clone().into_iter().collect();

--- a/tests/connection/protocol_dial_invalid_address.rs
+++ b/tests/connection/protocol_dial_invalid_address.rs
@@ -30,7 +30,6 @@ use litep2p::{
 
 use futures::StreamExt;
 use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
 use tokio::sync::oneshot;
 
 #[derive(Debug)]
@@ -94,9 +93,7 @@ async fn protocol_dial_invalid_dns_address() {
             "address.that.doesnt.exist.hopefully.pls".to_string(),
         )))
         .with(Protocol::Tcp(8888))
-        .with(Protocol::P2p(
-            Multihash::from_bytes(&PeerId::random().to_bytes()).unwrap(),
-        ));
+        .with(Protocol::P2p(PeerId::random().into()));
 
     let (custom_protocol, rx) = CustomProtocol::new(address);
     let custom_protocol = Box::new(custom_protocol);

--- a/tests/protocol/bitswap.rs
+++ b/tests/protocol/bitswap.rs
@@ -29,7 +29,7 @@ use litep2p::{
     types::{cid::Cid, multihash::Code},
     Litep2p,
 };
-use multihash::MultihashDigest;
+use multihash_codetable::MultihashDigest;
 use std::{pin::pin, time::Duration};
 use tracing::debug;
 

--- a/tests/protocol/identify.rs
+++ b/tests/protocol/identify.rs
@@ -199,11 +199,11 @@ async fn identify_not_supported(transport1: Transport, transport2: Transport) {
     while !litep2p1_done || !litep2p2_done {
         tokio::select! {
             event = litep2p1.next_event() => if let Litep2pEvent::ConnectionEstablished { .. } = event.unwrap() {
-                tracing::error!("litep2p1 connection established");
+                tracing::debug!("litep2p1 connection established");
                 litep2p1_done = true;
             },
             event = litep2p2.next_event() => if let Litep2pEvent::ConnectionEstablished { .. } = event.unwrap() {
-                tracing::error!("litep2p2 connection established");
+                tracing::debug!("litep2p2 connection established");
                 litep2p2_done = true;
             }
         }
@@ -215,11 +215,11 @@ async fn identify_not_supported(transport1: Transport, transport2: Transport) {
     while !litep2p1_done || !litep2p2_done {
         tokio::select! {
             event = litep2p1.next_event() => if let Litep2pEvent::ConnectionClosed { .. } = event.unwrap() {
-                tracing::error!("litep2p1 connection closed");
+                tracing::debug!("litep2p1 connection closed");
                 litep2p1_done = true;
             },
             event = litep2p2.next_event() => if let Litep2pEvent::ConnectionClosed { .. } = event.unwrap() {
-                tracing::error!("litep2p2 connection closed");
+                tracing::debug!("litep2p2 connection closed");
                 litep2p2_done = true;
             }
         }

--- a/tests/protocol/notification.rs
+++ b/tests/protocol/notification.rs
@@ -37,7 +37,6 @@ use litep2p::transport::websocket::config::Config as WebSocketConfig;
 use bytes::BytesMut;
 use futures::StreamExt;
 use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
 
 #[cfg(feature = "quic")]
 use std::net::Ipv4Addr;
@@ -3722,7 +3721,7 @@ async fn dial_failure(transport1: Transport, transport2: Transport) {
     let mut litep2p2 = Litep2p::new(config2).unwrap();
 
     let peer2 = *litep2p2.local_peer_id();
-    let known_address = known_address.with(Protocol::P2p(Multihash::from(peer2)));
+    let known_address = known_address.with(Protocol::P2p(peer2.into()));
 
     litep2p1.add_known_address(peer2, vec![known_address].into_iter());
 

--- a/tests/protocol/request_response.rs
+++ b/tests/protocol/request_response.rs
@@ -35,7 +35,6 @@ use litep2p::transport::websocket::config::Config as WebSocketConfig;
 
 use futures::{channel, StreamExt};
 use multiaddr::{Multiaddr, Protocol};
-use multihash::Multihash;
 use tokio::time::sleep;
 
 #[cfg(feature = "quic")]
@@ -2310,19 +2309,19 @@ async fn dial_failure(transport: Transport) {
         Transport::Tcp(_) => Multiaddr::empty()
             .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
             .with(Protocol::Tcp(5))
-            .with(Protocol::P2p(Multihash::from(peer))),
+            .with(Protocol::P2p(peer.into())),
         #[cfg(feature = "quic")]
         Transport::Quic(_) => Multiaddr::empty()
             .with(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
             .with(Protocol::Udp(5))
             .with(Protocol::QuicV1)
-            .with(Protocol::P2p(Multihash::from(peer))),
+            .with(Protocol::P2p(peer.into())),
         #[cfg(feature = "websocket")]
         Transport::WebSocket(_) => Multiaddr::empty()
             .with(Protocol::Ip6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))
             .with(Protocol::Tcp(5))
             .with(Protocol::Ws(std::borrow::Cow::Owned("/".to_string())))
-            .with(Protocol::P2p(Multihash::from(peer))),
+            .with(Protocol::P2p(peer.into())),
     };
 
     let config = add_transport(litep2p_config, transport).build();


### PR DESCRIPTION
  Triggered by the deprecation of https://crates.io/crates/core2 which was
  a transitive dependency pulled in by multihash 0.17 via multihash-codetable 0.1.0.
  Upgrading to multihash-codetable 0.2.1 removes the core2 dependency entirely.

  - multiaddr 0.17 → 0.18.2: Protocol::P2p now carries multiaddr::PeerId
    instead of raw Multihash; updated all call sites to use peer.into()
    via a new From<PeerId> for multiaddr::PeerId bridge impl

  - multihash 0.17 → 0.19.4: Multihash is now generic (Multihash<64>);
    Code and MultihashDigest moved to multihash-codetable 0.2.1; Code::Identity
    removed from codetable so identity peer IDs now use a manual 0x00 constant

  - libp2p 0.51 → 0.56 (dev dep): migrate conformance tests to new fluent
    SwarmBuilder API, remove keep_alive::Behaviour (handled by swarm idle
    timeout in 0.56), rename kad::Kademlia/KademliaConfig/KademliaEvent,
    fix add_external_address signature, force kad::Mode::Server on loopback
    test nodes to avoid silent query discard in client mode

  - cid 0.11.1 → 0.11.2 to drop the core2 dependency