### PR TITLE
kad: Implement client-server mode for Kademlia

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,12 @@ use crate::{
     config::Litep2pConfig,
     error::DialError,
     protocol::{
-        libp2p::{bitswap::Bitswap, identify::Identify, kademlia::Kademlia, ping::Ping},
+        libp2p::{
+            bitswap::Bitswap,
+            identify::Identify,
+            kademlia::{Kademlia, KademliaMode},
+            ping::Ping,
+        },
         mdns::Mdns,
         notification::NotificationProtocol,
         request_response::RequestResponseProtocol,
@@ -265,12 +270,20 @@ impl Litep2p {
         }
 
         // start kademlia protocol event loops
+        //
+        // protocol names of client-mode instances are not advertised via identify
+        let mut unadvertised_protocols = Vec::new();
         for kademlia_config in litep2p_config.kademlia.into_iter() {
             tracing::debug!(
                 target: LOG_TARGET,
                 protocol_names = ?kademlia_config.protocol_names,
+                mode = ?kademlia_config.mode,
                 "enable ipfs kademlia protocol",
             );
+
+            if kademlia_config.mode == KademliaMode::Client {
+                unadvertised_protocols.extend(kademlia_config.protocol_names.iter().cloned());
+            }
 
             let main_protocol =
                 kademlia_config.protocol_names.first().expect("protocol name to exist");
@@ -402,9 +415,14 @@ impl Litep2p {
             }));
         }
 
