### PR TITLE
webrtc: Fix memory leak by detecting closed connections

### DIFF
--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -713,7 +713,6 @@ impl Stream for WebRtcTransport {
                     entry.remove();
                 }
             }
-            this.timeouts.remove(&source);
         }
 
         loop {

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -152,7 +152,7 @@ pub(crate) struct WebRtcTransport {
     open: HashMap<AddressPair, ConnectionContext>,
 
     /// Watches for closed connections.
-    closed_connections: FuturesUnordered<BoxFuture<'static, (SocketAddr, ConnectionId)>>,
+    closed_connections: FuturesUnordered<BoxFuture<'static, (AddressPair, ConnectionId)>>,
 
     /// OpeningWebRtc connections.
     opening: HashMap<AddressPair, OpeningWebRtcConnection>,
@@ -547,7 +547,7 @@ impl Transport for WebRtcTransport {
         self.closed_connections.push(Box::pin(async move {
             // Resolves when the `WebRtcConnection` is dropped.
             watcher_tx.closed().await;
-            (source, connection_id)
+            (addrs, connection_id)
         }));
 
         self.open.insert(

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     PeerId,
 };
 
-use futures::{future::BoxFuture, Future, Stream};
+use futures::{future::BoxFuture, stream::FuturesUnordered, Future, Stream, StreamExt};
 use futures_timer::Delay;
 use hickory_resolver::TokioResolver;
 use multiaddr::{multihash::Multihash, Multiaddr, Protocol};
@@ -140,6 +140,9 @@ pub(crate) struct WebRtcTransport {
 
     /// Connected peers.
     open: HashMap<SocketAddr, ConnectionContext>,
+
+    /// Watches for closed connections.
+    closed_connections: FuturesUnordered<BoxFuture<'static, (SocketAddr, ConnectionId)>>,
 
     /// OpeningWebRtc connections.
     opening: HashMap<SocketAddr, OpeningWebRtcConnection>,
@@ -514,6 +517,7 @@ impl TransportBuilder for WebRtcTransport {
                 dtls_cert,
                 listen_address,
                 open: HashMap::new(),
+                closed_connections: FuturesUnordered::new(),
                 opening: HashMap::new(),
                 connections: HashMap::new(),
                 socket: Arc::new(socket),
@@ -605,6 +609,13 @@ impl Transport for WebRtcTransport {
         let socket = Arc::clone(&self.socket);
         let listen_address = self.listen_address;
 
+        let watcher_tx = tx.clone();
+        self.closed_connections.push(Box::pin(async move {
+            // Resolves when the `WebRtcConnection` is dropped.
+            watcher_tx.closed().await;
+            (source, connection_id)
+        }));
+
         self.open.insert(
             source,
             ConnectionContext {
@@ -692,6 +703,17 @@ impl Stream for WebRtcTransport {
 
         if let Some(event) = this.pending_events.pop_front() {
             return Poll::Ready(Some(event));
+        }
+
+        while let Poll::Ready(Some((source, connection_id))) =
+            this.closed_connections.poll_next_unpin(cx)
+        {
+            if let Entry::Occupied(entry) = this.open.entry(source) {
+                if entry.get().connection_id == connection_id {
+                    entry.remove();
+                }
+            }
+            this.timeouts.remove(&source);
         }
 
         loop {


### PR DESCRIPTION
The webrtc implementation has a mapping between the transport and individual `WebRtcConnection` connections.

At the moment, this is causing subtle memory leaks with every connection.

The memory is leaked because the removal of the mapping entry happens only if the `on_socket_input` is called after the connection has been dropped (which is extremly unlikely):

https://github.com/paritytech/litep2p/blob/4b24ac934f498aa3eb5d4f47537e184ef9191c09/src/transport/webrtc/mod.rs#L358

Instead, this PR detects when the `WebRtcConnection` is dropped by monitoring the communication channels between the transport and the connection.

Closes:
- https://github.com/paritytech/litep2p/issues/597

