### PR TITLE
feat(webrtc): producer backpressure

### DIFF
--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -62,7 +62,7 @@ const LOG_TARGET: &str = "litep2p::webrtc::connection";
 /// Threshold under which str0m emits Event::ChannelBufferedAmountLow.
 const BACKPRESSURE_THRESHOLD: usize = 16 * (1 << 10); // 16 KB
 
-/// Maximum number of pending message supported per channel.
+/// Maximum number of pending messages supported per channel.
 const MAX_PENDING_PER_CHANNEL: usize = 16;
 
 /// Opening channel context.
@@ -95,7 +95,7 @@ struct SubstreamHandleSet {
     /// Substream handles.
     handles: IndexMap<ChannelId, SubstreamHandle>,
 
-    /// Substream which has pending messages.
+    /// Substreams that have pending messages.
     pending: HashSet<ChannelId>,
 
     /// Waker used to drive the stream when no handle can make progress.
@@ -130,12 +130,12 @@ impl SubstreamHandleSet {
         self.handles.swap_remove(key)
     }
 
-    /// Add a channel to the ones which has pending messages.
+    /// Mark channel as having pending messages.
     pub fn add_pending(&mut self, key: ChannelId) {
         self.pending.insert(key);
     }
 
-    /// Remove the channel from the ones with pending messages.
+    /// Unmark channel as having pending messages.
     pub fn clear_pending(&mut self, key: &ChannelId) {
         if self.pending.remove(key) {
             self.waker.wake();
@@ -396,7 +396,7 @@ impl WebRtcConnection {
                     peer = ?peer,
                     ?channel_id,
                     ?e,
-                     "failed to write multistream-select fallback proposal",
+                    "failed to write message to webrtc channel",
                 );
                 Err(Error::WebRtc(e))
             }
@@ -404,7 +404,7 @@ impl WebRtcConnection {
     }
 
     // Attempt to write all pending messages of the specified ChannelId.
-    // Returns either all messages has been sent or not.
+    // Returns whether all messages have been sent or not.
     fn write_pending(&mut self, channel_id: ChannelId) -> Result<bool, Error> {
         let Some(mut channel) = self.rtc.channel(channel_id) else {
             tracing::trace!(
@@ -432,12 +432,12 @@ impl WebRtcConnection {
             };
 
             let succeeded = Self::channel_write(&mut channel, channel_id, message, self.peer)?;
-
-            match self.pending_messages.get_mut(&channel_id) {
-                Some(messages) if succeeded => {
-                    messages.pop_front();
-                }
-                _ => break Ok(false),
+            if succeeded {
+                self.pending_messages
+                    .get_mut(&channel_id)
+                    .and_then(|messages| messages.pop_front());
+            } else {
+                break Ok(false);
             }
         }
     }

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -38,7 +38,7 @@ use crate::{
     PeerId,
 };
 
-use futures::{Stream, StreamExt};
+use futures::{task::AtomicWaker, Stream, StreamExt};
 use indexmap::IndexMap;
 use str0m::{
     channel::{ChannelConfig, ChannelId},
@@ -94,6 +94,9 @@ struct SubstreamHandleSet {
 
     /// Substream which has pending messages.
     pending: HashSet<ChannelId>,
+
+    /// Waker used to drive the stream when no handle can make progress.
+    waker: AtomicWaker,
 }
 
 impl SubstreamHandleSet {
@@ -103,6 +106,7 @@ impl SubstreamHandleSet {
             index: 0usize,
             handles: IndexMap::new(),
             pending: HashSet::new(),
+            waker: AtomicWaker::new(),
         }
     }
 
@@ -114,6 +118,7 @@ impl SubstreamHandleSet {
     /// Insert new handle to [`SubstreamHandleSet`].
     pub fn insert(&mut self, key: ChannelId, handle: SubstreamHandle) {
         assert!(self.handles.insert(key, handle).is_none());
+        self.waker.wake();
     }
 
     /// Remove handle from [`SubstreamHandleSet`].
@@ -129,7 +134,9 @@ impl SubstreamHandleSet {
 
     /// Remove the channel from the ones with pending messages.
     pub fn clear_pending(&mut self, key: &ChannelId) {
-        self.pending.remove(key);
+        if self.pending.remove(key) {
+            self.waker.wake();
+        }
     }
 }
 
@@ -138,7 +145,10 @@ impl Stream for SubstreamHandleSet {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let len = match self.handles.len() {
-            0 => return Poll::Pending,
+            0 => {
+                self.waker.register(cx.waker());
+                return Poll::Pending;
+            }
             len => len,
         };
         let start_index = self.index;
@@ -159,6 +169,7 @@ impl Stream for SubstreamHandleSet {
             }
 
             if self.index == start_index + len {
+                self.waker.register(cx.waker());
                 break Poll::Pending;
             }
         }

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -242,7 +242,8 @@ pub struct WebRtcConnection {
     /// Pending outbound channels.
     pending_outbound: HashMap<ChannelId, ChannelContext>,
 
-    /// Pending outbound messages, at most one per channel.
+    /// Pending outbound messages,
+    /// at most [`MAX_PENDING_PER_CHANNEL`] per channel.
     pending_messages: HashMap<ChannelId, VecDeque<Vec<u8>>>,
 
     /// Open channels.
@@ -342,7 +343,7 @@ impl WebRtcConnection {
     // Attempt to write a message over the specified channel,
     // save the message as pending if `WebRtcConnection` didn't have
     // enough space.
-    fn write(&mut self, channel_id: ChannelId, message: Vec<u8>) -> Result<bool, Error> {
+    fn write(&mut self, channel_id: ChannelId, message: Vec<u8>) -> Result<(), Error> {
         let Some(mut channel) = self.rtc.channel(channel_id) else {
             tracing::trace!(
                 target: LOG_TARGET,
@@ -360,7 +361,7 @@ impl WebRtcConnection {
                 }
 
                 messages.push_back(message);
-                return Ok(false);
+                return Ok(());
             }
             _ => (),
         }
@@ -375,10 +376,10 @@ impl WebRtcConnection {
 
             pending_messages.push_back(message);
             self.handles.add_pending(channel_id);
-            return Ok(false);
+            return Ok(());
         }
 
-        Ok(true)
+        Ok(())
     }
 
     fn channel_write(
@@ -873,7 +874,7 @@ impl WebRtcConnection {
         );
 
         let message = WebRtcMessage::encode(data, flag);
-        self.write(channel_id, message).map(|_| ())
+        self.write(channel_id, message)
     }
 
     /// Open outbound substream.
@@ -981,6 +982,8 @@ impl WebRtcConnection {
                         continue;
                     }
                     Event::ChannelClose(channel_id) => {
+                        // This event is emitted once the rtc instance
+                        // completes the call to `close_data_channel(channel_id)`.
                         if let Err(error) = self.on_channel_closed(channel_id).await {
                             tracing::debug!(
                                 target: LOG_TARGET,

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -228,7 +228,7 @@ pub struct WebRtcConnection {
     /// Pending outbound channels.
     pending_outbound: HashMap<ChannelId, ChannelContext>,
 
-    /// Pending outboud messages, at most one per channel.
+    /// Pending outbound messages, at most one per channel.
     pending_messages: HashMap<ChannelId, Vec<u8>>,
 
     /// Open channels.
@@ -286,6 +286,10 @@ impl WebRtcConnection {
             "channel opened",
         );
 
+        if let Some(mut channel) = self.rtc.channel(channel_id) {
+            channel.set_buffered_amount_low_threshold(BACKPRESSURE_THRESHOLD);
+        }
+
         let Some(mut context) = self.pending_outbound.remove(&channel_id) else {
             tracing::trace!(
                 target: LOG_TARGET,
@@ -302,10 +306,6 @@ impl WebRtcConnection {
             );
             return Ok(());
         };
-
-        if let Some(mut channel) = self.rtc.channel(channel_id) {
-            channel.set_buffered_amount_low_threshold(BACKPRESSURE_THRESHOLD);
-        }
 
         let fallback_names = std::mem::take(&mut context.fallback_names);
         let (dialer_state, message) =
@@ -326,7 +326,7 @@ impl WebRtcConnection {
     }
 
     // Attempt to write a message over the specified channel,
-    // save the message as pening if `WebRtcConnection` didn't have
+    // save the message as pending if `WebRtcConnection` didn't have
     // enough space.
     fn write(&mut self, channel_id: ChannelId, message: Vec<u8>) -> Result<bool, Error> {
         let Some(mut channel) = self.rtc.channel(channel_id) else {
@@ -367,7 +367,7 @@ impl WebRtcConnection {
     fn write_pending(&mut self, channel_id: ChannelId) -> Result<bool, Error> {
         let Some(message) = self.pending_messages.remove(&channel_id) else {
             // This should never happen, `write_pending` should be called
-            // for only chennel with pending messages. Treat as a no-op
+            // for only the channel with pending messages. Treat as a no-op
             // instead of panicking to stay defensive.
             return Ok(true);
         };

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -303,7 +303,7 @@ impl WebRtcConnection {
             return Ok(());
         };
 
-        if let Some(mut channel) = self.rtc.channel(channel_id.clone()) {
+        if let Some(mut channel) = self.rtc.channel(channel_id) {
             channel.set_buffered_amount_low_threshold(BACKPRESSURE_THRESHOLD);
         }
 
@@ -354,7 +354,7 @@ impl WebRtcConnection {
         };
 
         if !succeeded {
-            self.pending_messages.insert(channel_id.clone(), message);
+            self.pending_messages.insert(channel_id, message);
             self.handles.add_pending(channel_id);
             return Ok(false);
         }
@@ -371,7 +371,7 @@ impl WebRtcConnection {
             // instead of panicking to stay defensive.
             return Ok(true);
         };
-        let succeeded = self.write(channel_id.clone(), message)?;
+        let succeeded = self.write(channel_id, message)?;
         if succeeded {
             self.handles.clear_pending(&channel_id);
         }
@@ -944,8 +944,7 @@ impl WebRtcConnection {
                         continue;
                     }
                     Event::ChannelBufferedAmountLow(_channel_id) => {
-                        let channel_ids: Vec<_> =
-                            self.pending_messages.keys().into_iter().cloned().collect();
+                        let channel_ids: Vec<_> = self.pending_messages.keys().cloned().collect();
                         for channel_id in channel_ids {
                             let _ = self.write_pending(channel_id);
                         }

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -41,14 +41,14 @@ use crate::{
 use futures::{task::AtomicWaker, Stream, StreamExt};
 use indexmap::IndexMap;
 use str0m::{
-    channel::{ChannelConfig, ChannelId},
+    channel::{Channel, ChannelConfig, ChannelId},
     net::{Protocol as Str0mProtocol, Receive},
     Event, IceConnectionState, Input, Output, Rtc,
 };
 use tokio::{net::UdpSocket, sync::mpsc::Receiver};
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     net::SocketAddr,
     pin::Pin,
     sync::Arc,
@@ -61,6 +61,9 @@ const LOG_TARGET: &str = "litep2p::webrtc::connection";
 
 /// Threshold under which str0m emits Event::ChannelBufferedAmountLow.
 const BACKPRESSURE_THRESHOLD: usize = 16 * (1 << 10); // 16 KB
+
+/// Maximum number of pending message supported per channel.
+const MAX_PENDING_PER_CHANNEL: usize = 16;
 
 /// Opening channel context.
 #[derive(Debug)]
@@ -240,7 +243,7 @@ pub struct WebRtcConnection {
     pending_outbound: HashMap<ChannelId, ChannelContext>,
 
     /// Pending outbound messages, at most one per channel.
-    pending_messages: HashMap<ChannelId, Vec<u8>>,
+    pending_messages: HashMap<ChannelId, VecDeque<Vec<u8>>>,
 
     /// Open channels.
     channels: HashMap<ChannelId, ChannelState>,
@@ -350,22 +353,27 @@ impl WebRtcConnection {
             return Err(Error::ChannelDoesntExist);
         };
 
-        let succeeded = match channel.write(true, message.as_ref()) {
-            Ok(succeeded) => succeeded,
-            Err(e) => {
-                tracing::trace!(
-                    target: LOG_TARGET,
-                    peer = ?self.peer,
-                    ?channel_id,
-                    ?e,
-                     "failed to write multistream-select fallback proposal",
-                );
-                return Err(Error::WebRtc(e));
+        match self.pending_messages.get_mut(&channel_id) {
+            Some(messages) if !messages.is_empty() => {
+                if messages.len() >= MAX_PENDING_PER_CHANNEL {
+                    return Err(Error::ChannelClogged);
+                }
+
+                messages.push_back(message);
+                return Ok(false);
             }
-        };
+            _ => (),
+        }
+
+        let succeeded = Self::channel_write(&mut channel, channel_id, &message, self.peer)?;
 
         if !succeeded {
-            self.pending_messages.insert(channel_id, message);
+            let pending_messages = self.pending_messages.entry(channel_id).or_default();
+            if pending_messages.len() >= MAX_PENDING_PER_CHANNEL {
+                return Err(Error::ChannelClogged);
+            }
+
+            pending_messages.push_back(message);
             self.handles.add_pending(channel_id);
             return Ok(false);
         }
@@ -373,20 +381,64 @@ impl WebRtcConnection {
         Ok(true)
     }
 
+    fn channel_write(
+        channel: &mut Channel<'_>,
+        channel_id: ChannelId,
+        message: &[u8],
+        peer: PeerId,
+    ) -> Result<bool, Error> {
+        match channel.write(true, message) {
+            Ok(succeeded) => Ok(succeeded),
+            Err(e) => {
+                tracing::trace!(
+                    target: LOG_TARGET,
+                    peer = ?peer,
+                    ?channel_id,
+                    ?e,
+                     "failed to write multistream-select fallback proposal",
+                );
+                Err(Error::WebRtc(e))
+            }
+        }
+    }
+
     // Attempt to write all pending messages of the specified ChannelId.
     // Returns either all messages has been sent or not.
     fn write_pending(&mut self, channel_id: ChannelId) -> Result<bool, Error> {
-        let Some(message) = self.pending_messages.remove(&channel_id) else {
-            // This should never happen, `write_pending` should be called
-            // for only the channel with pending messages. Treat as a no-op
-            // instead of panicking to stay defensive.
-            return Ok(true);
+        let Some(mut channel) = self.rtc.channel(channel_id) else {
+            tracing::trace!(
+                target: LOG_TARGET,
+                peer = ?self.peer,
+                ?channel_id,
+                "protocol rejected received for non-existing channel",
+            );
+            return Err(Error::ChannelDoesntExist);
         };
-        let succeeded = self.write(channel_id, message)?;
-        if succeeded {
-            self.handles.clear_pending(&channel_id);
+
+        loop {
+            let Some(pending_messages) = self.pending_messages.get_mut(&channel_id) else {
+                // This should never happen, `write_pending` should be called
+                // for only the channel with pending messages. Treat as a no-op
+                // instead of panicking to stay defensive.
+                self.handles.clear_pending(&channel_id);
+                return Ok(true);
+            };
+
+            let Some(message) = pending_messages.front() else {
+                self.pending_messages.remove(&channel_id);
+                self.handles.clear_pending(&channel_id);
+                break Ok(true);
+            };
+
+            let succeeded = Self::channel_write(&mut channel, channel_id, message, self.peer)?;
+
+            match self.pending_messages.get_mut(&channel_id) {
+                Some(messages) if succeeded => {
+                    messages.pop_front();
+                }
+                _ => break Ok(false),
+            }
         }
-        Ok(succeeded)
     }
 
     /// Handle closed channel.
@@ -1027,6 +1079,9 @@ impl WebRtcConnection {
                                 ?error,
                                 "failed to send data to remote peer",
                             );
+
+                            self.channels.insert(channel_id, ChannelState::Closing);
+                            self.rtc.direct_api().close_data_channel(channel_id);
                         }
                     }
                     Some((_, Some(SubstreamEvent::RecvClosed))) => {}

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -48,7 +48,7 @@ use str0m::{
 use tokio::{net::UdpSocket, sync::mpsc::Receiver};
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     net::SocketAddr,
     pin::Pin,
     sync::Arc,
@@ -58,6 +58,9 @@ use std::{
 
 /// Logging target for the file.
 const LOG_TARGET: &str = "litep2p::webrtc::connection";
+
+/// Threshold under which str0m emits Event::ChannelBufferedAmountLow.
+const BACKPRESSURE_THRESHOLD: usize = 16 * (1 << 10); // 16 KB
 
 /// Opening channel context.
 #[derive(Debug)]
@@ -88,6 +91,9 @@ struct SubstreamHandleSet {
 
     /// Substream handles.
     handles: IndexMap<ChannelId, SubstreamHandle>,
+
+    /// Substream which has pending messages.
+    pending: HashSet<ChannelId>,
 }
 
 impl SubstreamHandleSet {
@@ -96,6 +102,7 @@ impl SubstreamHandleSet {
         Self {
             index: 0usize,
             handles: IndexMap::new(),
+            pending: HashSet::new(),
         }
     }
 
@@ -111,7 +118,18 @@ impl SubstreamHandleSet {
 
     /// Remove handle from [`SubstreamHandleSet`].
     pub fn remove(&mut self, key: &ChannelId) -> Option<SubstreamHandle> {
-        self.handles.shift_remove(key)
+        self.pending.remove(key);
+        self.handles.swap_remove(key)
+    }
+
+    /// Add a channel to the ones which has pending messages.
+    pub fn add_pending(&mut self, key: ChannelId) {
+        self.pending.insert(key);
+    }
+
+    /// Remove the channel from the ones with pending messages.
+    pub fn clear_pending(&mut self, key: &ChannelId) {
+        self.pending.remove(key);
     }
 }
 
@@ -129,10 +147,15 @@ impl Stream for SubstreamHandleSet {
             let index = self.index % len;
             self.index += 1;
 
-            let (key, stream) = self.handles.get_index_mut(index).expect("handle to exist");
-            match stream.poll_next_unpin(cx) {
-                Poll::Pending => {}
-                Poll::Ready(event) => return Poll::Ready(Some((*key, event))),
+            let key =
+                self.handles.get_index(index).map(|(k, _)| k).cloned().expect("handle to exist");
+
+            if !self.pending.contains(&key) {
+                let (key, stream) = self.handles.get_index_mut(index).expect("handle to exist");
+                match stream.poll_next_unpin(cx) {
+                    Poll::Pending => {}
+                    Poll::Ready(event) => return Poll::Ready(Some((*key, event))),
+                }
             }
 
             if self.index == start_index + len {
@@ -205,6 +228,9 @@ pub struct WebRtcConnection {
     /// Pending outbound channels.
     pending_outbound: HashMap<ChannelId, ChannelContext>,
 
+    /// Pending outboud messages, at most one per channel.
+    pending_messages: HashMap<ChannelId, Vec<u8>>,
+
     /// Open channels.
     channels: HashMap<ChannelId, ChannelState>,
 
@@ -234,6 +260,7 @@ impl WebRtcConnection {
             endpoint,
             dgram_rx,
             pending_outbound: HashMap::new(),
+            pending_messages: HashMap::new(),
             channels: HashMap::new(),
             handles: SubstreamHandleSet::new(),
         }
@@ -276,16 +303,16 @@ impl WebRtcConnection {
             return Ok(());
         };
 
+        if let Some(mut channel) = self.rtc.channel(channel_id.clone()) {
+            channel.set_buffered_amount_low_threshold(BACKPRESSURE_THRESHOLD);
+        }
+
         let fallback_names = std::mem::take(&mut context.fallback_names);
         let (dialer_state, message) =
             WebRtcDialerState::propose(context.protocol.clone(), fallback_names)?;
         let message = WebRtcMessage::encode(message, None);
 
-        self.rtc
-            .channel(channel_id)
-            .ok_or(Error::ChannelDoesntExist)?
-            .write(true, message.as_ref())
-            .map_err(Error::WebRtc)?;
+        self.write(channel_id, message)?;
 
         self.channels.insert(
             channel_id,
@@ -296,6 +323,59 @@ impl WebRtcConnection {
         );
 
         Ok(())
+    }
+
+    // Attempt to write a message over the specified channel,
+    // save the message as pening if `WebRtcConnection` didn't have
+    // enough space.
+    fn write(&mut self, channel_id: ChannelId, message: Vec<u8>) -> Result<bool, Error> {
+        let Some(mut channel) = self.rtc.channel(channel_id) else {
+            tracing::trace!(
+                target: LOG_TARGET,
+                peer = ?self.peer,
+                ?channel_id,
+                "protocol rejected received for non-existing channel",
+            );
+            return Err(Error::ChannelDoesntExist);
+        };
+
+        let succeeded = match channel.write(true, message.as_ref()) {
+            Ok(succeeded) => succeeded,
+            Err(e) => {
+                tracing::trace!(
+                    target: LOG_TARGET,
+                    peer = ?self.peer,
+                    ?channel_id,
+                    ?e,
+                     "failed to write multistream-select fallback proposal",
+                );
+                return Err(Error::WebRtc(e));
+            }
+        };
+
+        if !succeeded {
+            self.pending_messages.insert(channel_id.clone(), message);
+            self.handles.add_pending(channel_id);
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
+    // Attempt to write all pending messages of the specified ChannelId.
+    // Returns either all messages has been sent or not.
+    fn write_pending(&mut self, channel_id: ChannelId) -> Result<bool, Error> {
+        let Some(message) = self.pending_messages.remove(&channel_id) else {
+            // This should never happen, `write_pending` should be called
+            // for only chennel with pending messages. Treat as a no-op
+            // instead of panicking to stay defensive.
+            return Ok(true);
+        };
+        let succeeded = self.write(channel_id.clone(), message)?;
+        if succeeded {
+            self.handles.clear_pending(&channel_id);
+        }
+        Ok(succeeded)
     }
 
     /// Handle closed channel.
@@ -309,6 +389,7 @@ impl WebRtcConnection {
 
         self.pending_outbound.remove(&channel_id);
         self.channels.remove(&channel_id);
+        self.pending_messages.remove(&channel_id);
         self.handles.remove(&channel_id);
 
         Ok(())
@@ -351,14 +432,8 @@ impl WebRtcConnection {
                 | ListenerSelectResult::PendingProtocol { message } => (message, None),
             };
 
-        self.rtc
-            .channel(channel_id)
-            .ok_or(Error::ChannelDoesntExist)?
-            .write(
-                true,
-                WebRtcMessage::encode(response.to_vec(), None).as_ref(),
-            )
-            .map_err(Error::WebRtc)?;
+        let message = WebRtcMessage::encode(response.to_vec(), None);
+        self.write(channel_id, message)?;
 
         let Some(protocol) = negotiated else {
             tracing::trace!(
@@ -468,30 +543,9 @@ impl WebRtcConnection {
 
                     let message = WebRtcMessage::encode(message, None);
 
-                    let Some(mut channel) = self.rtc.channel(channel_id) else {
-                        tracing::trace!(
-                            target: LOG_TARGET,
-                            peer = ?self.peer,
-                            ?channel_id,
-                            "protocol rejected received for non-existing channel",
-                        );
-                        return Err(SubstreamError::NegotiationError(
-                            NegotiationError::Failed.into(),
-                        ));
-                    };
-
-                    if let Err(err) = channel.write(true, message.as_ref()) {
-                        tracing::trace!(
-                            target: LOG_TARGET,
-                            peer = ?self.peer,
-                            ?channel_id,
-                            ?err,
-                             "failed to write multistream-select fallback proposal",
-                        );
-                        return Err(SubstreamError::NegotiationError(
-                            NegotiationError::Failed.into(),
-                        ));
-                    };
+                    self.write(channel_id, message).map_err(|_| {
+                        SubstreamError::NegotiationError(NegotiationError::Failed.into())
+                    })?;
 
                     self.channels.insert(
                         channel_id,
@@ -755,12 +809,8 @@ impl WebRtcConnection {
             "send data",
         );
 
-        self.rtc
-            .channel(channel_id)
-            .ok_or(Error::ChannelDoesntExist)?
-            .write(true, WebRtcMessage::encode(data, flag).as_ref())
-            .map_err(Error::WebRtc)
-            .map(|_| ())
+        let message = WebRtcMessage::encode(data, flag);
+        self.write(channel_id, message).map(|_| ())
     }
 
     /// Open outbound substream.
@@ -891,6 +941,14 @@ impl WebRtcConnection {
                             );
                         }
 
+                        continue;
+                    }
+                    Event::ChannelBufferedAmountLow(_channel_id) => {
+                        let channel_ids: Vec<_> =
+                            self.pending_messages.keys().into_iter().cloned().collect();
+                        for channel_id in channel_ids {
+                            let _ = self.write_pending(channel_id);
+                        }
                         continue;
                     }
                     event => {

--- a/src/transport/webrtc/opening.rs
+++ b/src/transport/webrtc/opening.rs
@@ -209,11 +209,21 @@ impl OpeningWebRtcConnection {
         // create first noise handshake and send it to remote peer
         let payload = WebRtcMessage::encode(context.first_message(Role::Dialer)?, None);
 
-        self.rtc
+        let succeeded = self
+            .rtc
             .channel(self.noise_channel_id)
             .ok_or(Error::ChannelDoesntExist)?
             .write(true, payload.as_slice())
             .map_err(Error::WebRtc)?;
+
+        if !succeeded {
+            tracing::error!(
+                target: LOG_TARGET,
+                connection_id = ?self.connection_id,
+                "noise channel full during initial handshake write"
+            );
+            return Err(Error::ChannelClogged);
+        }
 
         self.state = State::HandshakeSent { context };
         Ok(())
@@ -305,9 +315,18 @@ impl OpeningWebRtcConnection {
         let mut channel =
             self.rtc.channel(self.noise_channel_id).ok_or(Error::ChannelDoesntExist)?;
 
-        channel.write(true, payload.as_slice()).map_err(Error::WebRtc)?;
-        self.rtc.direct_api().close_data_channel(self.noise_channel_id);
+        let succeeded = channel.write(true, payload.as_slice()).map_err(Error::WebRtc)?;
 
+        if !succeeded {
+            tracing::error!(
+                target: LOG_TARGET,
+                connection_id = ?self.connection_id,
+                "noise channel full during initial handshake write"
+            );
+            return Err(Error::ChannelClogged);
+        }
+
+        self.rtc.direct_api().close_data_channel(self.noise_channel_id);
         Ok(self.rtc)
     }
 

--- a/src/transport/webrtc/opening.rs
+++ b/src/transport/webrtc/opening.rs
@@ -220,7 +220,7 @@ impl OpeningWebRtcConnection {
             tracing::error!(
                 target: LOG_TARGET,
                 connection_id = ?self.connection_id,
-                "noise channel full during initial handshake write"
+                "sending first noise handshake message failed: channel full"
             );
             return Err(Error::ChannelClogged);
         }
@@ -321,7 +321,7 @@ impl OpeningWebRtcConnection {
             tracing::error!(
                 target: LOG_TARGET,
                 connection_id = ?self.connection_id,
-                "noise channel full during initial handshake write"
+                "sending second noise handshake message failed: channel full"
             );
             return Err(Error::ChannelClogged);
         }


### PR DESCRIPTION
Sctp data channels have a limit over the amount of messages that can be saved within its internal buffer before sending them. Writes fail if there is no more space, messages needs to be saved as pending and sent again as soon as there is avaiable space.