-        // if identify was enabled, give it the enabled protocols and listen addresses and start it
-        if let Some((service, mut identify_config)) = identify_info.take() {
-            identify_config.protocols = transport_manager.protocols().cloned().collect();
+        // if identify was enabled, give it the advertised protocols and listen addresses and
+        // start it
+        if let Some((service, identify_config)) = identify_info.take() {
+            *identify_config.protocols.write() = transport_manager
+                .protocols()
+                .filter(|protocol| !unadvertised_protocols.contains(protocol))
+                .cloned()
+                .collect();
             let identify = Identify::new(service, identify_config);
 
             litep2p_config.executor.run(Box::pin(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,12 +417,8 @@ impl Litep2p {
 
         // if identify was enabled, give it the advertised protocols and listen addresses and
         // start it
-        if let Some((service, identify_config)) = identify_info.take() {
-            *identify_config.protocols.write() = transport_manager
-                .protocols()
-                .filter(|protocol| !unadvertised_protocols.contains(protocol))
-                .cloned()
-                .collect();
+        if let Some((service, mut identify_config)) = identify_info.take() {
+            identify_config.protocols = transport_manager.protocols().cloned().collect();
             let identify = Identify::new(service, identify_config);
 
             litep2p_config.executor.run(Box::pin(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,7 @@ use crate::{
         SubstreamKeepAlive,
     },
     transport::{
-        manager::{
-            AdvertiseProtocol, SupportedTransport, TransportManager, TransportManagerBuilder,
-        },
+        manager::{InboundProtocol, SupportedTransport, TransportManager, TransportManagerBuilder},
         tcp::TcpTransport,
         TransportBuilder, TransportEvent,
     },
@@ -207,7 +205,7 @@ impl Litep2p {
                 config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::Yes,
-                AdvertiseProtocol::Yes,
+                InboundProtocol::Accept,
             );
             let executor = Arc::clone(&litep2p_config.executor);
             litep2p_config.executor.run(Box::pin(async move {
@@ -229,7 +227,7 @@ impl Litep2p {
                 config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::Yes,
-                AdvertiseProtocol::Yes,
+                InboundProtocol::Accept,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 RequestResponseProtocol::new(service, config).run().await
@@ -247,7 +245,7 @@ impl Litep2p {
                 litep2p_config.keep_alive_timeout,
                 // TODO: make configurable by user.
                 SubstreamKeepAlive::Yes,
-                AdvertiseProtocol::Yes,
+                InboundProtocol::Accept,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 let _ = protocol.run(service).await;
@@ -268,7 +266,7 @@ impl Litep2p {
                 ping_config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::No,
-                AdvertiseProtocol::Yes,
+                InboundProtocol::Accept,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 Ping::new(service, ping_config).run().await
@@ -288,11 +286,11 @@ impl Litep2p {
                 kademlia_config.protocol_names.first().expect("protocol name to exist");
             let fallback_names = kademlia_config.protocol_names.iter().skip(1).cloned().collect();
 
-            // client-mode instances don't answer inbound requests, so their protocol names
-            // are not advertised
-            let advertise = match kademlia_config.mode {
-                KademliaMode::Client => AdvertiseProtocol::No,
-                KademliaMode::Server => AdvertiseProtocol::Yes,
+            // client-mode instances don't answer inbound requests, so their protocol names are
+            // neither advertised nor negotiated on substreams opened by remote peers
+            let inbound = match kademlia_config.mode {
+                KademliaMode::Client => InboundProtocol::Deny,
+                KademliaMode::Server => InboundProtocol::Accept,
             };
 
             let service = transport_manager.register_protocol(
@@ -301,7 +299,7 @@ impl Litep2p {
                 kademlia_config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::Yes,
-                advertise,
+                inbound,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 let _ = Kademlia::new(service, kademlia_config).run().await;
@@ -324,7 +322,7 @@ impl Litep2p {
                     identify_config.codec,
                     litep2p_config.keep_alive_timeout,
                     SubstreamKeepAlive::No,
-                    AdvertiseProtocol::Yes,
+                    InboundProtocol::Accept,
                 );
                 identify_config.public = Some(litep2p_config.keypair.public().into());
 
@@ -346,7 +344,7 @@ impl Litep2p {
                 bitswap_config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::Yes,
-                AdvertiseProtocol::Yes,
+                InboundProtocol::Accept,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 Bitswap::new(service, bitswap_config).run().await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,9 @@ use crate::{
         SubstreamKeepAlive,
     },
     transport::{
-        manager::{SupportedTransport, TransportManager, TransportManagerBuilder},
+        manager::{
+            AdvertiseProtocol, SupportedTransport, TransportManager, TransportManagerBuilder,
+        },
         tcp::TcpTransport,
         TransportBuilder, TransportEvent,
     },
@@ -205,6 +207,7 @@ impl Litep2p {
                 config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::Yes,
+                AdvertiseProtocol::Yes,
             );
             let executor = Arc::clone(&litep2p_config.executor);
             litep2p_config.executor.run(Box::pin(async move {
@@ -226,6 +229,7 @@ impl Litep2p {
                 config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::Yes,
+                AdvertiseProtocol::Yes,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 RequestResponseProtocol::new(service, config).run().await
@@ -243,6 +247,7 @@ impl Litep2p {
                 litep2p_config.keep_alive_timeout,
                 // TODO: make configurable by user.
                 SubstreamKeepAlive::Yes,
+                AdvertiseProtocol::Yes,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 let _ = protocol.run(service).await;
@@ -263,6 +268,7 @@ impl Litep2p {
                 ping_config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::No,
+                AdvertiseProtocol::Yes,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 Ping::new(service, ping_config).run().await
@@ -270,9 +276,6 @@ impl Litep2p {
         }
 
         // start kademlia protocol event loops
-        //
-        // protocol names of client-mode instances are not advertised via identify
-        let mut unadvertised_protocols = Vec::new();
         for kademlia_config in litep2p_config.kademlia.into_iter() {
             tracing::debug!(
                 target: LOG_TARGET,
@@ -281,13 +284,16 @@ impl Litep2p {
                 "enable ipfs kademlia protocol",
             );
 
-            if kademlia_config.mode == KademliaMode::Client {
-                unadvertised_protocols.extend(kademlia_config.protocol_names.iter().cloned());
-            }
-
             let main_protocol =
                 kademlia_config.protocol_names.first().expect("protocol name to exist");
             let fallback_names = kademlia_config.protocol_names.iter().skip(1).cloned().collect();
+
+            // client-mode instances don't answer inbound requests, so their protocol names
+            // are not advertised
+            let advertise = match kademlia_config.mode {
+                KademliaMode::Client => AdvertiseProtocol::No,
+                KademliaMode::Server => AdvertiseProtocol::Yes,
+            };
 
             let service = transport_manager.register_protocol(
                 main_protocol.clone(),
@@ -295,6 +301,7 @@ impl Litep2p {
                 kademlia_config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::Yes,
+                advertise,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 let _ = Kademlia::new(service, kademlia_config).run().await;
@@ -317,6 +324,7 @@ impl Litep2p {
                     identify_config.codec,
                     litep2p_config.keep_alive_timeout,
                     SubstreamKeepAlive::No,
+                    AdvertiseProtocol::Yes,
                 );
                 identify_config.public = Some(litep2p_config.keypair.public().into());
 
@@ -338,6 +346,7 @@ impl Litep2p {
                 bitswap_config.codec,
                 litep2p_config.keep_alive_timeout,
                 SubstreamKeepAlive::Yes,
+                AdvertiseProtocol::Yes,
             );
             litep2p_config.executor.run(Box::pin(async move {
                 Bitswap::new(service, bitswap_config).run().await
@@ -418,7 +427,7 @@ impl Litep2p {
         // if identify was enabled, give it the advertised protocols and listen addresses and
         // start it
         if let Some((service, mut identify_config)) = identify_info.take() {
-            identify_config.protocols = transport_manager.protocols().cloned().collect();
+            identify_config.protocols = transport_manager.advertised_protocols().cloned().collect();
             let identify = Identify::new(service, identify_config);
 
             litep2p_config.executor.run(Box::pin(async move {

--- a/src/protocol/libp2p/identify.rs
+++ b/src/protocol/libp2p/identify.rs
@@ -34,12 +34,14 @@ use crate::{
 
 use futures::{future::BoxFuture, Stream, StreamExt};
 use multiaddr::Multiaddr;
+use parking_lot::RwLock;
 use prost::Message;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio_stream::wrappers::ReceiverStream;
 
 use std::{
     collections::{HashMap, HashSet},
+    sync::Arc,
     time::Duration,
 };
 
@@ -63,6 +65,9 @@ mod identify_schema {
     include!(concat!(env!("OUT_DIR"), "/identify.rs"));
 }
 
+/// Protocols advertised to remote peers, shared so they can be updated at runtime.
+pub(crate) type AdvertisedProtocols = Arc<RwLock<HashSet<ProtocolName>>>;
+
 /// Identify configuration.
 pub struct Config {
     /// Protocol name.
@@ -77,8 +82,8 @@ pub struct Config {
     // Public key of the local node, filled by `Litep2p`.
     pub(crate) public: Option<PublicKey>,
 
-    /// Protocols supported by the local node, filled by `Litep2p`.
-    pub(crate) protocols: Vec<ProtocolName>,
+    /// Protocols advertised by the local node, filled by `Litep2p`.
+    pub(crate) protocols: AdvertisedProtocols,
 
     /// Protocol version.
     pub(crate) protocol_version: String,
@@ -105,7 +110,7 @@ impl Config {
                 protocol_version,
                 user_agent,
                 codec: ProtocolCodec::UnsignedVarint(Some(IDENTIFY_PAYLOAD_SIZE)),
-                protocols: Vec::new(),
+                protocols: Default::default(),
                 protocol: ProtocolName::from(PROTOCOL_NAME),
             },
             Box::new(ReceiverStream::new(rx_event)),
@@ -181,8 +186,8 @@ pub(crate) struct Identify {
     /// User agent.
     user_agent: String,
 
-    /// Protocols supported by the local node, filled by `Litep2p`.
-    protocols: Vec<String>,
+    /// Protocols advertised by the local node, filled by `Litep2p`.
+    protocols: AdvertisedProtocols,
 
     /// Pending outbound substreams.
     pending_outbound: FuturesStream<BoxFuture<'static, crate::Result<IdentifyResponse>>>,
@@ -210,7 +215,7 @@ impl Identify {
             user_agent: config.user_agent.unwrap_or(DEFAULT_AGENT.to_string()),
             pending_inbound: FuturesStream::new(),
             pending_outbound: FuturesStream::new(),
-            protocols: config.protocols.iter().map(|protocol| protocol.to_string()).collect(),
+            protocols: config.protocols,
         }
     }
 
@@ -269,7 +274,7 @@ impl Identify {
             public_key: Some(self.public.to_protobuf_encoding()),
             listen_addrs: listen_addr.into_iter().collect(),
             observed_addr,
-            protocols: self.protocols.clone(),
+            protocols: self.protocols.read().iter().map(|protocol| protocol.to_string()).collect(),
         };
 
         tracing::trace!(

--- a/src/protocol/libp2p/identify.rs
+++ b/src/protocol/libp2p/identify.rs
@@ -34,14 +34,12 @@ use crate::{
 
 use futures::{future::BoxFuture, Stream, StreamExt};
 use multiaddr::Multiaddr;
-use parking_lot::RwLock;
 use prost::Message;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio_stream::wrappers::ReceiverStream;
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
     time::Duration,
 };
 
@@ -65,9 +63,6 @@ mod identify_schema {
     include!(concat!(env!("OUT_DIR"), "/identify.rs"));
 }
 
-/// Protocols advertised to remote peers, shared so they can be updated at runtime.
-pub(crate) type AdvertisedProtocols = Arc<RwLock<HashSet<ProtocolName>>>;
-
 /// Identify configuration.
 pub struct Config {
     /// Protocol name.
@@ -82,8 +77,8 @@ pub struct Config {
     // Public key of the local node, filled by `Litep2p`.
     pub(crate) public: Option<PublicKey>,
 
-    /// Protocols advertised by the local node, filled by `Litep2p`.
-    pub(crate) protocols: AdvertisedProtocols,
+    /// Protocols supported by the local node, filled by `Litep2p`.
+    pub(crate) protocols: Vec<ProtocolName>,
 
     /// Protocol version.
     pub(crate) protocol_version: String,
@@ -110,7 +105,7 @@ impl Config {
                 protocol_version,
                 user_agent,
                 codec: ProtocolCodec::UnsignedVarint(Some(IDENTIFY_PAYLOAD_SIZE)),
-                protocols: Default::default(),
+                protocols: Vec::new(),
                 protocol: ProtocolName::from(PROTOCOL_NAME),
             },
             Box::new(ReceiverStream::new(rx_event)),
@@ -186,8 +181,8 @@ pub(crate) struct Identify {
     /// User agent.
     user_agent: String,
 
-    /// Protocols advertised by the local node, filled by `Litep2p`.
-    protocols: AdvertisedProtocols,
+    /// Protocols supported by the local node, filled by `Litep2p`.
+    protocols: Vec<String>,
 
     /// Pending outbound substreams.
     pending_outbound: FuturesStream<BoxFuture<'static, crate::Result<IdentifyResponse>>>,
@@ -215,7 +210,7 @@ impl Identify {
             user_agent: config.user_agent.unwrap_or(DEFAULT_AGENT.to_string()),
             pending_inbound: FuturesStream::new(),
             pending_outbound: FuturesStream::new(),
-            protocols: config.protocols,
+            protocols: config.protocols.iter().map(|protocol| protocol.to_string()).collect(),
         }
     }
 
@@ -274,7 +269,7 @@ impl Identify {
             public_key: Some(self.public.to_protobuf_encoding()),
             listen_addrs: listen_addr.into_iter().collect(),
             observed_addr,
-            protocols: self.protocols.read().iter().map(|protocol| protocol.to_string()).collect(),
+            protocols: self.protocols.clone(),
         };
 
         tracing::trace!(

--- a/src/protocol/libp2p/kademlia/config.rs
+++ b/src/protocol/libp2p/kademlia/config.rs
@@ -23,7 +23,7 @@ use crate::{
     protocol::libp2p::kademlia::{
         handle::{
             IncomingRecordValidationMode, KademliaCommand, KademliaEvent, KademliaHandle,
-            RoutingTableUpdateMode,
+            KademliaMode, RoutingTableUpdateMode,
         },
         store::MemoryStoreConfig,
     },
@@ -93,6 +93,9 @@ pub struct Config {
     /// Routing table update mode.
     pub(super) update_mode: RoutingTableUpdateMode,
 
+    /// Operating mode.
+    pub(crate) mode: KademliaMode,
+
     /// Incoming records validation mode.
     pub(super) validation_mode: IncomingRecordValidationMode,
 
@@ -118,6 +121,7 @@ impl Config {
         known_peers: HashMap<PeerId, Vec<Multiaddr>>,
         mut protocol_names: Vec<ProtocolName>,
         update_mode: RoutingTableUpdateMode,
+        mode: KademliaMode,
         validation_mode: IncomingRecordValidationMode,
         record_ttl: Duration,
         memory_store_config: MemoryStoreConfig,
@@ -136,6 +140,7 @@ impl Config {
             Config {
                 protocol_names,
                 update_mode,
+                mode,
                 validation_mode,
                 record_ttl,
                 memory_store_config,
@@ -157,6 +162,7 @@ impl Config {
             HashMap::new(),
             Vec::new(),
             RoutingTableUpdateMode::Automatic,
+            KademliaMode::Server,
             IncomingRecordValidationMode::Automatic,
             DEFAULT_TTL,
             Default::default(),
@@ -173,6 +179,9 @@ pub struct ConfigBuilder {
 
     /// Routing table update mode.
     pub(super) update_mode: RoutingTableUpdateMode,
+
+    /// Operating mode.
+    pub(super) mode: KademliaMode,
 
     /// Incoming records validation mode.
     pub(super) validation_mode: IncomingRecordValidationMode,
@@ -207,6 +216,7 @@ impl ConfigBuilder {
             known_peers: HashMap::new(),
             protocol_names: Vec::new(),
             update_mode: RoutingTableUpdateMode::Automatic,
+            mode: KademliaMode::default(),
             validation_mode: IncomingRecordValidationMode::Automatic,
             record_ttl: DEFAULT_TTL,
             memory_store_config: Default::default(),
@@ -229,6 +239,19 @@ impl ConfigBuilder {
     /// Set routing table update mode.
     pub fn with_routing_table_update_mode(mut self, mode: RoutingTableUpdateMode) -> Self {
         self.update_mode = mode;
+        self
+    }
+
+    /// Sets the operating mode.
+    ///
+    /// By default, Substrate nodes operate in server mode.
+    ///
+    /// Light clients, or nodes that need to query DHT information without
+    /// participating in DHT routing, should use client mode.
+    ///
+    /// Defaults to [`KademliaMode::Server`].
+    pub fn with_mode(mut self, mode: KademliaMode) -> Self {
+        self.mode = mode;
         self
     }
 
@@ -335,6 +358,7 @@ impl ConfigBuilder {
             self.known_peers,
             self.protocol_names,
             self.update_mode,
+            self.mode,
             self.validation_mode,
             self.record_ttl,
             self.memory_store_config,

--- a/src/protocol/libp2p/kademlia/config.rs
+++ b/src/protocol/libp2p/kademlia/config.rs
@@ -23,7 +23,7 @@ use crate::{
     protocol::libp2p::kademlia::{
         handle::{
             IncomingRecordValidationMode, KademliaCommand, KademliaEvent, KademliaHandle,
-            KademliaMode, RoutingTableUpdateMode,
+            RoutingTableUpdateMode,
         },
         store::MemoryStoreConfig,
     },
@@ -113,6 +113,17 @@ pub struct Config {
 
     /// Next query ID counter shared with the handle.
     pub(super) next_query_id: Arc<AtomicUsize>,
+}
+
+/// Kademlia operating mode.
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub enum KademliaMode {
+    /// Don't answer inbound requests and don't advertise the protocol via identify.
+    Client,
+
+    /// Answer inbound requests and participate fully in the DHT.
+    #[default]
+    Server,
 }
 
 impl Config {

--- a/src/protocol/libp2p/kademlia/executor.rs
+++ b/src/protocol/libp2p/kademlia/executor.rs
@@ -112,6 +112,12 @@ impl QueryExecutor {
         }
     }
 
+    /// Check if the executor has no pending operations.
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.futures.is_empty()
+    }
+
     /// Send message to remote peer.
     pub fn send_message(
         &mut self,

--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -76,6 +76,17 @@ pub enum IncomingRecordValidationMode {
     Automatic,
 }
 
+/// Kademlia operating mode.
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub enum KademliaMode {
+    /// Don't answer inbound requests and don't advertise the protocol via identify.
+    Client,
+
+    /// Answer inbound requests and participate fully in the DHT.
+    #[default]
+    Server,
+}
+
 /// Kademlia commands.
 #[derive(Debug)]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]

--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -76,17 +76,6 @@ pub enum IncomingRecordValidationMode {
     Automatic,
 }
 
-/// Kademlia operating mode.
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
-pub enum KademliaMode {
-    /// Don't answer inbound requests and don't advertise the protocol via identify.
-    Client,
-
-    /// Answer inbound requests and participate fully in the DHT.
-    #[default]
-    Server,
-}
-
 /// Kademlia commands.
 #[derive(Debug)]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]

--- a/src/protocol/libp2p/kademlia/handle.rs
+++ b/src/protocol/libp2p/kademlia/handle.rs
@@ -193,14 +193,14 @@ pub enum KademliaEvent {
 
     /// Routing table update.
     ///
-    /// Kademlia has discovered one or more peers that should be added to the routing table.
-    /// If [`RoutingTableUpdateMode`] is `Automatic`, user can ignore this event unless some
-    /// upper-level protocols has user for this information.
+    /// A peer answered one of our queries, proving it operates in server mode, and should be
+    /// added to the routing table. If [`RoutingTableUpdateMode`] is `Automatic`, user can ignore
+    /// this event unless some upper-level protocols has user for this information.
     ///
     /// If the mode was set to `Manual`, user should call [`KademliaHandle::add_known_peer()`]
     /// in order to add the peers to routing table.
     RoutingTableUpdate {
-        /// Discovered peers.
+        /// Peers proven to operate in server mode.
         peers: Vec<PeerId>,
     },
 

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -56,8 +56,8 @@ use std::{
 
 pub use config::{Config, ConfigBuilder};
 pub use handle::{
-    IncomingRecordValidationMode, KademliaCommand, KademliaEvent, KademliaHandle, Quorum,
-    RoutingTableUpdateMode,
+    IncomingRecordValidationMode, KademliaCommand, KademliaEvent, KademliaHandle, KademliaMode,
+    Quorum, RoutingTableUpdateMode,
 };
 pub use query::QueryId;
 pub use record::{ContentProvider, Key as RecordKey, PeerRecord, Record};
@@ -169,6 +169,9 @@ pub(crate) struct Kademlia {
     /// Routing table update mode.
     update_mode: RoutingTableUpdateMode,
 
+    /// Operating mode.
+    mode: KademliaMode,
+
     /// Incoming records validation mode.
     validation_mode: IncomingRecordValidationMode,
 
@@ -211,6 +214,7 @@ impl Kademlia {
             executor: QueryExecutor::new(),
             pending_substreams: HashMap::new(),
             update_mode: config.update_mode,
+            mode: config.mode,
             validation_mode: config.validation_mode,
             record_ttl: config.record_ttl,
             replication_factor: config.replication_factor,
@@ -415,6 +419,12 @@ impl Kademlia {
     async fn on_inbound_substream(&mut self, peer: PeerId, substream: Substream) {
         tracing::trace!(target: LOG_TARGET, ?peer, "inbound substream opened");
 
+        if let KademliaMode::Client = self.mode {
+            tracing::trace!(target: LOG_TARGET, ?peer, "ignoring inbound substream in client mode");
+            let _ = substream.close().await;
+            return;
+        }
+
         // Ensure peer entry exists to treat peer as [`ConnectionType::Connected`].
         // when inserting into the routing table.
         self.peers.entry(peer).or_default();
@@ -422,11 +432,11 @@ impl Kademlia {
         self.executor.read_message(peer, None, substream);
     }
 
-    /// Update routing table if the routing table update mode was set to automatic.
+    /// Report peers discovered in a query response to the user and register their addresses.
     ///
-    /// Inform user about the potential routing table, allowing them to update it manually if
-    /// the mode was set to manual.
-    async fn update_routing_table(&mut self, peers: &[KademliaPeer]) {
+    /// Discovered peers are not inserted into the routing table as they haven't proven
+    /// they operate in server mode; they remain usable as query candidates.
+    async fn report_discovered_peers(&mut self, peers: &[KademliaPeer]) {
         let peers: Vec<_> =
             peers.iter().filter(|peer| peer.peer != self.service.local_peer_id()).collect();
 
@@ -440,19 +450,24 @@ impl Kademlia {
             .await;
 
         for info in peers {
-            let addresses = info.addresses();
-            self.service.add_known_address(&info.peer, addresses.clone().into_iter());
-
-            if std::matches!(self.update_mode, RoutingTableUpdateMode::Automatic) {
-                self.routing_table.add_known_peer(
-                    info.peer,
-                    addresses,
-                    self.peers
-                        .get(&info.peer)
-                        .map_or(ConnectionType::NotConnected, |_| ConnectionType::Connected),
-                );
-            }
+            self.service.add_known_address(&info.peer, info.addresses().into_iter());
         }
+    }
+
+    /// Insert a peer that answered one of our queries, proving it operates in server mode,
+    /// into the routing table if the update mode is automatic.
+    fn insert_proven_server(&mut self, proven: &KademliaPeer) {
+        if !std::matches!(self.update_mode, RoutingTableUpdateMode::Automatic) {
+            return;
+        }
+
+        self.routing_table.add_known_peer(
+            proven.peer,
+            proven.addresses(),
+            self.peers
+                .get(&proven.peer)
+                .map_or(ConnectionType::NotConnected, |_| ConnectionType::Connected),
+        );
     }
 
     /// Handle received message.
@@ -479,13 +494,16 @@ impl Kademlia {
                             "handle `FIND_NODE` response",
                         );
 
-                        // update routing table and inform user about the update
-                        self.update_routing_table(&peers).await;
-                        self.engine.register_response(
+                        // inform user about the discovered peers and update routing table
+                        // with the proven responder
+                        self.report_discovered_peers(&peers).await;
+                        if let Some(proven) = self.engine.register_response(
                             query_id,
                             peer,
                             KademliaMessage::FindNode { target, peers },
-                        );
+                        ) {
+                            self.insert_proven_server(&proven);
+                        }
                         substream.close().await;
                     }
                     None => {
@@ -515,7 +533,7 @@ impl Kademlia {
                         "handle `PUT_VALUE` response",
                     );
 
-                    self.engine.register_response(
+                    let _ = self.engine.register_response(
                         query_id,
                         peer,
                         KademliaMessage::PutValue { record },
@@ -559,14 +577,16 @@ impl Kademlia {
                             "handle `GET_VALUE` response",
                         );
 
-                        // update routing table and inform user about the update
-                        self.update_routing_table(&peers).await;
-
-                        self.engine.register_response(
+                        // inform user about the discovered peers and update routing table
+                        // with the proven responder
+                        self.report_discovered_peers(&peers).await;
+                        if let Some(proven) = self.engine.register_response(
                             query_id,
                             peer,
                             KademliaMessage::GetRecord { key, record, peers },
-                        );
+                        ) {
+                            self.insert_proven_server(&proven);
+                        }
 
                         substream.close().await;
                     }
@@ -665,10 +685,10 @@ impl Kademlia {
                             "handle `GET_PROVIDERS` response",
                         );
 
-                        // update routing table and inform user about the update
-                        self.update_routing_table(&peers).await;
-
-                        self.engine.register_response(
+                        // inform user about the discovered peers and update routing table
+                        // with the proven responder
+                        self.report_discovered_peers(&peers).await;
+                        if let Some(proven) = self.engine.register_response(
                             query_id,
                             peer,
                             KademliaMessage::GetProviders {
@@ -676,7 +696,9 @@ impl Kademlia {
                                 peers,
                                 providers,
                             },
-                        );
+                        ) {
+                            self.insert_proven_server(&proven);
+                        }
 
                         substream.close().await;
                     }
@@ -1416,6 +1438,7 @@ mod tests {
     use super::*;
     use crate::{
         codec::ProtocolCodec,
+        mock::substream::MockSubstream,
         transport::{
             manager::{SubstreamKeepAlive, TransportManager, TransportManagerBuilder},
             KEEP_ALIVE_TIMEOUT,
@@ -1424,7 +1447,7 @@ mod tests {
         ConnectionId,
     };
     use multiaddr::Protocol;
-    use std::str::FromStr;
+    use std::{collections::VecDeque, str::FromStr, task::Poll};
     use tokio::sync::mpsc::channel;
 
     #[allow(unused)]
@@ -1434,6 +1457,10 @@ mod tests {
     }
 
     fn make_kademlia() -> (Kademlia, Context, TransportManager) {
+        make_kademlia_with_mode(KademliaMode::Server)
+    }
+
+    fn make_kademlia_with_mode(mode: KademliaMode) -> (Kademlia, Context, TransportManager) {
         let manager = TransportManagerBuilder::new().build();
 
         let peer = PeerId::random();
@@ -1456,6 +1483,7 @@ mod tests {
             codec: ProtocolCodec::UnsignedVarint(Some(70 * 1024)),
             replication_factor: 20usize,
             update_mode: RoutingTableUpdateMode::Automatic,
+            mode,
             validation_mode: IncomingRecordValidationMode::Automatic,
             record_ttl: Duration::from_secs(36 * 60 * 60),
             memory_store_config: Default::default(),
@@ -1643,5 +1671,130 @@ mod tests {
             }
             _ => panic!("Peer not found in routing table"),
         };
+    }
+
+    #[tokio::test]
+    async fn client_mode_ignores_inbound_substreams() {
+        let (mut kademlia, _context, _manager) = make_kademlia_with_mode(KademliaMode::Client);
+
+        let peer = PeerId::random();
+        let mut substream = MockSubstream::new();
+        substream.expect_poll_close().times(1).return_once(|_| Poll::Ready(Ok(())));
+        let substream = Substream::new_mock(peer, SubstreamId::from(0usize), Box::new(substream));
+
+        kademlia.on_inbound_substream(peer, substream).await;
+
+        // the substream was closed without being scheduled for reading and the peer
+        // was not registered
+        assert!(kademlia.peers.is_empty());
+        assert!(kademlia.executor.is_empty());
+    }
+
+    #[tokio::test]
+    async fn server_mode_accepts_inbound_substreams() {
+        let (mut kademlia, _context, _manager) = make_kademlia();
+
+        let peer = PeerId::random();
+        let substream = Substream::new_mock(
+            peer,
+            SubstreamId::from(0usize),
+            Box::new(MockSubstream::new()),
+        );
+
+        kademlia.on_inbound_substream(peer, substream).await;
+
+        assert!(kademlia.peers.contains_key(&peer));
+        assert!(!kademlia.executor.is_empty());
+    }
+
+    #[tokio::test]
+    async fn responder_inserted_into_routing_table_discovered_peers_not() {
+        let (mut kademlia, mut context, _manager) = make_kademlia();
+
+        let responder_peer = PeerId::random();
+        let responder = KademliaPeer::new(
+            responder_peer,
+            vec![Multiaddr::from_str("/dns/responder.com/tcp/30333")
+                .unwrap()
+                .with(Protocol::P2p(responder_peer.into()))],
+            ConnectionType::NotConnected,
+        );
+
+        let discovered_peer = PeerId::random();
+        let discovered = KademliaPeer::new(
+            discovered_peer,
+            vec![Multiaddr::from_str("/dns/discovered.com/tcp/30333")
+                .unwrap()
+                .with(Protocol::P2p(discovered_peer.into()))],
+            ConnectionType::NotConnected,
+        );
+
+        let query_id = QueryId(0);
+        kademlia.engine.start_find_node(
+            query_id,
+            PeerId::random(),
+            VecDeque::from([responder.clone()]),
+        );
+
+        // move the responder to the engine's pending set
+        match kademlia.engine.next_action() {
+            Some(QueryAction::SendMessage { peer, .. }) => assert_eq!(peer, responder_peer),
+            action => panic!("unexpected action: {action:?}"),
+        }
+
+        // simulate handling a `FIND_NODE` response from the responder listing `discovered`
+        let peers = vec![discovered.clone()];
+        kademlia.report_discovered_peers(&peers).await;
+        let proven = kademlia
+            .engine
+            .register_response(
+                query_id,
+                responder_peer,
+                KademliaMessage::FindNode {
+                    target: Vec::new(),
+                    peers,
+                },
+            )
+            .expect("responder to be returned as proven server");
+        kademlia.insert_proven_server(&proven);
+
+        // only the responder was inserted into the routing table
+        assert!(std::matches!(
+            kademlia.routing_table.entry(Key::from(responder_peer)),
+            KBucketEntry::Occupied(_)
+        ));
+        assert!(std::matches!(
+            kademlia.routing_table.entry(Key::from(discovered_peer)),
+            KBucketEntry::Vacant(_)
+        ));
+
+        // the discovered peer was still reported to the user
+        match context.event_rx.try_recv() {
+            Ok(KademliaEvent::RoutingTableUpdate { peers }) => {
+                assert_eq!(peers, vec![discovered_peer]);
+            }
+            event => panic!("unexpected event: {event:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unexpected_responder_not_inserted_into_routing_table() {
+        let (mut kademlia, _context, _manager) = make_kademlia();
+
+        let responder_peer = PeerId::random();
+        kademlia.engine.start_find_node(QueryId(0), PeerId::random(), VecDeque::new());
+
+        // the responder was never queried, so it must not be proven
+        assert!(kademlia
+            .engine
+            .register_response(
+                QueryId(0),
+                responder_peer,
+                KademliaMessage::FindNode {
+                    target: Vec::new(),
+                    peers: Vec::new(),
+                },
+            )
+            .is_none());
     }
 }

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -532,11 +532,14 @@ impl Kademlia {
                         "handle `PUT_VALUE` response",
                     );
 
-                    let _ = self.engine.register_response(
+                    // update routing table with the proven responder
+                    if let Some(proven) = self.engine.register_response(
                         query_id,
                         peer,
                         KademliaMessage::PutValue { record },
-                    );
+                    ) {
+                        self.insert_proven_server(&proven).await;
+                    }
                     substream.close().await;
                 }
                 None => {
@@ -924,12 +927,8 @@ impl Kademlia {
                     }
                 }
 
-                self.engine.start_put_record_to_found_nodes_requests_tracking(
-                    query,
-                    key,
-                    peers.into_iter().map(|peer| peer.peer).collect(),
-                    quorum,
-                );
+                self.engine
+                    .start_put_record_to_found_nodes_requests_tracking(query, key, peers, quorum);
 
                 Ok(())
             }
@@ -980,7 +979,7 @@ impl Kademlia {
                 self.engine.start_add_provider_to_found_nodes_requests_tracking(
                     query,
                     provided_key,
-                    peers.into_iter().map(|peer| peer.peer).collect(),
+                    peers,
                     quorum,
                 );
 
@@ -1775,6 +1774,59 @@ mod tests {
             event => panic!("unexpected event: {event:?}"),
         }
         assert!(context.event_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn put_value_responder_inserted_into_routing_table() {
+        let (mut kademlia, mut context, _manager) = make_kademlia();
+
+        let responder_peer = PeerId::random();
+        let responder = KademliaPeer::new(
+            responder_peer,
+            vec![Multiaddr::from_str("/dns/responder.com/tcp/30333")
+                .unwrap()
+                .with(Protocol::P2p(responder_peer.into()))],
+            ConnectionType::NotConnected,
+        );
+
+        let query_id = QueryId(0);
+        let record = Record::new(RecordKey::from(vec![1, 2, 3]), vec![4, 5, 6]);
+        kademlia.engine.start_put_record_to_found_nodes_requests_tracking(
+            query_id,
+            record.key.clone(),
+            vec![responder],
+            Quorum::One,
+        );
+
+        // simulate handling the `PUT_VALUE` response of the responder
+        let mut substream = MockSubstream::new();
+        substream.expect_poll_close().times(1).return_once(|_| Poll::Ready(Ok(())));
+        let message = KademliaMessage::put_value_response(record.key.clone(), record.value.clone());
+        kademlia
+            .on_message_received(
+                responder_peer,
+                Some(query_id),
+                BytesMut::from(&message[..]),
+                Substream::new_mock(
+                    responder_peer,
+                    SubstreamId::from(0usize),
+                    Box::new(substream),
+                ),
+            )
+            .await
+            .unwrap();
+
+        // answering the `PUT_VALUE` proves the responder operates in server mode
+        assert!(std::matches!(
+            kademlia.routing_table.entry(Key::from(responder_peer)),
+            KBucketEntry::Occupied(_)
+        ));
+        match context.event_rx.try_recv() {
+            Ok(KademliaEvent::RoutingTableUpdate { peers }) => {
+                assert_eq!(peers, vec![responder_peer]);
+            }
+            event => panic!("unexpected event: {event:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -54,10 +54,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-pub use config::{Config, ConfigBuilder};
+pub use config::{Config, ConfigBuilder, KademliaMode};
 pub use handle::{
-    IncomingRecordValidationMode, KademliaCommand, KademliaEvent, KademliaHandle, KademliaMode,
-    Quorum, RoutingTableUpdateMode,
+    IncomingRecordValidationMode, KademliaCommand, KademliaEvent, KademliaHandle, Quorum,
+    RoutingTableUpdateMode,
 };
 pub use query::QueryId;
 pub use record::{ContentProvider, Key as RecordKey, PeerRecord, Record};

--- a/src/protocol/libp2p/kademlia/mod.rs
+++ b/src/protocol/libp2p/kademlia/mod.rs
@@ -432,31 +432,30 @@ impl Kademlia {
         self.executor.read_message(peer, None, substream);
     }
 
-    /// Report peers discovered in a query response to the user and register their addresses.
+    /// Register the addresses of the peers discovered in a query response.
     ///
     /// Discovered peers are not inserted into the routing table as they haven't proven
     /// they operate in server mode; they remain usable as query candidates.
-    async fn report_discovered_peers(&mut self, peers: &[KademliaPeer]) {
-        let peers: Vec<_> =
-            peers.iter().filter(|peer| peer.peer != self.service.local_peer_id()).collect();
+    fn register_discovered_peers(&mut self, peers: &[KademliaPeer]) {
+        let local_peer_id = self.service.local_peer_id();
 
-        // inform user about the routing table update, regardless of what the routing table update
-        // mode is
-        let _ = self
-            .event_tx
-            .send(KademliaEvent::RoutingTableUpdate {
-                peers: peers.iter().map(|peer| peer.peer).collect::<Vec<PeerId>>(),
-            })
-            .await;
-
-        for info in peers {
+        for info in peers.iter().filter(|peer| peer.peer != local_peer_id) {
             self.service.add_known_address(&info.peer, info.addresses().into_iter());
         }
     }
 
     /// Insert a peer that answered one of our queries, proving it operates in server mode,
     /// into the routing table if the update mode is automatic.
-    fn insert_proven_server(&mut self, proven: &KademliaPeer) {
+    async fn insert_proven_server(&mut self, proven: &KademliaPeer) {
+        // inform user about the routing table update, regardless of what the routing table update
+        // mode is
+        let _ = self
+            .event_tx
+            .send(KademliaEvent::RoutingTableUpdate {
+                peers: vec![proven.peer],
+            })
+            .await;
+
         if !std::matches!(self.update_mode, RoutingTableUpdateMode::Automatic) {
             return;
         }
@@ -494,15 +493,15 @@ impl Kademlia {
                             "handle `FIND_NODE` response",
                         );
 
-                        // inform user about the discovered peers and update routing table
-                        // with the proven responder
-                        self.report_discovered_peers(&peers).await;
+                        // register the discovered peers and update routing table with the
+                        // proven responder
+                        self.register_discovered_peers(&peers);
                         if let Some(proven) = self.engine.register_response(
                             query_id,
                             peer,
                             KademliaMessage::FindNode { target, peers },
                         ) {
-                            self.insert_proven_server(&proven);
+                            self.insert_proven_server(&proven).await;
                         }
                         substream.close().await;
                     }
@@ -577,15 +576,15 @@ impl Kademlia {
                             "handle `GET_VALUE` response",
                         );
 
-                        // inform user about the discovered peers and update routing table
-                        // with the proven responder
-                        self.report_discovered_peers(&peers).await;
+                        // register the discovered peers and update routing table with the
+                        // proven responder
+                        self.register_discovered_peers(&peers);
                         if let Some(proven) = self.engine.register_response(
                             query_id,
                             peer,
                             KademliaMessage::GetRecord { key, record, peers },
                         ) {
-                            self.insert_proven_server(&proven);
+                            self.insert_proven_server(&proven).await;
                         }
 
                         substream.close().await;
@@ -685,9 +684,9 @@ impl Kademlia {
                             "handle `GET_PROVIDERS` response",
                         );
 
-                        // inform user about the discovered peers and update routing table
-                        // with the proven responder
-                        self.report_discovered_peers(&peers).await;
+                        // register the discovered peers and update routing table with the
+                        // proven responder
+                        self.register_discovered_peers(&peers);
                         if let Some(proven) = self.engine.register_response(
                             query_id,
                             peer,
@@ -697,7 +696,7 @@ impl Kademlia {
                                 providers,
                             },
                         ) {
-                            self.insert_proven_server(&proven);
+                            self.insert_proven_server(&proven).await;
                         }
 
                         substream.close().await;
@@ -1744,7 +1743,7 @@ mod tests {
 
         // simulate handling a `FIND_NODE` response from the responder listing `discovered`
         let peers = vec![discovered.clone()];
-        kademlia.report_discovered_peers(&peers).await;
+        kademlia.register_discovered_peers(&peers);
         let proven = kademlia
             .engine
             .register_response(
@@ -1756,7 +1755,7 @@ mod tests {
                 },
             )
             .expect("responder to be returned as proven server");
-        kademlia.insert_proven_server(&proven);
+        kademlia.insert_proven_server(&proven).await;
 
         // only the responder was inserted into the routing table
         assert!(std::matches!(
@@ -1768,13 +1767,14 @@ mod tests {
             KBucketEntry::Vacant(_)
         ));
 
-        // the discovered peer was still reported to the user
+        // only the routing table update of the proven responder is reported to the user
         match context.event_rx.try_recv() {
             Ok(KademliaEvent::RoutingTableUpdate { peers }) => {
-                assert_eq!(peers, vec![discovered_peer]);
+                assert_eq!(peers, vec![responder_peer]);
             }
             event => panic!("unexpected event: {event:?}"),
         }
+        assert!(context.event_rx.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/src/protocol/libp2p/kademlia/query/find_node.rs
+++ b/src/protocol/libp2p/kademlia/query/find_node.rs
@@ -133,11 +133,18 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
     }
 
     /// Register `FIND_NODE` response from `peer`.
-    pub fn register_response(&mut self, peer: PeerId, peers: Vec<KademliaPeer>) {
+    ///
+    /// Returns the responding peer, proving it operates in server mode.
+    pub fn register_response(
+        &mut self,
+        peer: PeerId,
+        peers: Vec<KademliaPeer>,
+    ) -> Option<KademliaPeer> {
         let Some((peer, instant)) = self.pending.remove(&peer) else {
             tracing::debug!(target: LOG_TARGET, query = ?self.config.query, ?peer, "received response from peer but didn't expect it");
-            return;
+            return None;
         };
+        let proven_responder = peer.clone();
         self.pending_responses = self.pending_responses.saturating_sub(1);
 
         tracing::trace!(target: LOG_TARGET, query = ?self.config.query, ?peer, elapsed = ?instant.elapsed(), "received response from peer");
@@ -192,6 +199,8 @@ impl<T: Clone + Into<Vec<u8>>> FindNodeContext<T> {
             let distance = self.config.target.distance(&candidate.key);
             self.candidates.insert(distance, candidate);
         }
+
+        Some(proven_responder)
     }
 
     /// Register a failure of sending `FIN_NODE` request to `peer`.
@@ -357,6 +366,23 @@ mod tests {
         };
 
         (closest, furthest, config)
+    }
+
+    #[test]
+    fn register_response_returns_proven_responder() {
+        let config = default_config();
+        let peer = PeerId::random();
+        let mut context = FindNodeContext::new(config, VecDeque::from([peer_to_kad(peer)]));
+
+        // move the candidate to the pending set
+        let _ = context.next_action();
+        assert!(context.pending.contains_key(&peer));
+
+        let proven = context.register_response(peer, vec![]).expect("proven responder");
+        assert_eq!(proven.peer, peer);
+
+        // a peer that was never queried produces no proof
+        assert!(context.register_response(PeerId::random(), vec![]).is_none());
     }
 
     #[test]

--- a/src/protocol/libp2p/kademlia/query/get_providers.rs
+++ b/src/protocol/libp2p/kademlia/query/get_providers.rs
@@ -153,12 +153,14 @@ impl GetProvidersContext {
     }
 
     /// Register `GET_PROVIDERS` response from `peer`.
+    ///
+    /// Returns the responding peer, proving it operates in server mode.
     pub fn register_response(
         &mut self,
         peer: PeerId,
         providers: impl IntoIterator<Item = KademliaPeer>,
         closer_peers: impl IntoIterator<Item = KademliaPeer>,
-    ) {
+    ) -> Option<KademliaPeer> {
         tracing::trace!(
             target: LOG_TARGET,
             query = ?self.config.query,
@@ -173,7 +175,7 @@ impl GetProvidersContext {
                 ?peer,
                 "`GetProvidersContext`: received response from peer but didn't expect it",
             );
-            return;
+            return None;
         };
 
         self.found_providers.extend(providers);
@@ -205,6 +207,8 @@ impl GetProvidersContext {
             let distance = self.config.target.distance(&candidate.key);
             self.candidates.insert(distance, candidate);
         }
+
+        Some(peer)
     }
 
     /// Register a failure of sending a `GET_PROVIDERS` request to `peer`.

--- a/src/protocol/libp2p/kademlia/query/get_record.rs
+++ b/src/protocol/libp2p/kademlia/query/get_record.rs
@@ -152,13 +152,13 @@ impl GetRecordContext {
 
     /// Register `GET_VALUE` response from `peer`.
     ///
-    /// Returns some if the response should be propagated to the user.
+    /// Returns the responding peer, proving it operates in server mode.
     pub fn register_response(
         &mut self,
         peer: PeerId,
         record: Option<Record>,
         peers: Vec<KademliaPeer>,
-    ) {
+    ) -> Option<KademliaPeer> {
         tracing::trace!(
             target: LOG_TARGET,
             query = ?self.config.query,
@@ -173,7 +173,7 @@ impl GetRecordContext {
                 ?peer,
                 "`GetRecordContext`: received response from peer but didn't expect it",
             );
-            return;
+            return None;
         };
 
         if let Some(record) = record {
@@ -214,6 +214,8 @@ impl GetRecordContext {
             let distance = self.config.target.distance(&candidate.key);
             self.candidates.insert(distance, candidate);
         }
+
+        Some(peer)
     }
 
     /// Register a failure of sending a `GET_VALUE` request to `peer`.

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -568,17 +568,23 @@ impl QueryEngine {
     }
 
     /// Register that `response` received from `peer`.
-    pub fn register_response(&mut self, query: QueryId, peer: PeerId, message: KademliaMessage) {
+    ///
+    /// Returns the peer that provided the response, if the peer operates in server mode.
+    pub fn register_response(
+        &mut self,
+        query: QueryId,
+        peer: PeerId,
+        message: KademliaMessage,
+    ) -> Option<KademliaPeer> {
         tracing::trace!(target: LOG_TARGET, ?query, ?peer, "register response");
 
         match self.queries.get_mut(&query) {
             None => {
                 tracing::trace!(target: LOG_TARGET, ?query, ?peer, "response for a stale query");
+                None
             }
             Some(QueryType::FindNode { context }) => match message {
-                KademliaMessage::FindNode { peers, .. } => {
-                    context.register_response(peer, peers);
-                }
+                KademliaMessage::FindNode { peers, .. } => context.register_response(peer, peers),
                 message => {
                     tracing::debug!(
                         target: LOG_TARGET,
@@ -587,12 +593,11 @@ impl QueryEngine {
                         "unexpected response to `FIND_NODE`: {message}",
                     );
                     context.register_response_failure(peer);
+                    None
                 }
             },
             Some(QueryType::PutRecord { context, .. }) => match message {
-                KademliaMessage::FindNode { peers, .. } => {
-                    context.register_response(peer, peers);
-                }
+                KademliaMessage::FindNode { peers, .. } => context.register_response(peer, peers),
                 message => {
                     tracing::debug!(
                         target: LOG_TARGET,
@@ -601,11 +606,13 @@ impl QueryEngine {
                         "unexpected response to `FIND_NODE` during `PUT_VALUE` query: {message}",
                     );
                     context.register_response_failure(peer);
+                    None
                 }
             },
             Some(QueryType::PutRecordToPeers { context, .. }) => match message {
                 KademliaMessage::FindNode { peers, .. } => {
                     context.register_response(peer, peers);
+                    None
                 }
                 message => {
                     tracing::debug!(
@@ -615,11 +622,13 @@ impl QueryEngine {
                         "unexpected response to `FIND_NODE` during `PUT_VALUE` (to peers): {message}",
                     );
                     context.register_response_failure(peer);
+                    None
                 }
             },
             Some(QueryType::PutRecordToFoundNodes { context }) => match message {
                 KademliaMessage::PutValue { .. } => {
                     context.register_response(peer);
+                    None
                 }
                 message => {
                     tracing::debug!(
@@ -629,6 +638,7 @@ impl QueryEngine {
                         "unexpected response to `PUT_VALUE`: {message}",
                     );
                     context.register_response_failure(peer);
+                    None
                 }
             },
             Some(QueryType::GetRecord { context }) => match message {
@@ -642,12 +652,11 @@ impl QueryEngine {
                         "unexpected response to `GET_VALUE`: {message}",
                     );
                     context.register_response_failure(peer);
+                    None
                 }
             },
             Some(QueryType::AddProvider { context, .. }) => match message {
-                KademliaMessage::FindNode { peers, .. } => {
-                    context.register_response(peer, peers);
-                }
+                KademliaMessage::FindNode { peers, .. } => context.register_response(peer, peers),
                 message => {
                     tracing::debug!(
                         target: LOG_TARGET,
@@ -656,11 +665,13 @@ impl QueryEngine {
                         "unexpected response to `FIND_NODE` during `ADD_PROVIDER` query: {message}",
                     );
                     context.register_response_failure(peer);
+                    None
                 }
             },
             Some(QueryType::AddProviderToFoundNodes { context, .. }) => match message {
                 KademliaMessage::AddProvider { .. } => {
                     context.register_response(peer);
+                    None
                 }
                 message => {
                     tracing::debug!(
@@ -670,6 +681,7 @@ impl QueryEngine {
                         "unexpected response to `ADD_PROVIDER`: {message}",
                     );
                     context.register_response_failure(peer);
+                    None
                 }
             },
             Some(QueryType::GetProviders { context }) => match message {
@@ -677,9 +689,7 @@ impl QueryEngine {
                     key: _,
                     providers,
                     peers,
-                } => {
-                    context.register_response(peer, providers, peers);
-                }
+                } => context.register_response(peer, providers, peers),
                 message => {
                     tracing::debug!(
                         target: LOG_TARGET,
@@ -688,6 +698,7 @@ impl QueryEngine {
                         "unexpected response to `GET_PROVIDERS`: {message}",
                     );
                     context.register_response_failure(peer);
+                    None
                 }
             },
         }

--- a/src/protocol/libp2p/kademlia/query/mod.rs
+++ b/src/protocol/libp2p/kademlia/query/mod.rs
@@ -491,7 +491,7 @@ impl QueryEngine {
         &mut self,
         query_id: QueryId,
         key: RecordKey,
-        peers: Vec<PeerId>,
+        peers: Vec<KademliaPeer>,
         quorum: Quorum,
     ) {
         tracing::debug!(
@@ -514,7 +514,7 @@ impl QueryEngine {
         &mut self,
         query_id: QueryId,
         provided_key: RecordKey,
-        peers: Vec<PeerId>,
+        peers: Vec<KademliaPeer>,
         quorum: Quorum,
     ) {
         tracing::debug!(
@@ -626,10 +626,7 @@ impl QueryEngine {
                 }
             },
             Some(QueryType::PutRecordToFoundNodes { context }) => match message {
-                KademliaMessage::PutValue { .. } => {
-                    context.register_response(peer);
-                    None
-                }
+                KademliaMessage::PutValue { .. } => context.register_response(peer),
                 message => {
                     tracing::debug!(
                         target: LOG_TARGET,
@@ -669,6 +666,9 @@ impl QueryEngine {
                 }
             },
             Some(QueryType::AddProviderToFoundNodes { context, .. }) => match message {
+                // TODO: the spec defines no response to `ADD_PROVIDER`, so to learn that the peer
+                // operates in server mode we should track the substream opening & message sending
+                // success instead.
                 KademliaMessage::AddProvider { .. } => {
                     context.register_response(peer);
                     None
@@ -1202,7 +1202,7 @@ mod tests {
         engine.start_put_record_to_found_nodes_requests_tracking(
             original_query_id,
             record_key.clone(),
-            peers.iter().map(|p| p.peer).collect(),
+            peers.clone(),
             Quorum::All,
         );
 
@@ -1335,7 +1335,7 @@ mod tests {
         engine.start_put_record_to_found_nodes_requests_tracking(
             original_query_id,
             record_key.clone(),
-            peers.iter().map(|p| p.peer).collect(),
+            peers.clone(),
             Quorum::All,
         );
 
@@ -1534,7 +1534,7 @@ mod tests {
         engine.start_put_record_to_found_nodes_requests_tracking(
             original_query_id,
             record_key.clone(),
-            peers.iter().map(|p| p.peer).collect(),
+            peers.clone(),
             Quorum::One,
         );
 
@@ -1741,7 +1741,7 @@ mod tests {
         engine.start_add_provider_to_found_nodes_requests_tracking(
             original_query_id,
             original_provided_key.clone(),
-            peers.iter().map(|p| p.peer).collect(),
+            peers.clone(),
             Quorum::All,
         );
 
@@ -1880,7 +1880,7 @@ mod tests {
         engine.start_add_provider_to_found_nodes_requests_tracking(
             add_query_id,
             original_provided_key.clone(),
-            peers.iter().map(|p| p.peer).collect(),
+            peers.clone(),
             Quorum::All,
         );
 
@@ -2067,7 +2067,7 @@ mod tests {
         engine.start_add_provider_to_found_nodes_requests_tracking(
             add_query_id,
             original_provided_key.clone(),
-            peers.iter().map(|p| p.peer).collect(),
+            peers.clone(),
             Quorum::One,
         );
 

--- a/src/protocol/libp2p/kademlia/query/target_peers.rs
+++ b/src/protocol/libp2p/kademlia/query/target_peers.rs
@@ -18,11 +18,16 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 use crate::{
-    protocol::libp2p::kademlia::{handle::Quorum, query::QueryAction, QueryId, RecordKey},
+    protocol::libp2p::kademlia::{
+        handle::Quorum, query::QueryAction, types::KademliaPeer, QueryId, RecordKey,
+    },
     PeerId,
 };
 
-use std::{cmp, collections::HashSet};
+use std::{
+    cmp,
+    collections::{HashMap, HashSet},
+};
 
 /// Logging target for this file.
 const LOG_TARGET: &str = "litep2p::ipfs::kademlia::query::target_peers";
@@ -39,6 +44,9 @@ pub struct PutToTargetPeersContext {
     /// Quorum that needs to be reached for the query to succeed.
     peers_to_succeed: usize,
 
+    /// Peers the request was sent to and their addresses.
+    peers: HashMap<PeerId, KademliaPeer>,
+
     /// Peers we're waiting for responses from.
     pending_peers: HashSet<PeerId>,
 
@@ -48,7 +56,7 @@ pub struct PutToTargetPeersContext {
 
 impl PutToTargetPeersContext {
     /// Create new [`PutToTargetPeersContext`].
-    pub fn new(query: QueryId, key: RecordKey, peers: Vec<PeerId>, quorum: Quorum) -> Self {
+    pub fn new(query: QueryId, key: RecordKey, peers: Vec<KademliaPeer>, quorum: Quorum) -> Self {
         Self {
             query,
             key,
@@ -60,7 +68,8 @@ impl PutToTargetPeersContext {
                 Quorum::N(n) => cmp::min(n.get(), cmp::max(peers.len(), 1)),
                 Quorum::All => cmp::max(peers.len(), 1),
             },
-            pending_peers: peers.into_iter().collect(),
+            pending_peers: peers.iter().map(|peer| peer.peer).collect(),
+            peers: peers.into_iter().map(|peer| (peer.peer, peer)).collect(),
             n_succeeded: 0,
         }
     }
@@ -106,7 +115,9 @@ impl PutToTargetPeersContext {
     }
 
     /// Register successful response from peer.
-    pub fn register_response(&mut self, _peer: PeerId) {
+    ///
+    /// Returns the responding peer, as answering proves it operates in server mode.
+    pub fn register_response(&mut self, peer: PeerId) -> Option<KademliaPeer> {
         // Currently we only track if we successfully sent the message to the peer both for
         // `PUT_VALUE` and `ADD_PROVIDER`. While `PUT_VALUE` has a response message, due to litep2p
         // not sending it in the past, tracking it would frequently result in reporting query
@@ -114,6 +125,8 @@ impl PutToTargetPeersContext {
 
         // TODO: once most of the network is on a litep2p version that sends `PUT_VALUE` responses,
         // we should track them.
+
+        self.peers.get(&peer).cloned()
     }
 
     /// Register failed response from peer.

--- a/src/protocol/protocol_set.rs
+++ b/src/protocol/protocol_set.rs
@@ -496,7 +496,7 @@ impl Stream for ProtocolSet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock::substream::MockSubstream;
+    use crate::{mock::substream::MockSubstream, transport::manager::AdvertiseProtocol};
     use std::collections::HashSet;
 
     #[tokio::test]
@@ -518,6 +518,7 @@ mod tests {
                         ProtocolName::from("/notif/1/fallback/2"),
                     ],
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         );
@@ -568,6 +569,7 @@ mod tests {
                         ProtocolName::from("/notif/1/fallback/2"),
                     ],
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         );
@@ -618,6 +620,7 @@ mod tests {
                         ProtocolName::from("/notif/1/fallback/2"),
                     ],
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         );

--- a/src/protocol/protocol_set.rs
+++ b/src/protocol/protocol_set.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     substream::Substream,
     transport::{
-        manager::{ProtocolContext, TransportManagerEvent},
+        manager::{InboundProtocol, ProtocolContext, TransportManagerEvent},
         Endpoint,
     },
     types::{protocol::ProtocolName, ConnectionId, SubstreamId},
@@ -259,20 +259,22 @@ impl ProtocolSet {
             })
             .collect::<HashMap<_, _>>();
 
+        // Protocols that don't serve inbound substreams are omitted, which makes the negotiation
+        // of their names fail on inbound substreams.
         let main_keep_alives = protocols
             .iter()
+            .filter(|(_, context)| context.inbound == InboundProtocol::Accept)
             .map(|(name, context)| (name.clone(), context.keep_alive))
             .collect::<Vec<_>>();
         let fallback_keep_alives = fallback_names
             .iter()
-            .map(|(fallback, main)| {
-                (
-                    fallback.clone(),
-                    protocols
-                        .get(main)
-                        .expect("all main protocols are present due to construction above; qed")
-                        .keep_alive,
-                )
+            .filter_map(|(fallback, main)| {
+                let context = protocols
+                    .get(main)
+                    .expect("all main protocols are present due to construction above; qed");
+
+                (context.inbound == InboundProtocol::Accept)
+                    .then(|| (fallback.clone(), context.keep_alive))
             })
             .collect::<Vec<_>>();
         let keep_alives = main_keep_alives.into_iter().chain(fallback_keep_alives).collect();
@@ -496,7 +498,7 @@ impl Stream for ProtocolSet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{mock::substream::MockSubstream, transport::manager::AdvertiseProtocol};
+    use crate::{mock::substream::MockSubstream, transport::manager::InboundProtocol};
     use std::collections::HashSet;
 
     #[tokio::test]
@@ -518,7 +520,7 @@ mod tests {
                         ProtocolName::from("/notif/1/fallback/2"),
                     ],
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         );
@@ -551,6 +553,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inbound_negotiation_denied() {
+        let (tx, _rx) = channel(64);
+        let (tx1, _rx1) = channel(64);
+        let (tx2, _rx2) = channel(64);
+
+        let protocol_set = ProtocolSet::new(
+            ConnectionId::from(0usize),
+            tx,
+            Default::default(),
+            HashMap::from_iter([
+                (
+                    ProtocolName::from("/kad/1"),
+                    ProtocolContext {
+                        tx: tx1,
+                        codec: ProtocolCodec::UnsignedVarint(None),
+                        fallback_names: vec![ProtocolName::from("/kad/1/fallback")],
+                        keep_alive: SubstreamKeepAlive::Yes,
+                        inbound: InboundProtocol::Deny,
+                    },
+                ),
+                (
+                    ProtocolName::from("/notif/1"),
+                    ProtocolContext {
+                        tx: tx2,
+                        codec: ProtocolCodec::Identity(32),
+                        fallback_names: vec![ProtocolName::from("/notif/1/fallback")],
+                        keep_alive: SubstreamKeepAlive::Yes,
+                        inbound: InboundProtocol::Accept,
+                    },
+                ),
+            ]),
+        );
+
+        // the denied protocol and its fallback are not offered to remote peers, which makes
+        // `multistream-select` reject them on inbound substreams
+        assert_eq!(
+            protocol_set.protocols_with_keep_alives().into_keys().collect::<HashSet<_>>(),
+            HashSet::from([
+                ProtocolName::from("/notif/1"),
+                ProtocolName::from("/notif/1/fallback"),
+            ]),
+        );
+
+        // the protocol is still installed so that it can open outbound substreams
+        assert_eq!(
+            protocol_set.protocols().into_iter().collect::<HashSet<_>>(),
+            HashSet::from([
+                ProtocolName::from("/kad/1"),
+                ProtocolName::from("/kad/1/fallback"),
+                ProtocolName::from("/notif/1"),
+                ProtocolName::from("/notif/1/fallback"),
+            ]),
+        );
+    }
+
+    #[tokio::test]
     async fn main_protocol_reported_if_main_protocol_negotiated() {
         let (tx, _rx) = channel(64);
         let (tx1, mut rx1) = channel(64);
@@ -569,7 +627,7 @@ mod tests {
                         ProtocolName::from("/notif/1/fallback/2"),
                     ],
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         );
@@ -620,7 +678,7 @@ mod tests {
                         ProtocolName::from("/notif/1/fallback/2"),
                     ],
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         );

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -95,6 +95,15 @@ pub enum TransportManagerEvent {
     },
 }
 
+/// Whether the protocol name is advertised to remote peers via the identify protocol.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AdvertiseProtocol {
+    /// Protocol is advertised.
+    Yes,
+    /// Protocol is not advertised (ie client mode kademlia).
+    No,
+}
+
 // Protocol context.
 #[derive(Debug, Clone)]
 pub struct ProtocolContext {
@@ -109,6 +118,9 @@ pub struct ProtocolContext {
 
     /// Whether this protocol existing substreams should keep connection alive.
     pub keep_alive: SubstreamKeepAlive,
+
+    /// Whether the protocol name is advertised to remote peers.
+    pub advertise: AdvertiseProtocol,
 }
 
 impl ProtocolContext {
@@ -118,12 +130,14 @@ impl ProtocolContext {
         tx: Sender<InnerTransportEvent>,
         fallback_names: Vec<ProtocolName>,
         keep_alive: SubstreamKeepAlive,
+        advertise: AdvertiseProtocol,
     ) -> Self {
         Self {
             tx,
             codec,
             fallback_names,
             keep_alive,
+            advertise,
         }
     }
 }
@@ -365,9 +379,12 @@ impl TransportManagerBuilder {
 }
 
 impl TransportManager {
-    /// Get iterator to installed protocols.
-    pub fn protocols(&self) -> impl Iterator<Item = &ProtocolName> {
-        self.protocols.keys()
+    /// Get iterator to installed protocols that are advertised to remote peers.
+    pub fn advertised_protocols(&self) -> impl Iterator<Item = &ProtocolName> {
+        self.protocols
+            .iter()
+            .filter(|(_, context)| context.advertise == AdvertiseProtocol::Yes)
+            .map(|(protocol, _)| protocol)
     }
 
     /// Get iterator to installed transports
@@ -391,6 +408,9 @@ impl TransportManager {
     ///
     /// This allocates new context for the protocol and returns a handle
     /// which the protocol can use the interact with the transport subsystem.
+    ///
+    /// `advertise` controls whether the protocol name is exposed to remote peers via the identify
+    /// protocol.
     pub fn register_protocol(
         &mut self,
         protocol: ProtocolName,
@@ -398,6 +418,7 @@ impl TransportManager {
         codec: ProtocolCodec,
         keep_alive_timeout: Duration,
         substream_keep_alive: SubstreamKeepAlive,
+        advertise: AdvertiseProtocol,
     ) -> TransportService {
         assert!(!self.protocol_names.contains(&protocol));
 
@@ -419,7 +440,13 @@ impl TransportManager {
 
         self.protocols.insert(
             protocol.clone(),
-            ProtocolContext::new(codec, sender, fallback_names.clone(), substream_keep_alive),
+            ProtocolContext::new(
+                codec,
+                sender,
+                fallback_names.clone(),
+                substream_keep_alive,
+                advertise,
+            ),
         );
         self.protocol_names.insert(protocol);
         self.protocol_names.extend(fallback_names);
@@ -1686,6 +1713,33 @@ mod tests {
     }
 
     #[test]
+    fn only_advertised_protocols_are_reported() {
+        let mut manager = TransportManagerBuilder::new().build();
+
+        manager.register_protocol(
+            ProtocolName::from("/advertised/1"),
+            vec![ProtocolName::from("/advertised/1/fallback")],
+            ProtocolCodec::UnsignedVarint(None),
+            KEEP_ALIVE_TIMEOUT,
+            SubstreamKeepAlive::Yes,
+            AdvertiseProtocol::Yes,
+        );
+        manager.register_protocol(
+            ProtocolName::from("/local/1"),
+            Vec::new(),
+            ProtocolCodec::UnsignedVarint(None),
+            KEEP_ALIVE_TIMEOUT,
+            SubstreamKeepAlive::Yes,
+            AdvertiseProtocol::No,
+        );
+
+        assert_eq!(
+            manager.advertised_protocols().cloned().collect::<HashSet<_>>(),
+            HashSet::from_iter([ProtocolName::from("/advertised/1")]),
+        );
+    }
+
+    #[test]
     #[should_panic]
     #[cfg(debug_assertions)]
     fn duplicate_protocol() {
@@ -1697,6 +1751,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
+            AdvertiseProtocol::Yes,
         );
         manager.register_protocol(
             ProtocolName::from("/notif/1"),
@@ -1704,6 +1759,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
+            AdvertiseProtocol::Yes,
         );
     }
 
@@ -1719,6 +1775,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
+            AdvertiseProtocol::Yes,
         );
         manager.register_protocol(
             ProtocolName::from("/notif/2"),
@@ -1729,6 +1786,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
+            AdvertiseProtocol::Yes,
         );
     }
 
@@ -1747,6 +1805,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
+            AdvertiseProtocol::Yes,
         );
         manager.register_protocol(
             ProtocolName::from("/notif/2"),
@@ -1757,6 +1816,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
+            AdvertiseProtocol::Yes,
         );
     }
 

--- a/src/transport/manager/mod.rs
+++ b/src/transport/manager/mod.rs
@@ -95,13 +95,15 @@ pub enum TransportManagerEvent {
     },
 }
 
-/// Whether the protocol name is advertised to remote peers via the identify protocol.
+/// Whether the protocol serves substreams opened by remote peers.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum AdvertiseProtocol {
-    /// Protocol is advertised.
-    Yes,
-    /// Protocol is not advertised (ie client mode kademlia).
-    No,
+pub enum InboundProtocol {
+    /// Inbound substreams are negotiated and the protocol name is advertised via identify.
+    Accept,
+
+    /// Inbound substreams are rejected during negotiation and the protocol name is not
+    /// advertised via identify (ie client mode kademlia).
+    Deny,
 }
 
 // Protocol context.
@@ -119,8 +121,8 @@ pub struct ProtocolContext {
     /// Whether this protocol existing substreams should keep connection alive.
     pub keep_alive: SubstreamKeepAlive,
 
-    /// Whether the protocol name is advertised to remote peers.
-    pub advertise: AdvertiseProtocol,
+    /// Whether the protocol serves substreams opened by remote peers.
+    pub inbound: InboundProtocol,
 }
 
 impl ProtocolContext {
@@ -130,14 +132,14 @@ impl ProtocolContext {
         tx: Sender<InnerTransportEvent>,
         fallback_names: Vec<ProtocolName>,
         keep_alive: SubstreamKeepAlive,
-        advertise: AdvertiseProtocol,
+        inbound: InboundProtocol,
     ) -> Self {
         Self {
             tx,
             codec,
             fallback_names,
             keep_alive,
-            advertise,
+            inbound,
         }
     }
 }
@@ -383,7 +385,7 @@ impl TransportManager {
     pub fn advertised_protocols(&self) -> impl Iterator<Item = &ProtocolName> {
         self.protocols
             .iter()
-            .filter(|(_, context)| context.advertise == AdvertiseProtocol::Yes)
+            .filter(|(_, context)| context.inbound == InboundProtocol::Accept)
             .map(|(protocol, _)| protocol)
     }
 
@@ -409,8 +411,8 @@ impl TransportManager {
     /// This allocates new context for the protocol and returns a handle
     /// which the protocol can use the interact with the transport subsystem.
     ///
-    /// `advertise` controls whether the protocol name is exposed to remote peers via the identify
-    /// protocol.
+    /// `inbound` controls whether remote peers can negotiate the protocol on inbound substreams
+    /// and whether the protocol name is exposed to them via the identify protocol.
     pub fn register_protocol(
         &mut self,
         protocol: ProtocolName,
@@ -418,7 +420,7 @@ impl TransportManager {
         codec: ProtocolCodec,
         keep_alive_timeout: Duration,
         substream_keep_alive: SubstreamKeepAlive,
-        advertise: AdvertiseProtocol,
+        inbound: InboundProtocol,
     ) -> TransportService {
         assert!(!self.protocol_names.contains(&protocol));
 
@@ -445,7 +447,7 @@ impl TransportManager {
                 sender,
                 fallback_names.clone(),
                 substream_keep_alive,
-                advertise,
+                inbound,
             ),
         );
         self.protocol_names.insert(protocol);
@@ -1722,7 +1724,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
-            AdvertiseProtocol::Yes,
+            InboundProtocol::Accept,
         );
         manager.register_protocol(
             ProtocolName::from("/local/1"),
@@ -1730,7 +1732,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
-            AdvertiseProtocol::No,
+            InboundProtocol::Deny,
         );
 
         assert_eq!(
@@ -1751,7 +1753,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
-            AdvertiseProtocol::Yes,
+            InboundProtocol::Accept,
         );
         manager.register_protocol(
             ProtocolName::from("/notif/1"),
@@ -1759,7 +1761,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
-            AdvertiseProtocol::Yes,
+            InboundProtocol::Accept,
         );
     }
 
@@ -1775,7 +1777,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
-            AdvertiseProtocol::Yes,
+            InboundProtocol::Accept,
         );
         manager.register_protocol(
             ProtocolName::from("/notif/2"),
@@ -1786,7 +1788,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
-            AdvertiseProtocol::Yes,
+            InboundProtocol::Accept,
         );
     }
 
@@ -1805,7 +1807,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
-            AdvertiseProtocol::Yes,
+            InboundProtocol::Accept,
         );
         manager.register_protocol(
             ProtocolName::from("/notif/2"),
@@ -1816,7 +1818,7 @@ mod tests {
             ProtocolCodec::UnsignedVarint(None),
             KEEP_ALIVE_TIMEOUT,
             SubstreamKeepAlive::Yes,
-            AdvertiseProtocol::Yes,
+            InboundProtocol::Accept,
         );
     }
 

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -639,7 +639,7 @@ mod tests {
         crypto::ed25519::Keypair,
         executor::DefaultExecutor,
         protocol::SubstreamKeepAlive,
-        transport::manager::{ProtocolContext, TransportHandle},
+        transport::manager::{AdvertiseProtocol, ProtocolContext, TransportHandle},
         types::protocol::ProtocolName,
         BandwidthSink,
     };
@@ -670,6 +670,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         };
@@ -698,6 +699,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         };

--- a/src/transport/quic/mod.rs
+++ b/src/transport/quic/mod.rs
@@ -639,7 +639,7 @@ mod tests {
         crypto::ed25519::Keypair,
         executor::DefaultExecutor,
         protocol::SubstreamKeepAlive,
-        transport::manager::{AdvertiseProtocol, ProtocolContext, TransportHandle},
+        transport::manager::{InboundProtocol, ProtocolContext, TransportHandle},
         types::protocol::ProtocolName,
         BandwidthSink,
     };
@@ -670,7 +670,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         };
@@ -699,7 +699,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         };

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -732,7 +732,7 @@ mod tests {
         executor::DefaultExecutor,
         protocol::SubstreamKeepAlive,
         transport::manager::{
-            AdvertiseProtocol, ProtocolContext, SupportedTransport, TransportManagerBuilder,
+            InboundProtocol, ProtocolContext, SupportedTransport, TransportManagerBuilder,
         },
         types::protocol::ProtocolName,
         BandwidthSink, PeerId,
@@ -767,7 +767,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         };
@@ -800,7 +800,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         };
@@ -865,7 +865,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         };
@@ -898,7 +898,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         };
@@ -958,7 +958,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         };
@@ -998,7 +998,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
-                    advertise: AdvertiseProtocol::Yes,
+                    inbound: InboundProtocol::Accept,
                 },
             )]),
         };

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -731,7 +731,9 @@ mod tests {
         crypto::ed25519::Keypair,
         executor::DefaultExecutor,
         protocol::SubstreamKeepAlive,
-        transport::manager::{ProtocolContext, SupportedTransport, TransportManagerBuilder},
+        transport::manager::{
+            AdvertiseProtocol, ProtocolContext, SupportedTransport, TransportManagerBuilder,
+        },
         types::protocol::ProtocolName,
         BandwidthSink, PeerId,
     };
@@ -765,6 +767,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         };
@@ -797,6 +800,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         };
@@ -861,6 +865,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         };
@@ -893,6 +898,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         };
@@ -952,6 +958,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         };
@@ -991,6 +998,7 @@ mod tests {
                     codec: ProtocolCodec::Identity(32),
                     fallback_names: Vec::new(),
                     keep_alive: SubstreamKeepAlive::Yes,
+                    advertise: AdvertiseProtocol::Yes,
                 },
             )]),
         };

--- a/tests/conformance/rust/kademlia.rs
+++ b/tests/conformance/rust/kademlia.rs
@@ -34,7 +34,7 @@ use litep2p::{
     config::ConfigBuilder as Litep2pConfigBuilder,
     crypto::ed25519::Keypair,
     protocol::libp2p::kademlia::{
-        ConfigBuilder, KademliaEvent, KademliaHandle, Quorum, Record, RecordKey,
+        ConfigBuilder, KademliaEvent, KademliaHandle, KademliaMode, Quorum, Record, RecordKey,
     },
     transport::tcp::config::Config as TcpConfig,
     types::multiaddr::{Multiaddr, Protocol},
@@ -50,8 +50,12 @@ struct Behaviour {
 
 // initialize litep2p with ping support
 fn initialize_litep2p() -> (Litep2p, KademliaHandle) {
+    initialize_litep2p_with_mode(KademliaMode::Server)
+}
+
+fn initialize_litep2p_with_mode(mode: KademliaMode) -> (Litep2p, KademliaHandle) {
     let keypair = Keypair::generate();
-    let (kad_config, kad_handle) = ConfigBuilder::new().build();
+    let (kad_config, kad_handle) = ConfigBuilder::new().with_mode(mode).build();
 
     let litep2p = Litep2p::new(
         Litep2pConfigBuilder::new()
@@ -653,6 +657,65 @@ async fn libp2p_get_providers_from_litep2p() {
             }
             _ = litep2p.next_event() => {}
             _ = litep2p_kad.next() => {}
+        }
+    }
+}
+
+#[tokio::test]
+async fn litep2p_in_client_mode_queries_libp2p_server() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let mut libp2p = initialize_libp2p();
+    let (mut litep2p, mut kad_handle) = initialize_litep2p_with_mode(KademliaMode::Client);
+
+    #[allow(unused_assignments)]
+    let mut listen_addr = None;
+    let peer_id = *libp2p.local_peer_id();
+
+    loop {
+        if let SwarmEvent::NewListenAddr { address, .. } = libp2p.select_next_some().await {
+            listen_addr = Some(address);
+            break;
+        }
+    }
+
+    tokio::spawn(async move {
+        loop {
+            let _ = libp2p.select_next_some().await;
+        }
+    });
+
+    tokio::spawn(async move {
+        loop {
+            let _ = litep2p.next_event().await;
+        }
+    });
+
+    let listen_addr = listen_addr.unwrap().with(Protocol::P2p(peer_id));
+
+    kad_handle
+        .add_known_peer(
+            litep2p::PeerId::from_bytes(&peer_id.to_bytes()).unwrap(),
+            vec![listen_addr],
+        )
+        .await;
+
+    // the client can still query the libp2p server
+    let target = litep2p::PeerId::random();
+    let _ = kad_handle.find_node(target).await;
+
+    loop {
+        if let Some(KademliaEvent::FindNodeSuccess {
+            target: query_target,
+            peers,
+            ..
+        }) = kad_handle.next().await
+        {
+            assert_eq!(target, query_target);
+            assert!(!peers.is_empty());
+            break;
         }
     }
 }

--- a/tests/conformance/rust/kademlia.rs
+++ b/tests/conformance/rust/kademlia.rs
@@ -719,3 +719,65 @@ async fn litep2p_in_client_mode_queries_libp2p_server() {
         }
     }
 }
+
+/// Drive `libp2p` until it marks `peer` as a connected DHT server in its routing table, giving
+/// up after ten seconds.
+async fn wait_until_marked_as_dht_server(libp2p: &mut Swarm<Behaviour>, peer: PeerId) -> bool {
+    let deadline = tokio::time::sleep(Duration::from_secs(10));
+    tokio::pin!(deadline);
+
+    let mut sampler = tokio::time::interval(Duration::from_millis(100));
+
+    loop {
+        tokio::select! {
+            _ = libp2p.select_next_some() => {}
+            _ = sampler.tick() => {
+                let connected = libp2p.behaviour_mut().kad.kbuckets().any(|bucket| {
+                    bucket.iter().any(|entry| {
+                        entry.node.key.preimage() == &peer
+                            && entry.status == kad::NodeStatus::Connected
+                    })
+                });
+
+                if connected {
+                    return true;
+                }
+            }
+            _ = &mut deadline => return false,
+        }
+    }
+}
+
+/// Verify that a `libp2p` node only considers litep2p part of the DHT if litep2p accepts inbound
+/// substreams for the Kademlia protocol.
+async fn marked_as_dht_server(mode: KademliaMode) -> bool {
+    let (mut litep2p, _kad_handle) = initialize_litep2p_with_mode(mode);
+    let peer = PeerId::from_bytes(&litep2p.local_peer_id().to_bytes()).unwrap();
+    let address = litep2p.listen_addresses().next().unwrap().to_string().parse().unwrap();
+
+    tokio::spawn(async move { while litep2p.next_event().await.is_some() {} });
+
+    let mut libp2p = initialize_libp2p();
+    libp2p.behaviour_mut().kad.add_address(&peer, address);
+    libp2p.behaviour_mut().kad.get_closest_peers(PeerId::random());
+
+    wait_until_marked_as_dht_server(&mut libp2p, peer).await
+}
+
+#[tokio::test]
+async fn server_mode_accepts_inbound_substreams() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    assert!(marked_as_dht_server(KademliaMode::Server).await);
+}
+
+#[tokio::test]
+async fn client_mode_denies_inbound_substreams() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    assert!(!marked_as_dht_server(KademliaMode::Client).await);
+}

--- a/tests/protocol/kademlia.rs
+++ b/tests/protocol/kademlia.rs
@@ -24,12 +24,18 @@ use futures::StreamExt;
 use litep2p::{
     config::ConfigBuilder,
     crypto::ed25519::Keypair,
-    protocol::libp2p::kademlia::{
-        ConfigBuilder as KademliaConfigBuilder, ContentProvider, IncomingRecordValidationMode,
-        KademliaEvent, PeerRecord, Quorum, Record, RecordKey,
+    protocol::libp2p::{
+        identify::{Config as IdentifyConfig, IdentifyEvent},
+        kademlia::{
+            ConfigBuilder as KademliaConfigBuilder, ContentProvider, IncomingRecordValidationMode,
+            KademliaEvent, KademliaMode, PeerRecord, Quorum, Record, RecordKey,
+        },
     },
     transport::tcp::config::Config as TcpConfig,
-    types::multiaddr::{Multiaddr, Protocol},
+    types::{
+        multiaddr::{Multiaddr, Protocol},
+        protocol::ProtocolName,
+    },
     Litep2p, PeerId,
 };
 
@@ -816,6 +822,265 @@ async fn provider_added_to_remote_node() {
                         break
                     }
                 }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn client_does_not_answer_queries() {
+    // node1 runs in client mode, node2 in server mode
+    let (kad_config1, mut kad_handle1) =
+        KademliaConfigBuilder::new().with_mode(KademliaMode::Client).build();
+    let (kad_config2, mut kad_handle2) = KademliaConfigBuilder::new().build();
+
+    let config1 = ConfigBuilder::new()
+        .with_tcp(TcpConfig {
+            listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
+            ..Default::default()
+        })
+        .with_libp2p_kademlia(kad_config1)
+        .build();
+
+    let config2 = ConfigBuilder::new()
+        .with_tcp(TcpConfig {
+            listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
+            ..Default::default()
+        })
+        .with_libp2p_kademlia(kad_config2)
+        .build();
+
+    let mut litep2p1 = Litep2p::new(config1).unwrap();
+    let mut litep2p2 = Litep2p::new(config2).unwrap();
+
+    // the server knows the client and queries it
+    kad_handle2
+        .add_known_peer(
+            *litep2p1.local_peer_id(),
+            litep2p1.listen_addresses().cloned().collect(),
+        )
+        .await;
+    let query = kad_handle2.find_node(PeerId::random()).await;
+
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
+                panic!("query did not finish in 10 secs")
+            }
+            _ = litep2p1.next_event() => {}
+            _ = litep2p2.next_event() => {}
+            _ = kad_handle1.next() => {}
+            event = kad_handle2.next() => match event {
+                Some(KademliaEvent::QueryFailed { query_id }) => {
+                    assert_eq!(query_id, query);
+                    break;
+                }
+                Some(KademliaEvent::FindNodeSuccess { .. }) => {
+                    panic!("client answered the query");
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn server_does_not_add_querying_client_to_routing_table() {
+    // node1 runs in client mode, node2 in server mode
+    let (kad_config1, mut kad_handle1) =
+        KademliaConfigBuilder::new().with_mode(KademliaMode::Client).build();
+    let (kad_config2, mut kad_handle2) = KademliaConfigBuilder::new().build();
+
+    let config1 = ConfigBuilder::new()
+        .with_tcp(TcpConfig {
+            listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
+            ..Default::default()
+        })
+        .with_libp2p_kademlia(kad_config1)
+        .build();
+
+    let config2 = ConfigBuilder::new()
+        .with_tcp(TcpConfig {
+            listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
+            ..Default::default()
+        })
+        .with_libp2p_kademlia(kad_config2)
+        .build();
+
+    let mut litep2p1 = Litep2p::new(config1).unwrap();
+    let mut litep2p2 = Litep2p::new(config2).unwrap();
+
+    // the client knows the server and queries it
+    kad_handle1
+        .add_known_peer(
+            *litep2p2.local_peer_id(),
+            litep2p2.listen_addresses().cloned().collect(),
+        )
+        .await;
+    let query1 = kad_handle1.find_node(PeerId::random()).await;
+
+    // the client's query succeeds as the server answers it
+    let mut query2 = None;
+
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
+                panic!("queries did not finish in 10 secs")
+            }
+            _ = litep2p1.next_event() => {}
+            _ = litep2p2.next_event() => {}
+            event = kad_handle1.next() => {
+                if let Some(KademliaEvent::FindNodeSuccess { query_id, .. }) = event {
+                    assert_eq!(query_id, query1);
+
+                    // the server answered but the client gave it no server evidence,
+                    // so the server's routing table must still be empty and its own
+                    // query must fail immediately
+                    query2 = Some(kad_handle2.find_node(PeerId::random()).await);
+                }
+            }
+            event = kad_handle2.next() => match event {
+                Some(KademliaEvent::QueryFailed { query_id }) => {
+                    assert_eq!(Some(query_id), query2);
+                    break;
+                }
+                Some(KademliaEvent::FindNodeSuccess { .. }) => {
+                    panic!("client was added to the server's routing table");
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn client_can_publish_records() {
+    // node1 runs in client mode, node2 in server mode
+    let (kad_config1, mut kad_handle1) =
+        KademliaConfigBuilder::new().with_mode(KademliaMode::Client).build();
+    let (kad_config2, mut kad_handle2) = KademliaConfigBuilder::new().build();
+
+    let config1 = ConfigBuilder::new()
+        .with_tcp(TcpConfig {
+            listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
+            ..Default::default()
+        })
+        .with_libp2p_kademlia(kad_config1)
+        .build();
+
+    let config2 = ConfigBuilder::new()
+        .with_tcp(TcpConfig {
+            listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
+            ..Default::default()
+        })
+        .with_libp2p_kademlia(kad_config2)
+        .build();
+
+    let mut litep2p1 = Litep2p::new(config1).unwrap();
+    let mut litep2p2 = Litep2p::new(config2).unwrap();
+
+    kad_handle1
+        .add_known_peer(
+            *litep2p2.local_peer_id(),
+            litep2p2.listen_addresses().cloned().collect(),
+        )
+        .await;
+
+    let record = Record::new(vec![1, 2, 3], vec![0x01]);
+    let query = kad_handle1.put_record(record.clone(), Quorum::One).await;
+
+    let mut put_record_success = false;
+    let mut incoming_record = false;
+
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
+                panic!("record was not published in 10 secs")
+            }
+            _ = litep2p1.next_event() => {}
+            _ = litep2p2.next_event() => {}
+            event = kad_handle1.next() => {
+                if let Some(KademliaEvent::PutRecordSuccess { query_id, key }) = event {
+                    assert_eq!(query_id, query);
+                    assert_eq!(key, record.key);
+                    put_record_success = true;
+                    if incoming_record {
+                        break
+                    }
+                }
+            }
+            event = kad_handle2.next() => {
+                if let Some(KademliaEvent::IncomingRecord { record: got_record }) = event {
+                    assert_eq!(got_record.key, record.key);
+                    assert_eq!(got_record.value, record.value);
+                    incoming_record = true;
+                    if put_record_success {
+                        break
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn client_mode_not_advertised_via_identify() {
+    // node1 runs in client mode, node2 in server mode, both with identify
+    let (kad_config1, _kad_handle1) =
+        KademliaConfigBuilder::new().with_mode(KademliaMode::Client).build();
+    let (kad_config2, _kad_handle2) = KademliaConfigBuilder::new().build();
+
+    let (identify_config1, mut identify_stream1) =
+        IdentifyConfig::new("/proto/1".to_string(), None);
+    let (identify_config2, mut identify_stream2) =
+        IdentifyConfig::new("/proto/1".to_string(), None);
+
+    let config1 = ConfigBuilder::new()
+        .with_tcp(TcpConfig {
+            listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
+            ..Default::default()
+        })
+        .with_libp2p_kademlia(kad_config1)
+        .with_libp2p_identify(identify_config1)
+        .build();
+
+    let config2 = ConfigBuilder::new()
+        .with_tcp(TcpConfig {
+            listen_addresses: vec!["/ip6/::1/tcp/0".parse().unwrap()],
+            ..Default::default()
+        })
+        .with_libp2p_kademlia(kad_config2)
+        .with_libp2p_identify(identify_config2)
+        .build();
+
+    let mut litep2p1 = Litep2p::new(config1).unwrap();
+    let mut litep2p2 = Litep2p::new(config2).unwrap();
+
+    let address2 = litep2p2.listen_addresses().next().unwrap().clone();
+    litep2p1.dial_address(address2).await.unwrap();
+
+    let kad_protocol = ProtocolName::from("/ipfs/kad/1.0.0");
+    let mut client_identified = false;
+    let mut server_identified = false;
+
+    while !client_identified || !server_identified {
+        tokio::select! {
+            _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
+                panic!("peers were not identified in 10 secs")
+            }
+            _ = litep2p1.next_event() => {}
+            _ = litep2p2.next_event() => {}
+            event = identify_stream1.next() => {
+                // the client observes the server advertising kademlia
+                let IdentifyEvent::PeerIdentified { supported_protocols, .. } = event.unwrap();
+                assert!(supported_protocols.contains(&kad_protocol));
+                server_identified = true;
+            }
+            event = identify_stream2.next() => {
+                // the server observes the client not advertising kademlia
+                let IdentifyEvent::PeerIdentified { supported_protocols, .. } = event.unwrap();
+                assert!(!supported_protocols.contains(&kad_protocol));
+                client_identified = true;
             }
         }
     }


### PR DESCRIPTION
This PR implements the client-server mode of operation for Kademlia.

Full nodes and substrate-nodes utilize the server mode by default:
- nodes respond to queries
- They are added to the routing table in automatic mode

Light clients or DHT crawlers are encouraged to use the client mode:
- To preserve resources, they are not responding to queries
- Client nodes are not added to the routing table, therefore not polluting the DHT (or even worse, intertwining multiple DHTs)

To prepare for supporting the dynamic addition and removal of multiple DHTs at runtime, this PR introduces dynamic protocol configuration for the identify protocol.
By default, Kademlia implementations running in client mode are not advertised via the identify protocol.

cc @dmitry-markin @skunert 