### PR TITLE
fix(webrtc): support unspecified listen addresses instead of panicking

### DIFF
--- a/src/transport/webrtc/config.rs
+++ b/src/transport/webrtc/config.rs
@@ -32,7 +32,9 @@ use crate::transport::webrtc::certificate::DtlsCertificate;
 pub struct Config {
     /// WebRTC listening address.
     ///
-    /// Unspecified addresses (`0.0.0.0` / `[::]`) are not supported.
+    /// Unspecified addresses (`0.0.0.0` / `[::]`) are expanded into one listener per
+    /// matching local network interface address, since WebRTC ICE candidates require a
+    /// concrete IP.
     pub listen_addresses: Vec<Multiaddr>,
 
     /// Connection datagram buffer size.

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     future::Future,
     io,
     net::{IpAddr, SocketAddr},
@@ -10,6 +11,7 @@ use std::{
 
 use futures_timer::Delay;
 use multiaddr::{multihash::Multihash, Multiaddr, Protocol};
+use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use socket2::{Domain, Socket, Type};
 use tokio::{io::ReadBuf, net::UdpSocket};
 
@@ -36,51 +38,47 @@ impl WebRtcListener {
     ) -> crate::Result<(Self, Vec<Multiaddr>)> {
         let mut listen_multi_addresses = Vec::with_capacity(multiaddr_listen_addresses.len());
         let mut listen_sockets = Vec::with_capacity(multiaddr_listen_addresses.len());
+        // De-duplicate bound addresses to avoid binding the same socket twice.
+        let mut bound = HashSet::new();
 
-        let handle_multiaddr = |listen_socket| -> crate::Result<(UdpSocket, SocketAddr)> {
-            let listen_socket = Self::get_socket_address(&listen_socket)?;
-            // Unspecified addresses (`0.0.0.0` / `[::]`) are rejected,
-            // WebRTC ICE candidates must carry a concrete IP, so the listener must
-            // be bound to a specific address of a local interface.
-            if listen_socket.ip().is_unspecified() {
-                return Err(Error::Other(
-                    "WebRTC cannot listen on an unspecified address".to_string(),
-                ));
-            }
+        for listen_address in multiaddr_listen_addresses {
+            let listen_socket = Self::get_socket_address(&listen_address)?;
+            let is_unspecified = listen_socket.ip().is_unspecified();
+            let bind_addresses = Self::expand_listen_address(listen_socket)?;
 
-            let socket = if listen_socket.is_ipv4() {
-                Socket::new(Domain::IPV4, Type::DGRAM, Some(socket2::Protocol::UDP))?
-            } else {
-                let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(socket2::Protocol::UDP))?;
-                socket.set_only_v6(true)?;
-                socket
-            };
-
-            socket.bind(&listen_socket.into())?;
-            socket.set_nonblocking(true)?;
-
-            let socket = UdpSocket::from_std(socket.into())?;
-            let listen_socket = socket.local_addr()?;
-            Ok((socket, listen_socket))
-        };
-
-        for listen_socket in multiaddr_listen_addresses {
-            let (socket, listen_socket) = match handle_multiaddr(listen_socket) {
-                Ok(res) => res,
-                Err(err) => {
-                    tracing::warn!(target: LOG_TARGET, ?err, "failed to bind listen address");
-                    return Err(err);
+            for bind_address in bind_addresses {
+                if !bound.insert(bind_address) {
+                    continue;
                 }
-            };
 
-            listen_sockets.push((listen_socket, Arc::new(socket)));
-            listen_multi_addresses.push(
-                Multiaddr::empty()
-                    .with(Protocol::from(listen_socket.ip()))
-                    .with(Protocol::Udp(listen_socket.port()))
-                    .with(Protocol::WebRTCDirect)
-                    .with(Protocol::Certhash(certificate)),
-            );
+                let (socket, local_socket) = match Self::bind_socket(bind_address) {
+                    Ok(res) => res,
+                    // Expanded interface addresses may fail to bind; only explicit ones are fatal.
+                    Err(err) if is_unspecified => {
+                        tracing::warn!(
+                            target: LOG_TARGET,
+                            ?bind_address,
+                            ?err,
+                            "failed to bind interface address, skipping",
+                        );
+                        bound.remove(&bind_address);
+                        continue;
+                    }
+                    Err(err) => {
+                        tracing::warn!(target: LOG_TARGET, ?err, "failed to bind listen address");
+                        return Err(err);
+                    }
+                };
+
+                listen_sockets.push((local_socket, Arc::new(socket)));
+                listen_multi_addresses.push(
+                    Multiaddr::empty()
+                        .with(Protocol::from(local_socket.ip()))
+                        .with(Protocol::Udp(local_socket.port()))
+                        .with(Protocol::WebRTCDirect)
+                        .with(Protocol::Certhash(certificate)),
+                );
+            }
         }
 
         if listen_sockets.is_empty() {
@@ -97,6 +95,63 @@ impl WebRtcListener {
             },
             listen_multi_addresses,
         ))
+    }
+
+    /// Bind a non-blocking UDP socket to `listen_socket` and return it together with the
+    /// concrete local address it was bound to.
+    fn bind_socket(listen_socket: SocketAddr) -> crate::Result<(UdpSocket, SocketAddr)> {
+        let socket = if listen_socket.is_ipv4() {
+            Socket::new(Domain::IPV4, Type::DGRAM, Some(socket2::Protocol::UDP))?
+        } else {
+            let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(socket2::Protocol::UDP))?;
+            socket.set_only_v6(true)?;
+            socket
+        };
+
+        socket.bind(&listen_socket.into())?;
+        socket.set_nonblocking(true)?;
+
+        let socket = UdpSocket::from_std(socket.into())?;
+        let local_socket = socket.local_addr()?;
+        Ok((socket, local_socket))
+    }
+
+    /// Expand a listen address into the concrete socket addresses to bind to.
+    ///
+    /// Concrete addresses pass through unchanged. Unspecified addresses (`0.0.0.0` / `[::]`)
+    /// are expanded into one address per matching local interface, since a socket bound to
+    /// `0.0.0.0` reports `0.0.0.0` as its local IP, which `str0m` rejects as an ICE candidate.
+    fn expand_listen_address(listen_socket: SocketAddr) -> crate::Result<Vec<SocketAddr>> {
+        if !listen_socket.ip().is_unspecified() {
+            return Ok(vec![listen_socket]);
+        }
+
+        let port = listen_socket.port();
+        let want_ipv4 = listen_socket.is_ipv4();
+
+        let interfaces = NetworkInterface::show()
+            .map_err(|error| Error::Other(format!("failed to fetch network interfaces: {error}")))?;
+
+        let addresses: Vec<SocketAddr> = interfaces
+            .into_iter()
+            .flat_map(|iface| iface.addr.into_iter())
+            .filter_map(|addr| match (addr, want_ipv4) {
+                (Addr::V4(inner), true) => Some(SocketAddr::new(IpAddr::V4(inner.ip), port)),
+                // Skip IPv6 link-local (`fe80::/10`): unusable as an ICE candidate.
+                (Addr::V6(inner), false) if inner.ip.segments()[0] != 0xfe80 =>
+                    Some(SocketAddr::new(IpAddr::V6(inner.ip), port)),
+                _ => None,
+            })
+            .collect();
+
+        if addresses.is_empty() {
+            return Err(Error::Other(format!(
+                "WebRTC listener found no concrete {} interface address to bind to",
+                if want_ipv4 { "IPv4" } else { "IPv6" },
+            )));
+        }
+
+        Ok(addresses)
     }
 
     pub(super) fn socket(&self, local: &SocketAddr) -> Option<Arc<UdpSocket>> {
@@ -212,5 +267,81 @@ impl WebRtcListener {
         }
 
         Ok(socket_address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use multihash_codetable::MultihashDigest;
+
+    fn test_certhash() -> Multihash<64> {
+        multihash_codetable::Code::Sha2_256.digest(b"litep2p-webrtc-test")
+    }
+
+    #[tokio::test]
+    async fn concrete_listen_address_is_bound() {
+        let (listener, addresses) = WebRtcListener::new(
+            vec!["/ip4/127.0.0.1/udp/0/webrtc-direct".parse().unwrap()],
+            test_certhash(),
+        )
+        .expect("binding a concrete loopback address should succeed");
+
+        assert_eq!(listener.listen_sockets.len(), 1);
+        assert_eq!(addresses.len(), 1);
+        let bound = listener.listen_sockets[0].0;
+        assert_eq!(bound.ip(), IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+        assert_ne!(bound.port(), 0);
+    }
+
+    #[tokio::test]
+    async fn unspecified_ipv4_listen_address_is_expanded() {
+        let (listener, addresses) = WebRtcListener::new(
+            vec!["/ip4/0.0.0.0/udp/0/webrtc-direct".parse().unwrap()],
+            test_certhash(),
+        )
+        .expect("unspecified address should expand to at least loopback");
+
+        assert!(!listener.listen_sockets.is_empty());
+        assert_eq!(listener.listen_sockets.len(), addresses.len());
+
+        // Every bound socket and advertised address must carry a concrete IPv4 address.
+        for (bound, _) in &listener.listen_sockets {
+            assert!(bound.is_ipv4());
+            assert!(!bound.ip().is_unspecified());
+        }
+        for address in &addresses {
+            let mut iter = address.iter();
+            match iter.next() {
+                Some(Protocol::Ip4(ip)) => assert!(!ip.is_unspecified()),
+                protocol => panic!("expected concrete ip4 address, got {protocol:?}"),
+            }
+            assert!(matches!(iter.next(), Some(Protocol::Udp(_))));
+            assert!(matches!(iter.next(), Some(Protocol::WebRTCDirect)));
+            assert!(matches!(iter.next(), Some(Protocol::Certhash(_))));
+        }
+
+        // Loopback is always present in the expansion.
+        assert!(listener
+            .listen_sockets
+            .iter()
+            .any(|(addr, _)| addr.ip() == IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)));
+    }
+
+    #[tokio::test]
+    async fn duplicate_addresses_are_bound_once() {
+        // Two identical addresses must collapse to a single bind (port 0 keeps them
+        // colliding on the same pre-bind key `127.0.0.1:0`).
+        let (listener, addresses) = WebRtcListener::new(
+            vec![
+                "/ip4/127.0.0.1/udp/0/webrtc-direct".parse().unwrap(),
+                "/ip4/127.0.0.1/udp/0/webrtc-direct".parse().unwrap(),
+            ],
+            test_certhash(),
+        )
+        .expect("binding loopback should succeed");
+
+        assert_eq!(listener.listen_sockets.len(), 1);
+        assert_eq!(addresses.len(), 1);
     }
 }


### PR DESCRIPTION
Fixes #592: instead of rejecting (and previously panicking on) unspecified WebRTC listen addresses, the listener now expands `0.0.0.0`/`[::]` into one bound socket per concrete local interface address, so the local ICE candidate is always a valid IP that `str0m` accepts.