### PR TITLE
chore: Upgrade sha2 to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,7 +566,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -605,6 +611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
 
@@ -1927,7 +1934,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_millis",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "simple-dns",
  "smallvec",
  "snow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ pin-project = "1.1.10"
 prost = "0.13.5"
 rand = { version = "0.8.0", features = ["getrandom"] }
 serde = "1.0.158"
-sha2 = "0.10.9"
+sha2 = "0.11"
 simple-dns = "0.11.0"
 smallvec = "1.15.0"
 snow = { version = "0.9.3", features = [

--- a/src/protocol/libp2p/kademlia/types.rs
+++ b/src/protocol/libp2p/kademlia/types.rs
@@ -32,12 +32,9 @@ use crate::{
 
 use multiaddr::Multiaddr;
 
-#[allow(deprecated)]
-// TODO: remove `#[allow(deprecated)] once sha2-0.11 is released.
-//       See https://github.com/paritytech/litep2p/issues/449.
-use sha2::digest::generic_array::GenericArray;
+use sha2::digest::array::Array;
 
-use sha2::{digest::generic_array::typenum::U32, Digest, Sha256};
+use sha2::{digest::typenum::U32, Digest, Sha256};
 use uint::*;
 
 use std::{
@@ -153,10 +150,7 @@ impl<T: Clone> Hash for Key<T> {
 
 /// The raw bytes of a key in the DHT keyspace.
 #[derive(PartialEq, Eq, Clone, Debug)]
-#[allow(deprecated)]
-// TODO: remove `#[allow(deprecated)] once sha2-0.11 is released.
-//       See https://github.com/paritytech/litep2p/issues/449.
-pub struct KeyBytes(GenericArray<u8, U32>);
+pub struct KeyBytes(Array<u8, U32>);
 
 impl KeyBytes {
     /// Creates a new key in the DHT keyspace by running the given
@@ -169,9 +163,6 @@ impl KeyBytes {
     }
 
     /// Computes the distance of the keys according to the XOR metric.
-    #[allow(deprecated)]
-    // TODO: remove `#[allow(deprecated)] once sha2-0.11 is released.
-    //       See https://github.com/paritytech/litep2p/issues/449.
     pub fn distance<U>(&self, other: &U) -> Distance
     where
         U: AsRef<KeyBytes>,
@@ -187,12 +178,9 @@ impl KeyBytes {
     ///
     /// `self xor other = distance <==> other = self xor distance`
     #[cfg(test)]
-    #[allow(deprecated)]
-    // TODO: remove `#[allow(deprecated)] once sha2-0.11 is released.
-    //       See https://github.com/paritytech/litep2p/issues/449.
     pub fn for_distance(&self, d: Distance) -> KeyBytes {
         let key_int = U256::from_big_endian(self.0.as_slice()) ^ d.0;
-        KeyBytes(GenericArray::from(key_int.to_big_endian()))
+        KeyBytes(Array::from(key_int.to_big_endian()))
     }
 }
 


### PR DESCRIPTION
## Summary

Now that `sha2` 0.11 is released, this bumps the direct dependency from `0.10.9` to `0.11` and migrates the Kademlia key types accordingly.

## Changes

  - `Cargo.toml`: `sha2 = "0.10.9"` → `"0.11"`
  - `kademlia/types.rs`: `GenericArray` → `Array`, updated `typenum` import path removed the 4 `#[allow(deprecated)]` blocks and their TODOs

Closes #449