### PR TITLE
mdns: Avoid overflows on long running nodes

### DIFF
--- a/src/protocol/mdns.rs
+++ b/src/protocol/mdns.rs
@@ -148,8 +148,7 @@ impl Mdns {
     /// Get next query ID.
     fn next_query_id(&mut self) -> u16 {
         let query_id = self.next_query_id;
-        self.next_query_id += 1;
-
+        self.next_query_id = self.next_query_id.wrapping_add(1);
         query_id
     }
 


### PR DESCRIPTION
The next query ID for mdns is using a `u16` integer to create the MDNS packet.

This is enforced by the packet structure of `simple-dns-0.11.2` crate used under the hood.

For long-running bulletin chains, we have observed testing panics for nodes running more than ~22 days.

This PR wraps the `u16` to ensure packet IDs are unique and avoid panics.

