### PR TITLE
  deps: quinn 0.11 + rustls 0.23 + hickory-resolver 0.26 (closes #308)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,13 +294,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -545,7 +556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1059,6 +1070,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto 0.26.1",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1120,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring 0.17.14",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,7 +1147,7 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
@@ -1100,6 +1155,32 @@ dependencies = [
  "rand 0.9.4",
  "resolv-conf",
  "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1420,6 +1501,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "itertools"
@@ -1435,6 +1519,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "js-sys"
@@ -1553,7 +1686,7 @@ checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "libp2p-core",
  "libp2p-identity",
  "parking_lot",
@@ -1634,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
 dependencies = [
  "futures",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
@@ -1870,7 +2003,7 @@ dependencies = [
  "futures-timer",
  "futures_ringbuf",
  "hex-literal",
- "hickory-resolver",
+ "hickory-resolver 0.26.1",
  "indexmap",
  "ip_network",
  "libc",
@@ -2121,6 +2254,12 @@ dependencies = [
  "smallvec",
  "unsigned-varint 0.7.2",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netlink-packet-core"
@@ -2538,6 +2677,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,6 +2998,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -3142,6 +3293,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,6 +3498,22 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-dns"
@@ -3990,6 +4166,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,6 +4356,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -319,13 +328,12 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
 dependencies = [
  "multibase",
  "multihash",
- "no_std_io2",
  "serde",
  "serde_bytes",
  "unsigned-varint 0.8.0",
@@ -437,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "critical-section"
@@ -535,15 +543,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -551,12 +559,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -605,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "crypto-common 0.2.1",
@@ -890,7 +898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
 ]
 
@@ -1004,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1032,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1110,7 +1118,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand 0.9.4",
- "ring 0.17.14",
+ "ring",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1132,7 +1140,7 @@ dependencies = [
  "once_cell",
  "prefix-trie",
  "rand 0.10.1",
- "ring 0.17.14",
+ "ring",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
@@ -1245,9 +1253,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1394,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1463,7 +1471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1571,10 +1579,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1593,9 +1603,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libp2p"
@@ -1848,10 +1858,10 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
- "quinn 0.11.9",
+ "quinn",
  "rand 0.8.6",
- "ring 0.17.14",
- "rustls 0.23.38",
+ "ring",
+ "rustls",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
@@ -1918,12 +1928,12 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "rcgen 0.13.2",
- "ring 0.17.14",
- "rustls 0.23.38",
+ "ring",
+ "rustls",
  "rustls-webpki",
  "thiserror 2.0.18",
  "x509-parser 0.17.0",
- "yasna",
+ "yasna 0.5.2",
 ]
 
 [[package]]
@@ -2018,11 +2028,12 @@ dependencies = [
  "prost 0.13.5",
  "prost-build",
  "quickcheck",
- "quinn 0.9.4",
+ "quinn",
  "rand 0.8.6",
- "rcgen 0.14.7",
- "ring 0.17.14",
- "rustls 0.20.9",
+ "rcgen 0.14.8",
+ "ring",
+ "rustls",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_millis",
@@ -2042,11 +2053,10 @@ dependencies = [
  "uint",
  "unsigned-varint 0.8.0",
  "url",
- "webpki",
  "x25519-dalek",
  "x509-parser 0.17.0",
  "yamux 0.13.10",
- "yasna",
+ "yasna 0.5.2",
  "zeroize",
 ]
 
@@ -2190,43 +2200,40 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "no_std_io2",
  "serde",
  "unsigned-varint 0.8.0",
 ]
 
 [[package]]
 name = "multihash-codetable"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "facfe64780489b29aae20d32d0245219f4a8167f91193f7061589f5dae9ba307"
+checksum = "60384411b100398c5b2fdca476eed82e9898d09f2c60d1b1b66c5080ebe06118"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
  "multihash-derive",
- "no_std_io2",
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0576e09c49157d1910e522e595d2b32749b029dd0bc10ff6967d588490c30348"
+checksum = "4723acdce756db211a53f01b3419dbdf63cb48cef5df86260f55309364735fbf"
 dependencies = [
  "multihash",
  "multihash-derive-impl",
- "no_std_io2",
 ]
 
 [[package]]
 name = "multihash-derive-impl"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3dc7141bd06405929948754f0628d247f5ca1865be745099205e5086da957cb"
+checksum = "f932556f78452e5604cef711349d337ec081a9aa3c96e67b3127c8f5df05d550"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2331,15 +2338,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2543,18 +2541,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2847,24 +2845,6 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8b432585672228923edbbf64b8b12c14e1112f62e88737655b4a083dbcd78e"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto 0.9.6",
- "quinn-udp 0.3.2",
- "rustc-hash 1.1.0",
- "rustls 0.20.9",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "webpki",
-]
-
-[[package]]
-name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
@@ -2873,33 +2853,15 @@ dependencies = [
  "cfg_aliases",
  "futures-io",
  "pin-project-lite",
- "quinn-proto 0.11.14",
- "quinn-udp 0.5.14",
- "rustc-hash 2.1.2",
- "rustls 0.23.38",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
-dependencies = [
- "bytes",
- "rand 0.8.6",
- "ring 0.16.20",
- "rustc-hash 1.1.0",
- "rustls 0.20.9",
- "slab",
- "thiserror 1.0.69",
- "tinyvec",
- "tracing",
- "webpki",
 ]
 
 [[package]]
@@ -2912,28 +2874,15 @@ dependencies = [
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
- "ring 0.17.14",
- "rustc-hash 2.1.2",
- "rustls 0.23.38",
+ "ring",
+ "rustc-hash",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
-dependencies = [
- "libc",
- "quinn-proto 0.9.6",
- "socket2 0.4.10",
- "tracing",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3054,24 +3003,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
  "pem",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "time",
- "yasna",
+ "yasna 0.5.2",
 ]
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "time",
  "x509-parser 0.18.1",
- "yasna",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -3120,21 +3069,6 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -3143,7 +3077,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3173,12 +3107,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -3219,23 +3147,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3256,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3266,13 +3183,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -3317,16 +3234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "sctp-proto"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3336,7 +3243,7 @@ dependencies = [
  "crc",
  "log",
  "rand 0.9.4",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "slab",
  "thiserror 2.0.18",
 ]
@@ -3472,7 +3379,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3547,20 +3454,10 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "ring 0.17.14",
+ "ring",
  "rustc_version",
  "sha2 0.10.9",
  "subtle",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3597,12 +3494,6 @@ dependencies = [
  "rand 0.8.6",
  "sha1",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -3838,9 +3729,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3869,7 +3760,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls",
  "tokio",
 ]
 
@@ -3892,7 +3783,7 @@ checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.38",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -4030,7 +3921,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -4099,12 +3990,6 @@ dependencies = [
  "bytes",
  "tokio-util",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -4210,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4223,9 +4108,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4233,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4246,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4288,16 +4173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4305,16 +4180,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4486,21 +4351,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4570,12 +4420,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4588,12 +4432,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4603,12 +4441,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4636,12 +4468,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4651,12 +4477,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4672,12 +4492,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4687,12 +4501,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4708,9 +4516,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -4856,7 +4664,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
- "ring 0.17.14",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
@@ -4918,6 +4726,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4962,9 +4780,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tokio = { version = "1.45.0", features = [
     "parking_lot",
 ] }
 tracing = { version = "0.1.40", features = ["log"] }
-hickory-resolver = "0.25.2"
+hickory-resolver = "0.26"
 uint = "0.10.0"
 unsigned-varint = { version = "0.8.0", features = ["codec"] }
 url = "2.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,15 +74,21 @@ tokio-tungstenite = { version = "0.27.0", features = [
 # End of websocket related dependencies.
 
 # Quic related dependencies. Quic is an experimental feature flag. The dependencies must be updated.
-quinn = { version = "0.9.3", default-features = false, features = [
-    "tls-rustls",
+quinn = { version = "0.11", default-features = false, features = [
+    "rustls-ring",
     "runtime-tokio",
+    "log",
 ], optional = true }
-rustls = { version = "0.20.7", default-features = false, features = [
-    "dangerous_configuration",
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "std",
+    # `tls12` deliberately omitted: libp2p TLS is TLS 1.3-only.
+], optional = true }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+    "std",
+    "ring",
 ], optional = true }
 ring = { version = "0.17.14", optional = true }
-webpki = { version = "0.22.4", optional = true }
 rcgen = { version = "0.14.5", optional = true }
 # End of Quic related dependencies.
 
@@ -131,7 +137,7 @@ fuzz = [
 
 # Unstable / experimental feature flags. These features are not guaranteed to be stable and may change in the future.
 # They are not yet suitable for production use-cases and should be used with caution.
-quic = ["dep:webpki", "dep:quinn", "dep:rustls", "dep:ring", "dep:rcgen"]
+quic = ["dep:quinn", "dep:rustls", "dep:rustls-webpki", "dep:ring", "dep:rcgen"]
 webrtc = ["dep:str0m"]
 rsa = ["dep:ring"]
 

--- a/src/crypto/tls/certificate.rs
+++ b/src/crypto/tls/certificate.rs
@@ -27,9 +27,55 @@ use crate::{
     PeerId,
 };
 
+use std::sync::Arc;
+
 // use libp2p_identity as identity;
 // use libp2p_identity::PeerId;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use x509_parser::{prelude::*, signature_algorithm::SignatureAlgorithm};
+
+/// Custom `ResolvesServerCert` / `ResolvesClientCert` so the libp2p
+/// certificate (which carries a critical custom X.509 extension) bypasses
+/// rustls's `with_single_cert` validation path — that path rejects unknown
+/// critical extensions.
+#[derive(Debug)]
+pub(crate) struct AlwaysResolvesCert(Arc<rustls::sign::CertifiedKey>);
+
+impl AlwaysResolvesCert {
+    pub(crate) fn new(
+        cert: CertificateDer<'static>,
+        key: &PrivateKeyDer<'_>,
+    ) -> Result<Self, rustls::Error> {
+        let certified_key = rustls::sign::CertifiedKey::new(
+            vec![cert],
+            rustls::crypto::ring::sign::any_ecdsa_type(key)?,
+        );
+        Ok(Self(Arc::new(certified_key)))
+    }
+}
+
+impl rustls::client::ResolvesClientCert for AlwaysResolvesCert {
+    fn resolve(
+        &self,
+        _root_hint_subjects: &[&[u8]],
+        _sigschemes: &[rustls::SignatureScheme],
+    ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+        Some(Arc::clone(&self.0))
+    }
+
+    fn has_certs(&self) -> bool {
+        true
+    }
+}
+
+impl rustls::server::ResolvesServerCert for AlwaysResolvesCert {
+    fn resolve(
+        &self,
+        _client_hello: rustls::server::ClientHello<'_>,
+    ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+        Some(Arc::clone(&self.0))
+    }
+}
 
 /// The libp2p Public Key Extension is a X.509 extension
 /// with the Object Identier 1.3.6.1.4.1.53594.1.1,
@@ -51,14 +97,15 @@ static P2P_SIGNATURE_ALGORITHM: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_
 /// certificate extension containing the public key of the given keypair.
 pub fn generate(
     identity_keypair: &Keypair,
-) -> Result<(rustls::Certificate, rustls::PrivateKey), GenError> {
+) -> Result<(CertificateDer<'static>, PrivateKeyDer<'static>), GenError> {
     // Keypair used to sign the certificate.
     // SHOULD NOT be related to the host's key.
     // Endpoints MAY generate a new key and certificate
     // for every connection attempt, or they MAY reuse the same key
     // and certificate for multiple connections.
     let certificate_keypair = rcgen::KeyPair::generate_for(P2P_SIGNATURE_ALGORITHM)?;
-    let rustls_key = rustls::PrivateKey(certificate_keypair.serialize_der());
+    let rustls_key: PrivateKeyDer<'static> =
+        PrivatePkcs8KeyDer::from(certificate_keypair.serialize_der()).into();
 
     let certificate = {
         let mut params = rcgen::CertificateParams::new(vec![])?;
@@ -70,7 +117,7 @@ pub fn generate(
         params.self_signed(&certificate_keypair)?
     };
 
-    let rustls_certificate = rustls::Certificate(certificate.der().to_vec());
+    let rustls_certificate = CertificateDer::from(certificate.der().to_vec());
 
     Ok((rustls_certificate, rustls_key))
 }
@@ -79,7 +126,7 @@ pub fn generate(
 ///
 /// For this to succeed, the certificate must contain the specified extension and the signature must
 /// match the embedded public key.
-pub fn parse(certificate: &rustls::Certificate) -> Result<P2pCertificate<'_>, ParseError> {
+pub fn parse<'a>(certificate: &'a CertificateDer<'a>) -> Result<P2pCertificate<'a>, ParseError> {
     let certificate = parse_unverified(certificate.as_ref())?;
 
     certificate.verify()?;
@@ -292,6 +339,8 @@ impl P2pCertificate<'_> {
             RSA_PKCS1_SHA1 => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
             ECDSA_SHA1_Legacy => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
             Unknown(_) => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
+            // `SignatureScheme` is `#[non_exhaustive]`.
+            _ => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
         };
         let spki = &self.certificate.tbs_certificate.subject_pki;
         let key = signature::UnparsedPublicKey::new(
@@ -487,7 +536,7 @@ mod tests {
 
     #[test]
     fn rsa_pss_sha384() {
-        let cert = rustls::Certificate(include_bytes!("./test_assets/rsa_pss_sha384.der").to_vec());
+        let cert = CertificateDer::from(include_bytes!("./test_assets/rsa_pss_sha384.der").to_vec());
 
         let cert = parse(&cert).unwrap();
 
@@ -508,7 +557,7 @@ mod tests {
 
     #[test]
     fn can_parse_certificate_with_ed25519_keypair() {
-        let certificate = rustls::Certificate(hex!("308201773082011ea003020102020900f5bd0debaa597f52300a06082a8648ce3d04030230003020170d3735303130313030303030305a180f34303936303130313030303030305a30003059301306072a8648ce3d020106082a8648ce3d030107034200046bf9871220d71dcb3483ecdfcbfcc7c103f8509d0974b3c18ab1f1be1302d643103a08f7a7722c1b247ba3876fe2c59e26526f479d7718a85202ddbe47562358a37f307d307b060a2b0601040183a25a01010101ff046a30680424080112207fda21856709c5ae12fd6e8450623f15f11955d384212b89f56e7e136d2e17280440aaa6bffabe91b6f30c35e3aa4f94b1188fed96b0ffdd393f4c58c1c047854120e674ce64c788406d1c2c4b116581fd7411b309881c3c7f20b46e54c7e6fe7f0f300a06082a8648ce3d040302034700304402207d1a1dbd2bda235ff2ec87daf006f9b04ba076a5a5530180cd9c2e8f6399e09d0220458527178c7e77024601dbb1b256593e9b96d961b96349d1f560114f61a87595").to_vec());
+        let certificate = CertificateDer::from(hex!("308201773082011ea003020102020900f5bd0debaa597f52300a06082a8648ce3d04030230003020170d3735303130313030303030305a180f34303936303130313030303030305a30003059301306072a8648ce3d020106082a8648ce3d030107034200046bf9871220d71dcb3483ecdfcbfcc7c103f8509d0974b3c18ab1f1be1302d643103a08f7a7722c1b247ba3876fe2c59e26526f479d7718a85202ddbe47562358a37f307d307b060a2b0601040183a25a01010101ff046a30680424080112207fda21856709c5ae12fd6e8450623f15f11955d384212b89f56e7e136d2e17280440aaa6bffabe91b6f30c35e3aa4f94b1188fed96b0ffdd393f4c58c1c047854120e674ce64c788406d1c2c4b116581fd7411b309881c3c7f20b46e54c7e6fe7f0f300a06082a8648ce3d040302034700304402207d1a1dbd2bda235ff2ec87daf006f9b04ba076a5a5530180cd9c2e8f6399e09d0220458527178c7e77024601dbb1b256593e9b96d961b96349d1f560114f61a87595").to_vec());
 
         let peer_id = parse(&certificate).unwrap().peer_id();
 
@@ -522,7 +571,7 @@ mod tests {
 
     #[test]
     fn fails_to_parse_bad_certificate_with_ed25519_keypair() {
-        let certificate = rustls::Certificate(hex!("308201773082011da003020102020830a73c5d896a1109300a06082a8648ce3d04030230003020170d3735303130313030303030305a180f34303936303130313030303030305a30003059301306072a8648ce3d020106082a8648ce3d03010703420004bbe62df9a7c1c46b7f1f21d556deec5382a36df146fb29c7f1240e60d7d5328570e3b71d99602b77a65c9b3655f62837f8d66b59f1763b8c9beba3be07778043a37f307d307b060a2b0601040183a25a01010101ff046a3068042408011220ec8094573afb9728088860864f7bcea2d4fd412fef09a8e2d24d482377c20db60440ecabae8354afa2f0af4b8d2ad871e865cb5a7c0c8d3dbdbf42de577f92461a0ebb0a28703e33581af7d2a4f2270fc37aec6261fcc95f8af08f3f4806581c730a300a06082a8648ce3d040302034800304502202dfb17a6fa0f94ee0e2e6a3b9fb6e986f311dee27392058016464bd130930a61022100ba4b937a11c8d3172b81e7cd04aedb79b978c4379c2b5b24d565dd5d67d3cb3c").to_vec());
+        let certificate = CertificateDer::from(hex!("308201773082011da003020102020830a73c5d896a1109300a06082a8648ce3d04030230003020170d3735303130313030303030305a180f34303936303130313030303030305a30003059301306072a8648ce3d020106082a8648ce3d03010703420004bbe62df9a7c1c46b7f1f21d556deec5382a36df146fb29c7f1240e60d7d5328570e3b71d99602b77a65c9b3655f62837f8d66b59f1763b8c9beba3be07778043a37f307d307b060a2b0601040183a25a01010101ff046a3068042408011220ec8094573afb9728088860864f7bcea2d4fd412fef09a8e2d24d482377c20db60440ecabae8354afa2f0af4b8d2ad871e865cb5a7c0c8d3dbdbf42de577f92461a0ebb0a28703e33581af7d2a4f2270fc37aec6261fcc95f8af08f3f4806581c730a300a06082a8648ce3d040302034800304502202dfb17a6fa0f94ee0e2e6a3b9fb6e986f311dee27392058016464bd130930a61022100ba4b937a11c8d3172b81e7cd04aedb79b978c4379c2b5b24d565dd5d67d3cb3c").to_vec());
 
         match parse(&certificate) {
             Ok(_) => unreachable!(),

--- a/src/crypto/tls/mod.rs
+++ b/src/crypto/tls/mod.rs
@@ -34,20 +34,38 @@ mod verifier;
 
 const P2P_ALPN: [u8; 6] = *b"libp2p";
 
+/// `CryptoProvider` narrowed to the libp2p TLS 1.3 cipher-suite and kx-group set.
+///
+/// `kx_groups` is pinned rather than inherited from the ring default so that a
+/// future ring release can't silently widen the negotiation surface.
+fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    use rustls::crypto::ring::kx_group;
+
+    let mut provider = rustls::crypto::ring::default_provider();
+    provider.cipher_suites = verifier::CIPHERSUITES.to_vec();
+    provider.kx_groups = vec![kx_group::X25519, kx_group::SECP256R1, kx_group::SECP384R1];
+    Arc::new(provider)
+}
+
 /// Create a TLS server configuration for litep2p.
 pub fn make_server_config(
     keypair: &Keypair,
 ) -> Result<rustls::ServerConfig, certificate::GenError> {
     let (certificate, private_key) = certificate::generate(keypair)?;
 
-    let mut crypto = rustls::ServerConfig::builder()
-        .with_cipher_suites(verifier::CIPHERSUITES)
-        .with_safe_default_kx_groups()
+    // Custom `ResolvesServerCert` bypasses `with_single_cert`'s validation
+    // path; rustls 0.23 rejects our libp2p extension as an unsupported
+    // critical X.509 extension if it goes through the standard path.
+    let cert_resolver = Arc::new(
+        certificate::AlwaysResolvesCert::new(certificate, &private_key)
+            .expect("Server cert key DER is valid; qed"),
+    );
+
+    let mut crypto = rustls::ServerConfig::builder_with_provider(crypto_provider())
         .with_protocol_versions(verifier::PROTOCOL_VERSIONS)
         .expect("Cipher suites and kx groups are configured; qed")
         .with_client_cert_verifier(Arc::new(verifier::Libp2pCertificateVerifier::new()))
-        .with_single_cert(vec![certificate], private_key)
-        .expect("Server cert key DER is valid; qed");
+        .with_cert_resolver(cert_resolver);
     crypto.alpn_protocols = vec![P2P_ALPN.to_vec()];
 
     Ok(crypto)
@@ -60,16 +78,19 @@ pub fn make_client_config(
 ) -> Result<rustls::ClientConfig, certificate::GenError> {
     let (certificate, private_key) = certificate::generate(keypair)?;
 
-    let mut crypto = rustls::ClientConfig::builder()
-        .with_cipher_suites(verifier::CIPHERSUITES)
-        .with_safe_default_kx_groups()
+    let cert_resolver = Arc::new(
+        certificate::AlwaysResolvesCert::new(certificate, &private_key)
+            .expect("Client cert key DER is valid; qed"),
+    );
+
+    let mut crypto = rustls::ClientConfig::builder_with_provider(crypto_provider())
         .with_protocol_versions(verifier::PROTOCOL_VERSIONS)
         .expect("Cipher suites and kx groups are configured; qed")
+        .dangerous()
         .with_custom_certificate_verifier(Arc::new(
             verifier::Libp2pCertificateVerifier::with_remote_peer_id(remote_peer_id),
         ))
-        .with_single_cert(vec![certificate], private_key)
-        .expect("Client cert key DER is valid; qed");
+        .with_client_cert_resolver(cert_resolver);
     crypto.alpn_protocols = vec![P2P_ALPN.to_vec()];
 
     Ok(crypto)

--- a/src/crypto/tls/verifier.rs
+++ b/src/crypto/tls/verifier.rs
@@ -26,14 +26,14 @@
 use crate::{crypto::tls::certificate, PeerId};
 
 use rustls::{
-    cipher_suite::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::ring::cipher_suite::{
         TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
     },
-    client::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
-    internal::msgs::handshake::DigitallySignedStruct,
-    server::{ClientCertVerified, ClientCertVerifier},
-    Certificate, DistinguishedNames, SignatureScheme, SupportedCipherSuite,
-    SupportedProtocolVersion,
+    pki_types::{CertificateDer, ServerName, UnixTime},
+    server::danger::{ClientCertVerified, ClientCertVerifier},
+    CertificateError, DigitallySignedStruct, DistinguishedName, SignatureScheme,
+    SupportedCipherSuite, SupportedProtocolVersion,
 };
 
 /// The protocol versions supported by this verifier.
@@ -57,6 +57,7 @@ pub static CIPHERSUITES: &[SupportedCipherSuite] = &[
 /// Implementation of the `rustls` certificate verification traits for libp2p.
 ///
 /// Only TLS 1.3 is supported. TLS 1.2 should be disabled in the configuration of `rustls`.
+#[derive(Debug)]
 pub struct Libp2pCertificateVerifier {
     /// The peer ID we intend to connect to
     remote_peer_id: Option<PeerId>,
@@ -105,12 +106,11 @@ impl Libp2pCertificateVerifier {
 impl ServerCertVerifier for Libp2pCertificateVerifier {
     fn verify_server_cert(
         &self,
-        end_entity: &Certificate,
-        intermediates: &[Certificate],
-        _server_name: &rustls::ServerName,
-        _scts: &mut dyn Iterator<Item = &[u8]>,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
         _ocsp_response: &[u8],
-        _now: std::time::SystemTime,
+        _now: UnixTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
         let peer_id = verify_presented_certs(end_entity, intermediates)?;
 
@@ -120,8 +120,10 @@ impl ServerCertVerifier for Libp2pCertificateVerifier {
             // the certificate matches the peer ID they intended to connect to,
             // and MUST abort the connection if there is a mismatch.
             if remote_peer_id != peer_id {
-                return Err(rustls::Error::PeerMisbehavedError(
-                    "Wrong peer ID in p2p extension".to_string(),
+                // Ships a `bad_certificate` / `access_denied` TLS alert;
+                // `Error::General` would emit the less specific `internal_error`.
+                return Err(rustls::Error::InvalidCertificate(
+                    CertificateError::ApplicationVerificationFailure,
                 ));
             }
         }
@@ -132,7 +134,7 @@ impl ServerCertVerifier for Libp2pCertificateVerifier {
     fn verify_tls12_signature(
         &self,
         _message: &[u8],
-        _cert: &Certificate,
+        _cert: &CertificateDer<'_>,
         _dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
         unreachable!("`PROTOCOL_VERSIONS` only allows TLS 1.3")
@@ -141,7 +143,7 @@ impl ServerCertVerifier for Libp2pCertificateVerifier {
     fn verify_tls13_signature(
         &self,
         message: &[u8],
-        cert: &Certificate,
+        cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
         verify_tls13_signature(cert, dss.scheme, message, dss.signature())
@@ -164,15 +166,17 @@ impl ClientCertVerifier for Libp2pCertificateVerifier {
         true
     }
 
-    fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
-        Some(vec![])
+    fn root_hint_subjects(&self) -> &[DistinguishedName] {
+        // libp2p does not authenticate via PKI / root CAs; the cert is self-signed and
+        // identity is bound through the libp2p extension. No subject hints to offer.
+        &[]
     }
 
     fn verify_client_cert(
         &self,
-        end_entity: &Certificate,
-        intermediates: &[Certificate],
-        _now: std::time::SystemTime,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        _now: UnixTime,
     ) -> Result<ClientCertVerified, rustls::Error> {
         let _: PeerId = verify_presented_certs(end_entity, intermediates)?;
 
@@ -182,7 +186,7 @@ impl ClientCertVerifier for Libp2pCertificateVerifier {
     fn verify_tls12_signature(
         &self,
         _message: &[u8],
-        _cert: &Certificate,
+        _cert: &CertificateDer<'_>,
         _dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
         unreachable!("`PROTOCOL_VERSIONS` only allows TLS 1.3")
@@ -191,7 +195,7 @@ impl ClientCertVerifier for Libp2pCertificateVerifier {
     fn verify_tls13_signature(
         &self,
         message: &[u8],
-        cert: &Certificate,
+        cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
         verify_tls13_signature(cert, dss.scheme, message, dss.signature())
@@ -209,8 +213,8 @@ impl ClientCertVerifier for Libp2pCertificateVerifier {
 /// Endpoints MUST abort the connection attempt if more than one certificate is received,
 /// or if the certificate’s self-signature is not valid.
 fn verify_presented_certs(
-    end_entity: &Certificate,
-    intermediates: &[Certificate],
+    end_entity: &CertificateDer<'_>,
+    intermediates: &[CertificateDer<'_>],
 ) -> Result<PeerId, rustls::Error> {
     if !intermediates.is_empty() {
         return Err(rustls::Error::General(
@@ -224,7 +228,7 @@ fn verify_presented_certs(
 }
 
 fn verify_tls13_signature(
-    cert: &Certificate,
+    cert: &CertificateDer<'_>,
     signature_scheme: SignatureScheme,
     message: &[u8],
     signature: &[u8],
@@ -238,8 +242,10 @@ impl From<certificate::ParseError> for rustls::Error {
     fn from(certificate::ParseError(e): certificate::ParseError) -> Self {
         use webpki::Error::*;
         match e {
-            BadDer => rustls::Error::InvalidCertificateEncoding,
-            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {e}")),
+            BadDer => rustls::Error::InvalidCertificate(CertificateError::BadEncoding),
+            e => rustls::Error::InvalidCertificate(CertificateError::Other(
+                rustls::OtherError(std::sync::Arc::new(InvalidLibp2pCertificate(e))),
+            )),
         }
     }
 }
@@ -247,10 +253,28 @@ impl From<certificate::VerificationError> for rustls::Error {
     fn from(certificate::VerificationError(e): certificate::VerificationError) -> Self {
         use webpki::Error::*;
         match e {
-            InvalidSignatureForPublicKey => rustls::Error::InvalidCertificateSignature,
+            InvalidSignatureForPublicKey =>
+                rustls::Error::InvalidCertificate(CertificateError::BadSignature),
             UnsupportedSignatureAlgorithm | UnsupportedSignatureAlgorithmForPublicKey =>
-                rustls::Error::InvalidCertificateSignatureType,
-            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {e}")),
+                rustls::Error::InvalidCertificate(
+                    CertificateError::UnsupportedSignatureAlgorithm,
+                ),
+            e => rustls::Error::InvalidCertificate(CertificateError::Other(
+                rustls::OtherError(std::sync::Arc::new(InvalidLibp2pCertificate(e))),
+            )),
         }
     }
 }
+
+/// Wrapper to turn a `webpki::Error` into something that satisfies the bounds on
+/// `rustls::CertificateError::Other`, which requires `std::error::Error + Send + Sync + 'static`.
+#[derive(Debug)]
+struct InvalidLibp2pCertificate(webpki::Error);
+
+impl std::fmt::Display for InvalidLibp2pCertificate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid peer certificate: {}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidLibp2pCertificate {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,7 +127,7 @@ pub enum Error {
     #[error("Failed to dial peer immediately")]
     ImmediateDialError(#[from] ImmediateDialError),
     #[error("Cannot read system DNS config: `{0}`")]
-    CannotReadSystemDnsConfig(hickory_resolver::ResolveError),
+    CannotReadSystemDnsConfig(hickory_resolver::net::NetError),
 }
 
 /// Error type for address parsing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ use crate::transport::webrtc::WebRtcTransport;
 #[cfg(feature = "websocket")]
 use crate::transport::websocket::WebSocketTransport;
 
-use hickory_resolver::{name_server::TokioConnectionProvider, TokioResolver};
+use hickory_resolver::{net::runtime::TokioRuntimeProvider, TokioResolver};
 use multiaddr::{Multiaddr, Protocol};
 use transport::Endpoint;
 use types::ConnectionId;
@@ -158,16 +158,30 @@ impl Litep2p {
         let bandwidth_sink = BandwidthSink::new();
         let mut listen_addresses = vec![];
 
+        // `ResolverConfig::default()` has an empty `name_servers` list and
+        // silently no-ops every DNS lookup; fall back to Cloudflare instead.
+        use hickory_resolver::config::{CLOUDFLARE, ResolverConfig};
+        let fallback = || ResolverConfig::udp_and_tcp(&CLOUDFLARE);
         let (resolver_config, resolver_opts) = if litep2p_config.use_system_dns_config {
-            hickory_resolver::system_conf::read_system_conf()
-                .map_err(Error::CannotReadSystemDnsConfig)?
+            match hickory_resolver::system_conf::read_system_conf() {
+                Ok(cfg) => cfg,
+                Err(error) => {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        ?error,
+                        "could not read system DNS config; falling back to Cloudflare",
+                    );
+                    (fallback(), Default::default())
+                }
+            }
         } else {
-            (Default::default(), Default::default())
+            (fallback(), Default::default())
         };
         let resolver = Arc::new(
-            TokioResolver::builder_with_config(resolver_config, TokioConnectionProvider::default())
+            TokioResolver::builder_with_config(resolver_config, TokioRuntimeProvider::default())
                 .with_options(resolver_opts)
-                .build(),
+                .build()
+                .map_err(Error::CannotReadSystemDnsConfig)?,
         );
 
         let supported_transports = Self::supported_transports(&litep2p_config);

--- a/src/transport/quic/listener.rs
+++ b/src/transport/quic/listener.rs
@@ -62,7 +62,11 @@ impl QuicListener {
         for address in addresses.into_iter() {
             let (listen_address, _) = Self::get_socket_address(&address)?;
             let crypto_config = Arc::new(make_server_config(keypair).expect("to succeed"));
-            let server_config = ServerConfig::with_crypto(crypto_config);
+            let quic_crypto = quinn::crypto::rustls::QuicServerConfig::try_from(crypto_config)
+                .map_err(|error| crate::Error::Other(format!(
+                    "quic server crypto config rejected by quinn: {error}"
+                )))?;
+            let server_config = ServerConfig::with_crypto(Arc::new(quic_crypto));
             let listener = Endpoint::server(server_config, listen_address).unwrap();
 
             let listen_address = listener.local_addr()?;
@@ -89,8 +93,25 @@ impl QuicListener {
                     .enumerate()
                     .map(|(i, listener)| {
                         let inner = listener.clone();
-                        async move { inner.accept().await.map(|connecting| (i, connecting)) }
-                            .boxed()
+                        async move {
+                            // Yield `None` on an accept failure so the polling
+                            // loop re-arms this listener instead of tearing the
+                            // whole stream down.
+                            let incoming = inner.accept().await?;
+                            match incoming.accept() {
+                                Ok(connecting) => Some((i, connecting)),
+                                Err(error) => {
+                                    tracing::debug!(
+                                        target: LOG_TARGET,
+                                        ?error,
+                                        listener = i,
+                                        "quic incoming.accept() failed; will re-arm listener",
+                                    );
+                                    None
+                                }
+                            }
+                        }
+                        .boxed()
                     })
                     .collect(),
                 listeners,
@@ -163,21 +184,41 @@ impl Stream for QuicListener {
     type Item = Connecting;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if self.incoming.is_empty() {
-            return Poll::Pending;
-        }
+        loop {
+            if self.incoming.is_empty() {
+                return Poll::Pending;
+            }
 
-        match futures::ready!(self.incoming.poll_next_unpin(cx)) {
-            None => Poll::Ready(None),
-            Some(None) => Poll::Ready(None),
-            Some(Some((listener, future))) => {
-                let inner = self.listeners[listener].clone();
-                self.incoming.push(
-                    async move { inner.accept().await.map(|connecting| (listener, connecting)) }
+            match futures::ready!(self.incoming.poll_next_unpin(cx)) {
+                None => return Poll::Ready(None),
+                Some(None) => {
+                    // Re-poll on a transient accept failure (see constructor);
+                    // only return `None` when `incoming` is genuinely empty.
+                    continue;
+                }
+                Some(Some((listener, future))) => {
+                    let inner = self.listeners[listener].clone();
+                    self.incoming.push(
+                        async move {
+                            let incoming = inner.accept().await?;
+                            match incoming.accept() {
+                                Ok(connecting) => Some((listener, connecting)),
+                                Err(error) => {
+                                    tracing::debug!(
+                                        target: LOG_TARGET,
+                                        ?error,
+                                        listener,
+                                        "quic incoming.accept() failed; re-arming",
+                                    );
+                                    None
+                                }
+                            }
+                        }
                         .boxed(),
-                );
+                    );
 
-                Poll::Ready(Some(future))
+                    return Poll::Ready(Some(future));
+                }
             }
         }
     }
@@ -268,7 +309,8 @@ mod tests {
 
         let crypto_config =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
-        let client_config = ClientConfig::new(crypto_config);
+        let quic_crypto = quinn::crypto::rustls::QuicClientConfig::try_from(crypto_config).expect("rustls config is QUIC-compatible; qed");
+        let client_config = ClientConfig::new(Arc::new(quic_crypto));
         let client =
             Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)).unwrap();
         let connection = client
@@ -314,7 +356,8 @@ mod tests {
 
         let crypto_config1 =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
-        let client_config1 = ClientConfig::new(crypto_config1);
+        let quic_crypto1 = quinn::crypto::rustls::QuicClientConfig::try_from(crypto_config1).expect("rustls config is QUIC-compatible; qed");
+        let client_config1 = ClientConfig::new(Arc::new(quic_crypto1));
         let client1 =
             Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)).unwrap();
         let connection1 = client1
@@ -327,7 +370,8 @@ mod tests {
 
         let crypto_config2 =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
-        let client_config2 = ClientConfig::new(crypto_config2);
+        let quic_crypto2 = quinn::crypto::rustls::QuicClientConfig::try_from(crypto_config2).expect("rustls config is QUIC-compatible; qed");
+        let client_config2 = ClientConfig::new(Arc::new(quic_crypto2));
         let client2 =
             Endpoint::client(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)).unwrap();
         let connection2 = client2
@@ -382,7 +426,8 @@ mod tests {
 
         let crypto_config1 =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
-        let client_config1 = ClientConfig::new(crypto_config1);
+        let quic_crypto1 = quinn::crypto::rustls::QuicClientConfig::try_from(crypto_config1).expect("rustls config is QUIC-compatible; qed");
+        let client_config1 = ClientConfig::new(Arc::new(quic_crypto1));
         let client1 =
             Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)).unwrap();
         let connection1 = client1
@@ -395,7 +440,8 @@ mod tests {
 
         let crypto_config2 =
             Arc::new(make_client_config(&Keypair::generate(), Some(peer)).expect("to succeed"));
-        let client_config2 = ClientConfig::new(crypto_config2);
+        let quic_crypto2 = quinn::crypto::rustls::QuicClientConfig::try_from(crypto_config2).expect("rustls config is QUIC-compatible; qed");
+        let client_config2 = ClientConfig::new(Arc::new(quic_crypto2));
         let client2 =
             Endpoint::client(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)).unwrap();
         let connection2 = client2
@@ -423,5 +469,58 @@ mod tests {
         for _ in 0..2 {
             let _ = listener.next().await;
         }
+    }
+
+    #[tokio::test]
+    async fn handshake_extracts_peer_id_both_sides() {
+        // End-to-end QUIC handshake: assert that after the libp2p TLS
+        // exchange completes, both peers can extract the *other* side's
+        // PeerId from the certificate via the libp2p X.509 extension.
+        let server_keypair = Keypair::generate();
+        let server_peer = PeerId::from_public_key(&server_keypair.public().into());
+        let client_keypair = Keypair::generate();
+        let client_peer = PeerId::from_public_key(&client_keypair.public().into());
+
+        let address: Multiaddr = "/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap();
+        let (mut listener, listen_addresses) =
+            QuicListener::new(&server_keypair, vec![address]).unwrap();
+        let Some(Protocol::Udp(port)) = listen_addresses.first().unwrap().clone().iter().nth(1)
+        else {
+            panic!("invalid address");
+        };
+
+        let crypto = Arc::new(make_client_config(&client_keypair, Some(server_peer)).unwrap());
+        let quic_crypto =
+            quinn::crypto::rustls::QuicClientConfig::try_from(crypto).unwrap();
+        let client_config = ClientConfig::new(Arc::new(quic_crypto));
+        let client =
+            Endpoint::client(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)).unwrap();
+        let connecting = client
+            .connect_with(client_config, format!("127.0.0.1:{port}").parse().unwrap(), "l")
+            .unwrap();
+
+        let (accepted, dialed) =
+            tokio::join!(listener.next(), async move { connecting.await });
+        let server_side = accepted.expect("listener yielded").await.expect("accept");
+        let client_side = dialed.expect("dial");
+
+        // The certificate the peer presented carries the libp2p extension.
+        // Round-trip both directions: server learns the client's PeerId,
+        // client learns the server's PeerId.
+        let peer_id_from = |c: &quinn::Connection| -> PeerId {
+            let certs: Box<Vec<rustls::pki_types::CertificateDer<'static>>> = c
+                .peer_identity()
+                .expect("peer identity present")
+                .downcast()
+                .expect("identity is a cert chain");
+            let parsed = crate::crypto::tls::certificate::parse(
+                certs.first().expect("at least one cert"),
+            )
+            .expect("libp2p cert parses");
+            parsed.peer_id()
+        };
+
+        assert_eq!(peer_id_from(&server_side), client_peer);
+        assert_eq!(peer_id_from(&client_side), server_peer);
     }
 }

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -641,7 +641,7 @@ mod tests {
                 },
             )]),
         };
-        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build());
+        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap());
 
         let (mut transport1, listen_addresses) =
             QuicTransport::new(handle1, Default::default(), resolver.clone()).unwrap();

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -131,7 +131,7 @@ pub(crate) struct QuicTransport {
 impl QuicTransport {
     /// Attempt to extract `PeerId` from connection certificates.
     fn extract_peer_id(connection: &Connection) -> Option<PeerId> {
-        let certificates: Box<Vec<rustls::Certificate>> =
+        let certificates: Box<Vec<rustls::pki_types::CertificateDer<'static>>> =
             connection.peer_identity()?.downcast().ok()?;
         let p2p_cert = crate::crypto::tls::certificate::parse(certificates.first()?)
             .expect("the certificate was validated during TLS handshake; qed");
@@ -263,7 +263,9 @@ impl Transport for QuicTransport {
         let timeout =
             IdleTimeout::try_from(self.config.connection_open_timeout).expect("to succeed");
         transport_config.max_idle_timeout(Some(timeout));
-        let mut client_config = ClientConfig::new(crypto_config);
+        let quic_crypto = quinn::crypto::rustls::QuicClientConfig::try_from(crypto_config)
+            .map_err(|error| Error::Other(format!("quic crypto config rejected by quinn: {error}")))?;
+        let mut client_config = ClientConfig::new(Arc::new(quic_crypto));
         client_config.transport_config(Arc::new(transport_config));
 
         let client_listen_address = match address.iter().next() {
@@ -399,7 +401,9 @@ impl Transport for QuicTransport {
                     let timeout =
                         IdleTimeout::try_from(connection_open_timeout).expect("to succeed");
                     transport_config.max_idle_timeout(Some(timeout));
-                    let mut client_config = ClientConfig::new(crypto_config);
+                    let quic_crypto = quinn::crypto::rustls::QuicClientConfig::try_from(crypto_config)
+                        .expect("rustls config is QUIC-compatible; qed");
+                    let mut client_config = ClientConfig::new(Arc::new(quic_crypto));
                     client_config.transport_config(Arc::new(transport_config));
 
                     let client_listen_address = match address.iter().next() {

--- a/src/transport/quic/substream.rs
+++ b/src/transport/quic/substream.rs
@@ -84,7 +84,13 @@ impl TokioAsyncRead for Substream {
         cx: &mut Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        match futures::ready!(Pin::new(&mut self.recv_stream).poll_read(cx, buf)) {
+        // quinn 0.11 impls both `tokio::io::AsyncRead` and `futures::AsyncRead`
+        // on `RecvStream`; disambiguate to the tokio one.
+        match futures::ready!(TokioAsyncRead::poll_read(
+            Pin::new(&mut self.recv_stream),
+            cx,
+            buf,
+        )) {
             Err(error) => Poll::Ready(Err(error)),
             Ok(res) => {
                 self.bandwidth_sink.increase_inbound(buf.filled().len());
@@ -100,7 +106,14 @@ impl TokioAsyncWrite for Substream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
-        match futures::ready!(Pin::new(&mut self.send_stream).poll_write(cx, buf)) {
+        // Use the tokio `AsyncWrite` impl on `SendStream`. The `From<WriteError>`
+        // conversion preserves the specific `ErrorKind` (`BrokenPipe` / etc.) so
+        // upstream callers that branch on `e.kind()` keep working.
+        match futures::ready!(TokioAsyncWrite::poll_write(
+            Pin::new(&mut self.send_stream),
+            cx,
+            buf,
+        )) {
             Err(error) => Poll::Ready(Err(error)),
             Ok(nwritten) => {
                 self.bandwidth_sink.increase_outbound(nwritten);
@@ -110,14 +123,14 @@ impl TokioAsyncWrite for Substream {
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        Pin::new(&mut self.send_stream).poll_flush(cx)
+        TokioAsyncWrite::poll_flush(Pin::new(&mut self.send_stream), cx)
     }
 
     fn poll_shutdown(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), io::Error>> {
-        Pin::new(&mut self.send_stream).poll_shutdown(cx)
+        TokioAsyncWrite::poll_shutdown(Pin::new(&mut self.send_stream), cx)
     }
 }
 
@@ -151,7 +164,7 @@ impl AsyncRead for NegotiatingSubstream {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.recv_stream).poll_read(cx, buf)
+        AsyncRead::poll_read(Pin::new(&mut self.recv_stream), cx, buf)
     }
 }
 
@@ -161,14 +174,14 @@ impl AsyncWrite for NegotiatingSubstream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.send_stream).poll_write(cx, buf)
+        AsyncWrite::poll_write(Pin::new(&mut self.send_stream), cx, buf)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.send_stream).poll_flush(cx)
+        AsyncWrite::poll_flush(Pin::new(&mut self.send_stream), cx)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.send_stream).poll_close(cx)
+        AsyncWrite::poll_close(Pin::new(&mut self.send_stream), cx)
     }
 }

--- a/src/transport/tcp/connection.rs
+++ b/src/transport/tcp/connection.rs
@@ -780,7 +780,7 @@ mod tests {
     use crate::transport::tcp::TcpTransport;
 
     use super::*;
-    use hickory_resolver::{name_server::TokioConnectionProvider, TokioResolver};
+    use hickory_resolver::{net::runtime::TokioRuntimeProvider, TokioResolver};
     use tokio::{io::AsyncWriteExt, net::TcpListener};
 
     #[tokio::test]
@@ -807,9 +807,9 @@ mod tests {
             Arc::new(
                 TokioResolver::builder_with_config(
                     Default::default(),
-                    TokioConnectionProvider::default(),
+                    TokioRuntimeProvider::default(),
                 )
-                .build(),
+                .build().unwrap(),
             ),
         )
         .await
@@ -909,9 +909,9 @@ mod tests {
             Arc::new(
                 TokioResolver::builder_with_config(
                     Default::default(),
-                    TokioConnectionProvider::default(),
+                    TokioRuntimeProvider::default(),
                 )
-                .build(),
+                .build().unwrap(),
             ),
         )
         .await
@@ -1058,9 +1058,9 @@ mod tests {
             Arc::new(
                 TokioResolver::builder_with_config(
                     Default::default(),
-                    TokioConnectionProvider::default(),
+                    TokioRuntimeProvider::default(),
                 )
-                .build(),
+                .build().unwrap(),
             ),
         )
         .await
@@ -1111,9 +1111,9 @@ mod tests {
             Arc::new(
                 TokioResolver::builder_with_config(
                     Default::default(),
-                    TokioConnectionProvider::default(),
+                    TokioRuntimeProvider::default(),
                 )
-                .build(),
+                .build().unwrap(),
             ),
         )
         .await
@@ -1291,9 +1291,9 @@ mod tests {
             Arc::new(
                 TokioResolver::builder_with_config(
                     Default::default(),
-                    TokioConnectionProvider::default(),
+                    TokioRuntimeProvider::default(),
                 )
-                .build(),
+                .build().unwrap(),
             ),
         )
         .await
@@ -1426,9 +1426,9 @@ mod tests {
             Arc::new(
                 TokioResolver::builder_with_config(
                     Default::default(),
-                    TokioConnectionProvider::default(),
+                    TokioRuntimeProvider::default(),
                 )
-                .build(),
+                .build().unwrap(),
             ),
         )
         .await

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -772,7 +772,7 @@ mod tests {
             listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
             ..Default::default()
         };
-        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build());
+        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap());
 
         let (mut transport1, listen_addresses) =
             TcpTransport::new(handle1, transport_config1, resolver.clone()).unwrap();
@@ -868,7 +868,7 @@ mod tests {
             listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
             ..Default::default()
         };
-        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build());
+        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap());
 
         let (mut transport1, listen_addresses) =
             TcpTransport::new(handle1, transport_config1, resolver.clone()).unwrap();
@@ -955,7 +955,7 @@ mod tests {
                 },
             )]),
         };
-        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build());
+        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap());
         let (mut transport1, _) =
             TcpTransport::new(handle1, Default::default(), resolver.clone()).unwrap();
 
@@ -1028,7 +1028,7 @@ mod tests {
     async fn dial_error_reported_for_outbound_connections() {
         let mut manager = TransportManagerBuilder::new().build();
         let handle = manager.transport_handle(Arc::new(DefaultExecutor {}));
-        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build());
+        let resolver = Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap());
         manager.register_transport(
             SupportedTransport::Tcp,
             Box::new(crate::transport::dummy::DummyTransport::new()),

--- a/src/transport/websocket/connection.rs
+++ b/src/transport/websocket/connection.rs
@@ -673,7 +673,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
-            Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+            Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
         )
         .await
         .unwrap();
@@ -789,7 +789,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
-            Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+            Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
         )
         .await
         .unwrap();
@@ -1061,7 +1061,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
-            Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+            Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
         )
         .await
         .unwrap();
@@ -1229,7 +1229,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
-            Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+            Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
         )
         .await
         .unwrap();
@@ -1383,7 +1383,7 @@ mod tests {
             Default::default(),
             Duration::from_secs(10),
             false,
-            Arc::new(TokioResolver::builder_tokio().unwrap().build()),
+            Arc::new(TokioResolver::builder_tokio().unwrap().build().unwrap()),
         )
         .await
         .unwrap();


### PR DESCRIPTION
Closes #308. Bumps the three deps that gate four open RustSec/GHSA
advisories surfacing in every downstream consumer of litep2p:

  - quinn-proto GHSA-6xvm-j4wr-6v98 / CVE-2026-31812 (high)
  - ring GHSA-4p46-pwfr-66x6 / CVE-2025-4432 (medium)
  - hickory-proto GHSA-3v94-mw7p-v465 (high)
  - hickory-proto GHSA-q2qq-hmj6-3wpp (medium)

Split into two commits along the dep boundary; each compiles
independently:

  1. `deps: hickory-resolver 0.25 → 0.26`
  2. `deps: quinn 0.9 → 0.11, rustls 0.20 → 0.23`

quinn and rustls had to land together — quinn 0.11 wraps
`rustls::ClientConfig` / `ServerConfig` via `QuicClientConfig::try_from` /
`QuicServerConfig::try_from` which require rustls 0.23's pluggable
`CryptoProvider`.

The hickory bump deserves extra eyeballs because hickory 0.26 ships two
**silent breaking default-value changes** that compile cleanly but
break at runtime:

  - `ResolverConfig::default()` lost its `Default` impl (was Google DNS,
    now empty `name_servers`); fixed by explicit Cloudflare fallback.
  - `LookupIpStrategy::default()` flipped from `Ipv4thenIpv6` (sequential
    v4-first) to `Ipv6AndIpv4` (parallel v6-preferred). Left at hickory's
    new default; documented in the commit so consumers in v6-broken
    environments know what to expect.

The rustls bump touches the libp2p TLS cert verifier substantially.
Notable behavioural decisions in the commit:

  - `AlwaysResolvesCert` resolver replaces `with_single_cert` (rustls
    0.23 rejects the libp2p X.509 extension as `UnsupportedCriticalExtension`
    on the old path). Same pattern as rust-libp2p's `libp2p-tls` 0.6.
  - Peer-id mismatch returns
    `CertificateError::ApplicationVerificationFailure` (ships a
    `bad_certificate`/`access_denied` TLS alert) rather than the generic
    `Error::General`.
  - `kx_groups` pinned explicitly so a future ring release can't widen
    the curve set.

## Testing

  - `cargo check --features quic,websocket` — clean (0 errors, 13 warnings,
    all cosmetic in pre-existing code).
  - `cargo check --no-default-features` — clean.
  - `cargo test --lib --features quic,websocket` — **361 passed, 0 failed,
    1 ignored**.
  - `cargo test --test mod conformance::rust::quic_ping` — **4/4 passed**,
    including the existing `libp2p_dials` interop test that performs a real
    rust-libp2p ↔ litep2p QUIC handshake + ping exchange. This is the
    best wire-level equivalence proof in the suite.
  - Added `transport::quic::listener::tests::handshake_extracts_peer_id_both_sides`
    asserting both peers extract each other's PeerId from the libp2p X.509
    extension after a real handshake.
  - End-to-end TCP/WSS sweep against polkadot/kusama/paseo bootnodes via
    [a downstream consumer](https://github.com/rotkonetworks/bootyspector) with `[patch.crates-io]` — behaviour-equivalent
    for A-record hosts.