### PR TITLE
feat(webrtc): update how webrtc certificate is handled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,6 +531,31 @@ impl Litep2p {
             }
         }
     }
+
+    /// Generates a fresh WebRTC DTLS certificate, encoded for persistence.
+    ///
+    /// The returned bytes contain the certificate **and its private key**.
+    /// Feed the value back via [`webrtc::Config::raw_dtls_certificate`]
+    /// to keep a stable WebRTC identity (`certhash`) across restarts.
+    #[cfg(feature = "webrtc")]
+    pub fn generate_webrtc_certificate() -> crate::Result<Vec<u8>> {
+        let certificate = transport::webrtc::generate_certificate()?;
+        Ok(transport::webrtc::encode(&certificate))
+    }
+
+    /// Validates an encoded WebRTC DTLS certificate.
+    ///
+    /// Accepts the bytes produced by [`Litep2p::generate_webrtc_certificate`] and
+    /// checks that they decode into a certificate and private key the DTLS stack
+    /// can actually use.
+    ///
+    /// Returns an error if the bytes are truncated, the encoded lengths are
+    /// inconsistent, or the certificate/key fails to load.
+    #[cfg(feature = "webrtc")]
+    pub fn validate_webrtc_certificate(encoded_certificate: Vec<u8>) -> crate::Result<()> {
+        let certificate = transport::webrtc::decode(encoded_certificate)?;
+        transport::webrtc::validate_certificate(&certificate)
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,9 +361,11 @@ impl Litep2p {
             transport_manager.register_transport(SupportedTransport::Quic, Box::new(transport));
         }
 
-        // enable webrtc transport if the config exists
+        // Enable webrtc transport if the config exists and is valid.
+        // A config without any listen address is skipped gracefully instead of
+        // failing startup.
         #[cfg(feature = "webrtc")]
-        if let Some(config) = litep2p_config.webrtc.take() {
+        if let Some(config) = litep2p_config.webrtc.take().filter(|config| config.is_valid()) {
             let handle = transport_manager.transport_handle(Arc::clone(&litep2p_config.executor));
             let (transport, transport_listen_addresses) =
                 <WebRtcTransport as TransportBuilder>::new(handle, config, resolver.clone())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,17 +365,23 @@ impl Litep2p {
         // A config without any listen address is skipped gracefully instead of
         // failing startup.
         #[cfg(feature = "webrtc")]
-        if let Some(config) = litep2p_config.webrtc.take().filter(|config| config.is_valid()) {
-            let handle = transport_manager.transport_handle(Arc::clone(&litep2p_config.executor));
-            let (transport, transport_listen_addresses) =
-                <WebRtcTransport as TransportBuilder>::new(handle, config, resolver.clone())?;
+        if let Some(config) = litep2p_config.webrtc.take() {
+            if !config.is_valid() {
+                tracing::warn!(target: LOG_TARGET, "Invalid WebRtc Config, no listen address specified");
+            } else {
+                let handle =
+                    transport_manager.transport_handle(Arc::clone(&litep2p_config.executor));
+                let (transport, transport_listen_addresses) =
+                    <WebRtcTransport as TransportBuilder>::new(handle, config, resolver.clone())?;
 
-            for address in transport_listen_addresses {
-                transport_manager.register_listen_address(address.clone());
-                listen_addresses.push(address.with(Protocol::P2p(local_peer_id.into())));
+                for address in transport_listen_addresses {
+                    transport_manager.register_listen_address(address.clone());
+                    listen_addresses.push(address.with(Protocol::P2p(local_peer_id.into())));
+                }
+
+                transport_manager
+                    .register_transport(SupportedTransport::WebRtc, Box::new(transport));
             }
-
-            transport_manager.register_transport(SupportedTransport::WebRtc, Box::new(transport));
         }
 
         // enable websocket transport if the config exists

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,31 +533,6 @@ impl Litep2p {
             }
         }
     }
-
-    /// Generates a fresh WebRTC DTLS certificate, encoded for persistence.
-    ///
-    /// The returned bytes contain the certificate **and its private key**.
-    /// Feed the value back via [`webrtc::Config::raw_dtls_certificate`]
-    /// to keep a stable WebRTC identity (`certhash`) across restarts.
-    #[cfg(feature = "webrtc")]
-    pub fn generate_webrtc_certificate() -> crate::Result<Vec<u8>> {
-        let certificate = transport::webrtc::generate_certificate()?;
-        Ok(transport::webrtc::encode(&certificate))
-    }
-
-    /// Validates an encoded WebRTC DTLS certificate.
-    ///
-    /// Accepts the bytes produced by [`Litep2p::generate_webrtc_certificate`] and
-    /// checks that they decode into a certificate and private key the DTLS stack
-    /// can actually use.
-    ///
-    /// Returns an error if the bytes are truncated, the encoded lengths are
-    /// inconsistent, or the certificate/key fails to load.
-    #[cfg(feature = "webrtc")]
-    pub fn validate_webrtc_certificate(encoded_certificate: Vec<u8>) -> crate::Result<()> {
-        let certificate = transport::webrtc::decode(encoded_certificate)?;
-        transport::webrtc::validate_certificate(&certificate)
-    }
 }
 
 #[cfg(test)]

--- a/src/transport/webrtc/certificate.rs
+++ b/src/transport/webrtc/certificate.rs
@@ -26,12 +26,14 @@ impl DtlsCertificate {
 
     /// Generates a fresh WebRTC DTLS certificate.
     pub fn new() -> crate::Result<Self> {
-        let dtls_cert =
-            str0m::crypto::from_feature_flags().dtls_provider.generate_certificate().ok_or(
-                crate::error::Error::WebRtc(RtcError::Dtls(DtlsError::CryptoError(
-                    CryptoError::Other("OpenSsl failed to generate certificate".to_string()),
-                ))),
-            )?;
+        let dtls_cert = str0m::crypto::from_feature_flags()
+            .dtls_provider
+            .generate_certificate()
+            .ok_or(crate::error::Error::WebRtc(RtcError::Dtls(
+                DtlsError::CryptoError(CryptoError::Other(
+                    "Crypto provider failed to generate DTLS certificate".to_string(),
+                )),
+            )))?;
         Ok(Self {
             certificate: dtls_cert.certificate,
             private_key: dtls_cert.private_key,

--- a/src/transport/webrtc/certificate.rs
+++ b/src/transport/webrtc/certificate.rs
@@ -1,168 +1,54 @@
-//! Serialization of the WebRTC DTLS certificate.
+//! WebRTC DTLS certificate.
 //!
 //! The DTLS certificate determines the node's WebRTC `certhash` and therefore its
-//! advertised multiaddrs. Generating a fresh certificate on every start gives
-//! the node a new identity each time, persisting one keeps that identity
-//! the same across restarts.
+//! advertised multiaddrs. Generating a fresh certificate on every start gives the node
+//! a new identity each time, reusing one keeps that identity stable across restarts.
 //!
-//! litep2p does not persist the certificate itself. Instead it exposes the certificate
-//! as an opaque byte blob: [`generate_certificate`] produces a new certificate,
-//! [`encode`] turns it into bytes the caller can store however they like, and
-//! [`decode`] reconstructs it.
-//!
-//! Format:
-//! `[u64 certificate_len]` ++ `[certificate]` ++ `[u64 private_key_len]` ++ `[private_key]`
-
-use std::panic::catch_unwind;
+//! litep2p does not persist the certificate itself, persistence is left to the caller.
 
 use str0m::{config::DtlsCert, crypto::CryptoError, error::DtlsError, RtcError};
 
-/// Generates a fresh self-signed DTLS certificate.
-pub fn generate_certificate() -> crate::Result<DtlsCert> {
-    // OpenSsl as crypto provider is specified through the 'openssl' str0m feature flag.
-    str0m::crypto::from_feature_flags().dtls_provider.generate_certificate().ok_or(
-        crate::error::Error::WebRtc(RtcError::Dtls(DtlsError::CryptoError(CryptoError::Other(
-            "OpenSsl failed to generate certificate".to_string(),
-        )))),
-    )
+#[derive(Debug)]
+pub struct DtlsCertificate {
+    certificate: Vec<u8>,
+    private_key: Vec<u8>,
 }
 
-/// Validates that a reconstructed certificate is usable by the DTLS stack.
-pub fn validate_certificate(certificate: &DtlsCert) -> crate::Result<()> {
-    catch_unwind(|| {
-        let mut rtc = str0m::Rtc::builder()
-            .set_dtls_cert(certificate.clone())
-            .build(std::time::Instant::now());
-        rtc.direct_api().start_dtls(false).unwrap();
-    })
-    .map(|_| ())
-    .map_err(|err| crate::Error::Other(format!("{:?}", err)))
+impl DtlsCertificate {
+    /// Reconstructs a certificate from previously stored bytes.
+    pub fn load(certificate: Vec<u8>, private_key: Vec<u8>) -> crate::Result<Self> {
+        // NOTE: here certificate and private_key could be validated.
+        Ok(Self {
+            certificate,
+            private_key,
+        })
+    }
+
+    /// Generates a fresh WebRTC DTLS certificate.
+    pub fn new() -> crate::Result<Self> {
+        let dtls_cert =
+            str0m::crypto::from_feature_flags().dtls_provider.generate_certificate().ok_or(
+                crate::error::Error::WebRtc(RtcError::Dtls(DtlsError::CryptoError(
+                    CryptoError::Other("OpenSsl failed to generate certificate".to_string()),
+                ))),
+            )?;
+        Ok(Self {
+            certificate: dtls_cert.certificate,
+            private_key: dtls_cert.private_key,
+        })
+    }
+
+    /// Returns the raw certificate and private-key bytes.
+    pub fn as_parts(&self) -> (&Vec<u8>, &Vec<u8>) {
+        (&self.certificate, &self.private_key)
+    }
 }
 
-/// Encodes a DTLS certificate into a byte blob.
-///
-/// Both the certificate and the private key are stored, each prefixed
-/// with its big-endian `u64` length.
-pub fn encode(dtls_cert: &DtlsCert) -> Vec<u8> {
-    let mut encoding = (dtls_cert.certificate.len() as u64).to_be_bytes().to_vec();
-    encoding.extend(&dtls_cert.certificate);
-    encoding.extend((dtls_cert.private_key.len() as u64).to_be_bytes());
-    encoding.extend(&dtls_cert.private_key);
-    encoding
-}
-
-/// Decodes a DTLS certificate.
-///
-/// Returns an error if the input is truncated or the encoded lengths are inconsistent
-/// with the buffer.
-pub fn decode(mut bytes: Vec<u8>) -> crate::Result<DtlsCert> {
-    const LENGTH_PREFIX_BYTES: usize = 8;
-    let decoding_err = |description: &str| -> crate::Result<Vec<u8>> {
-        Err(crate::Error::Other(description.to_string()))
-    };
-
-    let mut decode_vec = || -> crate::Result<Vec<u8>> {
-        if bytes.len() < LENGTH_PREFIX_BYTES {
-            return decoding_err("invalid encoding, too few bytes for length prefix");
+impl From<DtlsCertificate> for DtlsCert {
+    fn from(cert: DtlsCertificate) -> Self {
+        Self {
+            certificate: cert.certificate,
+            private_key: cert.private_key,
         }
-
-        let mut buf = [0; LENGTH_PREFIX_BYTES];
-        buf.copy_from_slice(&bytes[..LENGTH_PREFIX_BYTES]);
-        let vec_len = u64::from_be_bytes(buf) as usize;
-        bytes.drain(..LENGTH_PREFIX_BYTES);
-
-        if vec_len == 0 {
-            return decoding_err("invalid encoding, decoded len cannot be 0");
-        } else if vec_len > bytes.len() {
-            return decoding_err("invalid encoding, decoded len bigger than buffer");
-        }
-
-        let vec = bytes[..vec_len].to_vec();
-        bytes.drain(..vec_len);
-        Ok(vec)
-    };
-
-    Ok(DtlsCert {
-        certificate: decode_vec()?,
-        private_key: decode_vec()?,
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn round_trip() {
-        // generate -> encode -> decode
-        let cert = generate_certificate().unwrap();
-        let decoded = decode(encode(&cert)).unwrap();
-        assert_eq!(cert.certificate, decoded.certificate);
-        assert_eq!(cert.private_key, decoded.private_key);
-    }
-
-    #[test]
-    fn decode_empty_input_fails() {
-        // Empty input has not even a length prefix.
-        assert!(decode(Vec::new()).is_err());
-    }
-
-    #[test]
-    fn decode_too_few_bytes_for_length_prefix_fails() {
-        // Not enough for the first length prefix.
-        assert!(decode(vec![0; 4]).is_err());
-    }
-
-    #[test]
-    fn decode_certificate_length_exceeds_buffer_fails() {
-        // Certificate length bigger than buffer.
-        let mut bytes = 16u64.to_be_bytes().to_vec();
-        bytes.extend_from_slice(&[0u8; 2]);
-        assert!(decode(bytes).is_err());
-    }
-
-    #[test]
-    fn decode_truncated_private_key_prefix_fails() {
-        // too few bytes for the private-key length prefix.
-        let mut bytes = 16u64.to_be_bytes().to_vec();
-        bytes.extend_from_slice(&[0u8; 16]); // certificate
-        bytes.extend_from_slice(&[0u8; 3]);
-        assert!(decode(bytes).is_err());
-    }
-
-    #[test]
-    fn decode_private_key_length_exceeds_buffer_fails() {
-        // Private-key length bigger than buffer.
-        let mut bytes = 16u64.to_be_bytes().to_vec();
-        bytes.extend_from_slice(&[0u8; 16]); // certificate
-
-        bytes.extend_from_slice(&16u64.to_be_bytes());
-        bytes.extend_from_slice(&[0u8; 2]);
-        assert!(decode(bytes).is_err());
-    }
-
-    #[test]
-    fn support_trailing_bytes() {
-        // generate -> encode -> extend -> decode
-        let cert = generate_certificate().unwrap();
-        let mut encoded = encode(&cert);
-        encoded.extend_from_slice(&[7; 19]);
-        let decoded = decode(encoded).unwrap();
-        assert_eq!(cert.certificate, decoded.certificate);
-        assert_eq!(cert.private_key, decoded.private_key);
-    }
-
-    #[test]
-    fn validate_valid_certificate() {
-        let cert = generate_certificate().unwrap();
-        assert!(validate_certificate(&cert).is_ok());
-    }
-
-    #[test]
-    fn validate_invalid_certificate() {
-        let mut cert = generate_certificate().unwrap();
-        *cert.certificate.last_mut().unwrap() = 0;
-        *cert.private_key.last_mut().unwrap() = 0;
-        assert!(validate_certificate(&cert).is_err());
     }
 }

--- a/src/transport/webrtc/certificate.rs
+++ b/src/transport/webrtc/certificate.rs
@@ -1,0 +1,168 @@
+//! Serialization of the WebRTC DTLS certificate.
+//!
+//! The DTLS certificate determines the node's WebRTC `certhash` and therefore its
+//! advertised multiaddrs. Generating a fresh certificate on every start gives
+//! the node a new identity each time, persisting one keeps that identity
+//! the same across restarts.
+//!
+//! litep2p does not persist the certificate itself. Instead it exposes the certificate
+//! as an opaque byte blob: [`generate_certificate`] produces a new certificate,
+//! [`encode`] turns it into bytes the caller can store however they like, and
+//! [`decode`] reconstructs it.
+//!
+//! Format:
+//! `[u64 certificate_len]` ++ `[certificate]` ++ `[u64 private_key_len]` ++ `[private_key]`
+
+use std::panic::catch_unwind;
+
+use str0m::{config::DtlsCert, crypto::CryptoError, error::DtlsError, RtcError};
+
+/// Generates a fresh self-signed DTLS certificate.
+pub fn generate_certificate() -> crate::Result<DtlsCert> {
+    // OpenSsl as crypto provider is specified through the 'openssl' str0m feature flag.
+    str0m::crypto::from_feature_flags().dtls_provider.generate_certificate().ok_or(
+        crate::error::Error::WebRtc(RtcError::Dtls(DtlsError::CryptoError(CryptoError::Other(
+            "OpenSsl failed to generate certificate".to_string(),
+        )))),
+    )
+}
+
+/// Validates that a reconstructed certificate is usable by the DTLS stack.
+pub fn validate_certificate(certificate: &DtlsCert) -> crate::Result<()> {
+    catch_unwind(|| {
+        let mut rtc = str0m::Rtc::builder()
+            .set_dtls_cert(certificate.clone())
+            .build(std::time::Instant::now());
+        rtc.direct_api().start_dtls(false).unwrap();
+    })
+    .map(|_| ())
+    .map_err(|err| crate::Error::Other(format!("{:?}", err)))
+}
+
+/// Encodes a DTLS certificate into a byte blob.
+///
+/// Both the certificate and the private key are stored, each prefixed
+/// with its big-endian `u64` length.
+pub fn encode(dtls_cert: &DtlsCert) -> Vec<u8> {
+    let mut encoding = (dtls_cert.certificate.len() as u64).to_be_bytes().to_vec();
+    encoding.extend(&dtls_cert.certificate);
+    encoding.extend((dtls_cert.private_key.len() as u64).to_be_bytes());
+    encoding.extend(&dtls_cert.private_key);
+    encoding
+}
+
+/// Decodes a DTLS certificate.
+///
+/// Returns an error if the input is truncated or the encoded lengths are inconsistent
+/// with the buffer.
+pub fn decode(mut bytes: Vec<u8>) -> crate::Result<DtlsCert> {
+    const LENGTH_PREFIX_BYTES: usize = 8;
+    let decoding_err = |description: &str| -> crate::Result<Vec<u8>> {
+        Err(crate::Error::Other(description.to_string()))
+    };
+
+    let mut decode_vec = || -> crate::Result<Vec<u8>> {
+        if bytes.len() < LENGTH_PREFIX_BYTES {
+            return decoding_err("invalid encoding, too few bytes for length prefix");
+        }
+
+        let mut buf = [0; LENGTH_PREFIX_BYTES];
+        buf.copy_from_slice(&bytes[..LENGTH_PREFIX_BYTES]);
+        let vec_len = u64::from_be_bytes(buf) as usize;
+        bytes.drain(..LENGTH_PREFIX_BYTES);
+
+        if vec_len == 0 {
+            return decoding_err("invalid encoding, decoded len cannot be 0");
+        } else if vec_len > bytes.len() {
+            return decoding_err("invalid encoding, decoded len bigger than buffer");
+        }
+
+        let vec = bytes[..vec_len].to_vec();
+        bytes.drain(..vec_len);
+        Ok(vec)
+    };
+
+    Ok(DtlsCert {
+        certificate: decode_vec()?,
+        private_key: decode_vec()?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        // generate -> encode -> decode
+        let cert = generate_certificate().unwrap();
+        let decoded = decode(encode(&cert)).unwrap();
+        assert_eq!(cert.certificate, decoded.certificate);
+        assert_eq!(cert.private_key, decoded.private_key);
+    }
+
+    #[test]
+    fn decode_empty_input_fails() {
+        // Empty input has not even a length prefix.
+        assert!(decode(Vec::new()).is_err());
+    }
+
+    #[test]
+    fn decode_too_few_bytes_for_length_prefix_fails() {
+        // Not enough for the first length prefix.
+        assert!(decode(vec![0; 4]).is_err());
+    }
+
+    #[test]
+    fn decode_certificate_length_exceeds_buffer_fails() {
+        // Certificate length bigger than buffer.
+        let mut bytes = 16u64.to_be_bytes().to_vec();
+        bytes.extend_from_slice(&[0u8; 2]);
+        assert!(decode(bytes).is_err());
+    }
+
+    #[test]
+    fn decode_truncated_private_key_prefix_fails() {
+        // too few bytes for the private-key length prefix.
+        let mut bytes = 16u64.to_be_bytes().to_vec();
+        bytes.extend_from_slice(&[0u8; 16]); // certificate
+        bytes.extend_from_slice(&[0u8; 3]);
+        assert!(decode(bytes).is_err());
+    }
+
+    #[test]
+    fn decode_private_key_length_exceeds_buffer_fails() {
+        // Private-key length bigger than buffer.
+        let mut bytes = 16u64.to_be_bytes().to_vec();
+        bytes.extend_from_slice(&[0u8; 16]); // certificate
+
+        bytes.extend_from_slice(&16u64.to_be_bytes());
+        bytes.extend_from_slice(&[0u8; 2]);
+        assert!(decode(bytes).is_err());
+    }
+
+    #[test]
+    fn support_trailing_bytes() {
+        // generate -> encode -> extend -> decode
+        let cert = generate_certificate().unwrap();
+        let mut encoded = encode(&cert);
+        encoded.extend_from_slice(&[7; 19]);
+        let decoded = decode(encoded).unwrap();
+        assert_eq!(cert.certificate, decoded.certificate);
+        assert_eq!(cert.private_key, decoded.private_key);
+    }
+
+    #[test]
+    fn validate_valid_certificate() {
+        let cert = generate_certificate().unwrap();
+        assert!(validate_certificate(&cert).is_ok());
+    }
+
+    #[test]
+    fn validate_invalid_certificate() {
+        let mut cert = generate_certificate().unwrap();
+        *cert.certificate.last_mut().unwrap() = 0;
+        *cert.private_key.last_mut().unwrap() = 0;
+        assert!(validate_certificate(&cert).is_err());
+    }
+}

--- a/src/transport/webrtc/config.rs
+++ b/src/transport/webrtc/config.rs
@@ -40,7 +40,7 @@ pub struct Config {
     ///
     /// Accepts encoded bytes, when `None`, a fresh certificate
     /// is generated on every start.
-    pub raw_dtls_certificate: Option<Vec<u8>>,
+    pub raw_certificate: Option<Vec<u8>>,
 }
 
 impl Config {
@@ -60,7 +60,7 @@ impl Default for Config {
                 .parse()
                 .expect("valid multiaddress")],
             datagram_buffer_size: 2048,
-            raw_dtls_certificate: None,
+            raw_certificate: None,
         }
     }
 }

--- a/src/transport/webrtc/config.rs
+++ b/src/transport/webrtc/config.rs
@@ -27,7 +27,7 @@ use crate::transport::webrtc::certificate::DtlsCertificate;
 /// WebRTC transport configuration.
 ///
 /// To be valid, the configuration must contain at least one listen address,
-/// otherwise the WebRTC transport is skipped at startup.
+/// otherwise, the WebRTC transport is not initialized.
 #[derive(Debug)]
 pub struct Config {
     /// WebRTC listening address.

--- a/src/transport/webrtc/config.rs
+++ b/src/transport/webrtc/config.rs
@@ -31,6 +31,8 @@ use crate::transport::webrtc::certificate::DtlsCertificate;
 #[derive(Debug)]
 pub struct Config {
     /// WebRTC listening address.
+    ///
+    /// Unspecified addresses (`0.0.0.0` / `[::]`) are not supported.
     pub listen_addresses: Vec<Multiaddr>,
 
     /// Connection datagram buffer size.

--- a/src/transport/webrtc/config.rs
+++ b/src/transport/webrtc/config.rs
@@ -22,6 +22,8 @@
 
 use multiaddr::Multiaddr;
 
+use crate::transport::webrtc::certificate::DtlsCertificate;
+
 /// WebRTC transport configuration.
 ///
 /// To be valid, the configuration must contain at least one listen address,
@@ -38,9 +40,8 @@ pub struct Config {
 
     /// Optional pre-generated DTLS certificate.
     ///
-    /// Accepts encoded bytes, when `None`, a fresh certificate
-    /// is generated on every start.
-    pub raw_certificate: Option<Vec<u8>>,
+    /// If `None`, a fresh certificate is generated on every start.
+    pub certificate: Option<DtlsCertificate>,
 }
 
 impl Config {
@@ -60,7 +61,7 @@ impl Default for Config {
                 .parse()
                 .expect("valid multiaddress")],
             datagram_buffer_size: 2048,
-            raw_certificate: None,
+            certificate: None,
         }
     }
 }

--- a/src/transport/webrtc/config.rs
+++ b/src/transport/webrtc/config.rs
@@ -32,6 +32,12 @@ pub struct Config {
     ///
     /// How many datagrams can the buffer between `WebRtcTransport` and a connection handler hold.
     pub datagram_buffer_size: usize,
+
+    /// Optional pre-generated DTLS certificate.
+    ///
+    /// Accepts encoded bytes, when `None`, a fresh certificate
+    /// is generated on every start.
+    pub raw_dtls_certificate: Option<Vec<u8>>,
 }
 
 impl Default for Config {
@@ -41,6 +47,7 @@ impl Default for Config {
                 .parse()
                 .expect("valid multiaddress")],
             datagram_buffer_size: 2048,
+            raw_dtls_certificate: None,
         }
     }
 }

--- a/src/transport/webrtc/config.rs
+++ b/src/transport/webrtc/config.rs
@@ -23,6 +23,9 @@
 use multiaddr::Multiaddr;
 
 /// WebRTC transport configuration.
+///
+/// To be valid, the configuration must contain at least one listen address,
+/// otherwise the WebRTC transport is skipped at startup.
 #[derive(Debug)]
 pub struct Config {
     /// WebRTC listening address.
@@ -38,6 +41,16 @@ pub struct Config {
     /// Accepts encoded bytes, when `None`, a fresh certificate
     /// is generated on every start.
     pub raw_dtls_certificate: Option<Vec<u8>>,
+}
+
+impl Config {
+    /// Returns `true` if the WebRTC configuration is usable.
+    ///
+    /// A configuration is valid only when it specifies at least one listen
+    /// address.
+    pub fn is_valid(&self) -> bool {
+        !self.listen_addresses.is_empty()
+    }
 }
 
 impl Default for Config {

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -39,6 +39,9 @@ impl WebRtcListener {
 
         let handle_multiaddr = |listen_socket| -> crate::Result<(UdpSocket, SocketAddr)> {
             let listen_socket = Self::get_socket_address(&listen_socket)?;
+            // Unspecified addresses (`0.0.0.0` / `[::]`) are rejected,
+            // WebRTC ICE candidates must carry a concrete IP, so the listener must
+            // be bound to a specific address of a local interface.
             if listen_socket.ip().is_unspecified() {
                 return Err(Error::Other(
                     "WebRTC cannot listen on an unspecified address".to_string(),

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -63,7 +63,7 @@ use std::{
 
 pub(crate) use substream::Substream;
 
-pub mod certificate;
+mod certificate;
 mod connection;
 mod listener;
 mod opening;

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -63,7 +63,7 @@ use std::{
 
 pub(crate) use substream::Substream;
 
-mod certificate;
+pub mod certificate;
 mod connection;
 mod listener;
 mod opening;
@@ -71,7 +71,7 @@ mod substream;
 mod util;
 
 pub mod config;
-pub use certificate::{decode, encode, generate_certificate, validate_certificate};
+pub use certificate::DtlsCertificate;
 
 pub(super) mod schema {
     pub(super) mod webrtc {
@@ -432,17 +432,14 @@ impl TransportBuilder for WebRtcTransport {
             "start webrtc transport",
         );
 
-        let dtls_cert = match config.raw_certificate {
-            Some(raw_bytes) => {
-                let certificate = certificate::decode(raw_bytes)?;
-                certificate::validate_certificate(&certificate)?;
-                certificate
-            }
+        let dtls_cert: DtlsCert = match config.certificate {
+            Some(certificate) => certificate.into(),
             None => {
                 tracing::debug!(target: LOG_TARGET, "generating temporary WebRtc certificate");
-                certificate::generate_certificate()?
+                DtlsCertificate::new()?.into()
             }
         };
+
         // OpenSsl is used as crypto backend to generate the certificate, it uses sha256.
         let cert_hash = multihash_codetable::Code::Sha2_256.digest(&dtls_cert.certificate);
 

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -432,7 +432,7 @@ impl TransportBuilder for WebRtcTransport {
             "start webrtc transport",
         );
 
-        let dtls_cert = match config.raw_dtls_certificate {
+        let dtls_cert = match config.raw_certificate {
             Some(raw_bytes) => {
                 let certificate = certificate::decode(raw_bytes)?;
                 certificate::validate_certificate(&certificate)?;

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -42,8 +42,6 @@ use multihash_codetable::MultihashDigest;
 use str0m::{
     channel::{ChannelConfig, ChannelId},
     config::DtlsCert,
-    crypto::CryptoError,
-    error::DtlsError,
     ice::IceCreds,
     net::{DatagramRecv, Protocol as Str0mProtocol, Receive},
     Candidate, Input, Rtc, RtcError,
@@ -65,6 +63,7 @@ use std::{
 
 pub(crate) use substream::Substream;
 
+mod certificate;
 mod connection;
 mod listener;
 mod opening;
@@ -72,6 +71,7 @@ mod substream;
 mod util;
 
 pub mod config;
+pub use certificate::{decode, encode, generate_certificate, validate_certificate};
 
 pub(super) mod schema {
     pub(super) mod webrtc {
@@ -432,19 +432,19 @@ impl TransportBuilder for WebRtcTransport {
             "start webrtc transport",
         );
 
-        // OpenSsl as crypto provider is specified through the 'openssl' str0m feature flag.
-        let crypto_provider = str0m::crypto::from_feature_flags();
-        let dtls_cert = crypto_provider.dtls_provider.generate_certificate().ok_or(
-            crate::error::Error::WebRtc(RtcError::Dtls(DtlsError::CryptoError(
-                CryptoError::Other("OpenSsl failed to generate certificate".to_string()),
-            ))),
-        )?;
-
-        let fingerprint = crypto_provider.sha256_provider.sha256(&dtls_cert.certificate);
-        let cert_hash = multihash_codetable::Code::Sha2_256.wrap(&fingerprint).map_err(|err| {
-            tracing::warn!(target: LOG_TARGET, ?err, "failed to wrap WebRTC certificate");
-            Error::Other("could not compute WebRTC certificate".to_string())
-        })?;
+        let dtls_cert = match config.raw_dtls_certificate {
+            Some(raw_bytes) => {
+                let certificate = certificate::decode(raw_bytes)?;
+                certificate::validate_certificate(&certificate)?;
+                certificate
+            }
+            None => {
+                tracing::debug!(target: LOG_TARGET, "generating temporary WebRtc certificate");
+                certificate::generate_certificate()?
+            }
+        };
+        // OpenSsl is used as crypto backend to generate the certificate, it uses sha256.
+        let cert_hash = multihash_codetable::Code::Sha2_256.digest(&dtls_cert.certificate);
 
         let (listener, listen_multi_addresses) =
             WebRtcListener::new(config.listen_addresses, cert_hash)?;


### PR DESCRIPTION
add generate, encode, decode and validate functionalities for webrtc certificate, this to allow creating a persistent version which needs to be saved by the user and specified on every start-up to create a consistent multiaddr.

NOTE: while developing the validation, I discovered that str0m panics if the specified DTLS cert is not valid, it doesn't return an error.

To implement the `validate_certificate` function I used `catch_unwind`, but there are several problems with this approach. Two of them are:

1. It isn't pretty, and doesn't feel safe to rely on. `catch_unwind` is not foolproof, and there will still be traces of the panic that happened within str0m.
2. The main construction of the WebRTC instance can technically panic, but this should not happen: when the certificate is specified by the user, it is validated before being used, and when it is generated on the fly, it is not expected to cause any issue, at least according to what I gathered from the str0m docs.

EDIT: after multiple comments and discussion this PR has been simplified quite a lot. Now litep2p has only the bare minimum objective of wrapping `str0m` dtls certificate and provide and easy way to the caller to generate and to save it somewhere to make it persistent across run.
