### PR TITLE
Bitswap protocol robustness

### DIFF
--- a/src/protocol/libp2p/bitswap/mod.rs
+++ b/src/protocol/libp2p/bitswap/mod.rs
@@ -365,11 +365,7 @@ impl Bitswap {
         if !self.pending_dials.remove(&peer) {
             return;
         }
-        let dropped = self
-            .pending_outbound
-            .remove(&peer)
-            .map(|actions| actions.len())
-            .unwrap_or(0);
+        let dropped = self.pending_outbound.remove(&peer).map(|actions| actions.len()).unwrap_or(0);
         tracing::debug!(
             target: LOG_TARGET,
             ?peer,
@@ -401,11 +397,7 @@ impl Bitswap {
             return;
         };
 
-        let dropped = self
-            .pending_outbound
-            .remove(&peer)
-            .map(|actions| actions.len())
-            .unwrap_or(0);
+        let dropped = self.pending_outbound.remove(&peer).map(|actions| actions.len()).unwrap_or(0);
 
         tracing::debug!(
             target: LOG_TARGET,

--- a/src/protocol/libp2p/bitswap/mod.rs
+++ b/src/protocol/libp2p/bitswap/mod.rs
@@ -344,23 +344,19 @@ impl Bitswap {
 
     /// Handle connection closed event.
     ///
-    /// The outbound substream cached in [`Self::outbound`] now references a dead transport;
-    /// drop it so the next request/response triggers a fresh open. We deliberately do NOT touch
-    /// [`Self::pending_outbound`] or [`Self::pending_substreams`] here: any in-flight open on
-    /// the closed connection will surface as [`TransportEvent::SubstreamOpenFailure`], which
-    /// cleans both maps via [`Self::on_substream_open_failure`].
+    /// Drop all peer-scoped outbound state so the next request/response can open a fresh
+    /// substream instead of waiting behind state tied to a closed connection.
     fn on_connection_closed(&mut self, peer: PeerId) {
         if self.outbound.remove(&peer).is_some() {
             tracing::debug!(target: LOG_TARGET, ?peer, "dropping outbound substream on connection close");
         }
+        self.pending_outbound.remove(&peer);
+        self.pending_dials.remove(&peer);
+        self.pending_substreams.retain(|_, pending_peer| pending_peer != &peer);
         self.inbound.remove(&peer);
     }
 
     /// Dial to remote peer failed.
-    ///
-    /// We only enter `pending_dials` from [`Self::open_substream_or_dial`] when we already had
-    /// queued actions in [`Self::pending_outbound`]. Without this handler, both would stay
-    /// populated forever — same shape as the [`Self::on_substream_open_failure`] bug.
     fn on_dial_failure(&mut self, peer: PeerId) {
         if !self.pending_dials.remove(&peer) {
             return;
@@ -375,17 +371,6 @@ impl Bitswap {
     }
 
     /// Failed to open an outbound substream that we previously requested.
-    ///
-    /// The transport reports failure by [`SubstreamId`] (no [`PeerId`]), so we map it back via
-    /// [`Self::pending_substreams`]. Any actions queued in [`Self::pending_outbound`] for that
-    /// peer are dropped — there is no in-protocol retry — but the queue is cleared so that the
-    /// next request/response for the peer can trigger a fresh open instead of stacking onto a
-    /// queue that will never drain.
-    ///
-    /// Without this handler, [`TransportEvent::SubstreamOpenFailure`] would fall through to the
-    /// catch-all trace log in [`Self::run`] and [`Self::pending_outbound`] would grow forever
-    /// for the affected peer, producing a silent per-peer black hole that only a node restart
-    /// could clear.
     fn on_substream_open_failure(&mut self, substream_id: SubstreamId, error: SubstreamError) {
         let Some(peer) = self.pending_substreams.remove(&substream_id) else {
             tracing::debug!(

--- a/src/protocol/libp2p/bitswap/mod.rs
+++ b/src/protocol/libp2p/bitswap/mod.rs
@@ -786,7 +786,19 @@ fn extract_next_batch<'a>(
 mod tests {
     use cid::multihash::Multihash;
 
+    use crate::{
+        addresses::PublicAddresses,
+        protocol::{ProtocolName, SubstreamKeepAlive},
+        transport::{
+            manager::{handle::InnerTransportManagerCommand, TransportManagerHandle},
+            KEEP_ALIVE_TIMEOUT,
+        },
+    };
+
     use super::*;
+    use parking_lot::RwLock;
+    use std::sync::{atomic::AtomicUsize, Arc};
+    use tokio::sync::mpsc;
 
     fn cid(block: &[u8]) -> Cid {
         let codec = 0x55;
@@ -795,6 +807,90 @@ mod tests {
             Multihash::wrap(multihash.code(), multihash.digest()).expect("to be valid multihash");
 
         Cid::new_v1(codec, multihash)
+    }
+
+    fn bitswap() -> Bitswap {
+        let local_peer = PeerId::random();
+        let (cmd_tx, _cmd_rx) = mpsc::channel::<InnerTransportManagerCommand>(64);
+
+        let handle = TransportManagerHandle::new(
+            local_peer,
+            Arc::new(RwLock::new(HashMap::new())),
+            cmd_tx,
+            HashSet::new(),
+            Default::default(),
+            PublicAddresses::new(local_peer),
+        );
+
+        let (service, _) = TransportService::new(
+            local_peer,
+            ProtocolName::from(config::PROTOCOL_NAME),
+            Vec::new(),
+            Arc::new(AtomicUsize::new(0usize)),
+            handle,
+            KEEP_ALIVE_TIMEOUT,
+            SubstreamKeepAlive::No,
+        );
+        let (config, _) = Config::new();
+
+        Bitswap::new(service, config)
+    }
+
+    fn pending_action() -> SubstreamAction {
+        SubstreamAction::SendRequest(vec![(cid(b"test"), WantType::Have)])
+    }
+
+    #[test]
+    fn substream_open_failure_clears_pending_actions() {
+        let peer = PeerId::random();
+        let substream = SubstreamId::from(0usize);
+        let mut bitswap = bitswap();
+
+        bitswap.pending_outbound.insert(peer, vec![pending_action()]);
+        bitswap.pending_substreams.insert(substream, peer);
+
+        bitswap.on_substream_open_failure(substream, SubstreamError::ConnectionClosed);
+
+        assert!(!bitswap.pending_outbound.contains_key(&peer));
+        assert!(!bitswap.pending_substreams.contains_key(&substream));
+    }
+
+    #[test]
+    fn dial_failure_clears_pending_actions() {
+        let peer = PeerId::random();
+        let mut bitswap = bitswap();
+
+        bitswap.pending_outbound.insert(peer, vec![pending_action()]);
+        bitswap.pending_dials.insert(peer);
+
+        bitswap.on_dial_failure(peer);
+
+        assert!(!bitswap.pending_outbound.contains_key(&peer));
+        assert!(!bitswap.pending_dials.contains(&peer));
+    }
+
+    #[test]
+    fn connection_closed_clears_peer_scoped_state() {
+        let peer = PeerId::random();
+        let other = PeerId::random();
+        let substream = SubstreamId::from(0usize);
+        let other_substream = SubstreamId::from(1usize);
+        let mut bitswap = bitswap();
+
+        bitswap.pending_outbound.insert(peer, vec![pending_action()]);
+        bitswap.pending_dials.insert(peer);
+        bitswap.pending_substreams.insert(substream, peer);
+        bitswap.pending_substreams.insert(other_substream, other);
+
+        bitswap.on_connection_closed(peer);
+
+        assert!(!bitswap.pending_outbound.contains_key(&peer));
+        assert!(!bitswap.pending_dials.contains(&peer));
+        assert!(!bitswap.pending_substreams.contains_key(&substream));
+        assert_eq!(
+            bitswap.pending_substreams.get(&other_substream),
+            Some(&other)
+        );
     }
 
     #[test]

--- a/src/protocol/libp2p/bitswap/mod.rs
+++ b/src/protocol/libp2p/bitswap/mod.rs
@@ -21,7 +21,7 @@
 //! [`/ipfs/bitswap/1.2.0`](https://github.com/ipfs/specs/blob/main/BITSWAP.md) implementation.
 
 use crate::{
-    error::{Error, ImmediateDialError},
+    error::{Error, ImmediateDialError, SubstreamError},
     protocol::{Direction, TransportEvent, TransportService},
     substream::Substream,
     types::{
@@ -144,6 +144,11 @@ pub(crate) struct Bitswap {
     /// Pending outbound actions.
     pending_outbound: HashMap<PeerId, Vec<SubstreamAction>>,
 
+    /// Outbound substream opens in flight, mapped back to their target peer so that
+    /// [`TransportEvent::SubstreamOpenFailure`] (which only carries a [`SubstreamId`])
+    /// can be associated with the queued actions in [`Self::pending_outbound`].
+    pending_substreams: HashMap<SubstreamId, PeerId>,
+
     /// Inbound substreams.
     inbound: StreamMap<PeerId, Substream>,
 
@@ -162,6 +167,7 @@ impl Bitswap {
             cmd_rx: config.cmd_rx,
             event_tx: config.event_tx,
             pending_outbound: HashMap::new(),
+            pending_substreams: HashMap::new(),
             inbound: StreamMap::new(),
             outbound: HashMap::new(),
             pending_dials: HashSet::new(),
@@ -305,6 +311,8 @@ impl Bitswap {
         substream_id: SubstreamId,
         mut substream: Substream,
     ) {
+        self.pending_substreams.remove(&substream_id);
+
         let Some(actions) = self.pending_outbound.remove(&peer) else {
             tracing::warn!(target: LOG_TARGET, ?peer, ?substream_id, "pending outbound entry doesn't exist");
             return;
@@ -334,6 +342,81 @@ impl Bitswap {
         self.outbound.insert(peer, substream);
     }
 
+    /// Handle connection closed event.
+    ///
+    /// The outbound substream cached in [`Self::outbound`] now references a dead transport;
+    /// drop it so the next request/response triggers a fresh open. We deliberately do NOT touch
+    /// [`Self::pending_outbound`] or [`Self::pending_substreams`] here: any in-flight open on
+    /// the closed connection will surface as [`TransportEvent::SubstreamOpenFailure`], which
+    /// cleans both maps via [`Self::on_substream_open_failure`].
+    fn on_connection_closed(&mut self, peer: PeerId) {
+        if self.outbound.remove(&peer).is_some() {
+            tracing::debug!(target: LOG_TARGET, ?peer, "dropping outbound substream on connection close");
+        }
+        self.inbound.remove(&peer);
+    }
+
+    /// Dial to remote peer failed.
+    ///
+    /// We only enter `pending_dials` from [`Self::open_substream_or_dial`] when we already had
+    /// queued actions in [`Self::pending_outbound`]. Without this handler, both would stay
+    /// populated forever — same shape as the [`Self::on_substream_open_failure`] bug.
+    fn on_dial_failure(&mut self, peer: PeerId) {
+        if !self.pending_dials.remove(&peer) {
+            return;
+        }
+        let dropped = self
+            .pending_outbound
+            .remove(&peer)
+            .map(|actions| actions.len())
+            .unwrap_or(0);
+        tracing::debug!(
+            target: LOG_TARGET,
+            ?peer,
+            dropped_actions = dropped,
+            "dial failed, dropping queued bitswap actions",
+        );
+    }
+
+    /// Failed to open an outbound substream that we previously requested.
+    ///
+    /// The transport reports failure by [`SubstreamId`] (no [`PeerId`]), so we map it back via
+    /// [`Self::pending_substreams`]. Any actions queued in [`Self::pending_outbound`] for that
+    /// peer are dropped — there is no in-protocol retry — but the queue is cleared so that the
+    /// next request/response for the peer can trigger a fresh open instead of stacking onto a
+    /// queue that will never drain.
+    ///
+    /// Without this handler, [`TransportEvent::SubstreamOpenFailure`] would fall through to the
+    /// catch-all trace log in [`Self::run`] and [`Self::pending_outbound`] would grow forever
+    /// for the affected peer, producing a silent per-peer black hole that only a node restart
+    /// could clear.
+    fn on_substream_open_failure(&mut self, substream_id: SubstreamId, error: SubstreamError) {
+        let Some(peer) = self.pending_substreams.remove(&substream_id) else {
+            tracing::debug!(
+                target: LOG_TARGET,
+                ?substream_id,
+                ?error,
+                "outbound substream open failed for unknown substream id",
+            );
+            return;
+        };
+
+        let dropped = self
+            .pending_outbound
+            .remove(&peer)
+            .map(|actions| actions.len())
+            .unwrap_or(0);
+
+        tracing::debug!(
+            target: LOG_TARGET,
+            ?peer,
+            ?substream_id,
+            ?error,
+            dropped_actions = dropped,
+            "outbound substream open failed, dropping queued bitswap actions",
+        );
+    }
+
     /// Handle connection established event.
     fn on_connection_established(&mut self, peer: PeerId) {
         // If we have pending actions for this peer, open a substream.
@@ -344,16 +427,21 @@ impl Bitswap {
                 "open substream after connection established",
             );
 
-            if let Err(error) = self.service.open_substream(peer) {
-                tracing::debug!(
-                    target: LOG_TARGET,
-                    ?peer,
-                    ?error,
-                    "failed to open substream after connection established",
-                );
-                // Drop all pending actions; they are not going to be handled anyway, and we need
-                // the entry to be empty to properly open subsequent substreams.
-                self.pending_outbound.remove(&peer);
+            match self.service.open_substream(peer) {
+                Ok(substream_id) => {
+                    self.pending_substreams.insert(substream_id, peer);
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        target: LOG_TARGET,
+                        ?peer,
+                        ?error,
+                        "failed to open substream after connection established",
+                    );
+                    // Drop all pending actions; they are not going to be handled anyway, and we
+                    // need the entry to be empty to properly open subsequent substreams.
+                    self.pending_outbound.remove(&peer);
+                }
             }
         }
     }
@@ -362,33 +450,48 @@ impl Bitswap {
     fn open_substream_or_dial(&mut self, peer: PeerId) {
         tracing::trace!(target: LOG_TARGET, ?peer, "open substream");
 
-        if let Err(error) = self.service.open_substream(peer) {
-            tracing::trace!(
-                target: LOG_TARGET,
-                ?peer,
-                ?error,
-                "failed to open substream, dialing peer",
-            );
+        match self.service.open_substream(peer) {
+            Ok(substream_id) => {
+                self.pending_substreams.insert(substream_id, peer);
+            }
+            Err(error) => {
+                tracing::trace!(
+                    target: LOG_TARGET,
+                    ?peer,
+                    ?error,
+                    "failed to open substream, dialing peer",
+                );
 
-            // Failed to open substream, try to dial the peer.
-            match self.service.dial(&peer) {
-                Ok(()) => {
-                    // Store the peer to open a substream once it is connected.
-                    self.pending_dials.insert(peer);
-                }
-                Err(ImmediateDialError::AlreadyConnected) => {
-                    // By the time we tried to dial peer, it got connected.
-                    if let Err(error) = self.service.open_substream(peer) {
-                        tracing::trace!(
-                            target: LOG_TARGET,
-                            ?peer,
-                            ?error,
-                            "failed to open substream for a second time",
-                        );
+                // Failed to open substream, try to dial the peer.
+                match self.service.dial(&peer) {
+                    Ok(()) => {
+                        // Store the peer to open a substream once it is connected.
+                        self.pending_dials.insert(peer);
                     }
-                }
-                Err(error) => {
-                    tracing::debug!(target: LOG_TARGET, ?peer, ?error, "failed to dial peer");
+                    Err(ImmediateDialError::AlreadyConnected) => {
+                        // By the time we tried to dial peer, it got connected.
+                        match self.service.open_substream(peer) {
+                            Ok(substream_id) => {
+                                self.pending_substreams.insert(substream_id, peer);
+                            }
+                            Err(error) => {
+                                tracing::trace!(
+                                    target: LOG_TARGET,
+                                    ?peer,
+                                    ?error,
+                                    "failed to open substream for a second time",
+                                );
+                                // No event will ever arrive for this attempt; drop the queued
+                                // actions so the next response triggers a fresh open.
+                                self.pending_outbound.remove(&peer);
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        tracing::debug!(target: LOG_TARGET, ?peer, ?error, "failed to dial peer");
+                        // Same rationale as above: no event will ever arrive.
+                        self.pending_outbound.remove(&peer);
+                    }
                 }
             }
         }
@@ -470,8 +573,16 @@ impl Bitswap {
                         Direction::Outbound(substream_id) =>
                             self.on_outbound_substream(peer, substream_id, substream).await,
                     },
+                    Some(TransportEvent::SubstreamOpenFailure { substream, error }) => {
+                        self.on_substream_open_failure(substream, error);
+                    }
+                    Some(TransportEvent::ConnectionClosed { peer }) => {
+                        self.on_connection_closed(peer);
+                    }
+                    Some(TransportEvent::DialFailure { peer, .. }) => {
+                        self.on_dial_failure(peer);
+                    }
                     None => return,
-                    event => tracing::trace!(target: LOG_TARGET, ?event, "unhandled event"),
                 },
                 command = self.cmd_rx.recv() => match command {
                     Some(BitswapCommand::SendRequest { peer, cids }) => {


### PR DESCRIPTION
## Problematic flow

Substrate has a response to send to peer P. No outbound substream to P exists yet.

1. [`on_bitswap_response`](https://github.com/paritytech/litep2p/blob/9cca92c078327cc9ea63d47d21a070cd3b0d7e3d/src/protocol/libp2p/bitswap/mod.rs#L444-L450) pushes the response onto `pending_outbound[P]` and calls `open_substream_or_dial(P)`. The open is only triggered on the empty→non-empty transition.

2. [`open_substream_or_dial`](https://github.com/paritytech/litep2p/blob/9cca92c078327cc9ea63d47d21a070cd3b0d7e3d/src/protocol/libp2p/bitswap/mod.rs#L362-L395) calls `service.open_substream(P)` which returns `Ok(SubstreamId)`. The `SubstreamId` is discarded.

3. The transport's open times out after [5s](https://github.com/paritytech/litep2p/blob/9cca92c078327cc9ea63d47d21a070cd3b0d7e3d/src/transport/mod.rs#L51) and reports [`TransportEvent::SubstreamOpenFailure`](https://github.com/paritytech/litep2p/blob/9cca92c078327cc9ea63d47d21a070cd3b0d7e3d/src/protocol/protocol_set.rs#L386-L390) carrying only `SubstreamId` (no `PeerId`).

4. The bitswap event loop has no arm for `SubstreamOpenFailure`. It falls into [the catch-all `trace!` at mod.rs:474](https://github.com/paritytech/litep2p/blob/9cca92c078327cc9ea63d47d21a070cd3b0d7e3d/src/protocol/libp2p/bitswap/mod.rs#L458-L475) and is dropped.

5. `pending_outbound[P]` is only drained on `SubstreamOpened` ([on_outbound_substream](https://github.com/paritytech/litep2p/blob/9cca92c078327cc9ea63d47d21a070cd3b0d7e3d/src/protocol/libp2p/bitswap/mod.rs#L302-L335)). That event never comes.

6. The next response for P hits the same code as step 1. `pending_actions.is_empty()` is now false → **`open_substream_or_dial` is not called again**. Responses just keep stacking onto a dead queue.

Result: P stops getting served. Other peers are unaffected (their `outbound` substreams are healthy). `PeerId` is stable across pod restarts so restarting the remote doesn't help — only restarting the local node clears `pending_outbound`.

For comparison, [kademlia](https://github.com/paritytech/litep2p/blob/9cca92c078327cc9ea63d47d21a070cd3b0d7e3d/src/protocol/libp2p/kademlia/mod.rs#L1064-L1068), [request_response](https://github.com/paritytech/litep2p/blob/9cca92c078327cc9ea63d47d21a070cd3b0d7e3d/src/protocol/request_response/mod.rs#L922-L933) and [ping](https://github.com/paritytech/litep2p/blob/9cca92c078327cc9ea63d47d21a070cd3b0d7e3d/src/protocol/libp2p/ping/mod.rs#L217) all handle `SubstreamOpenFailure`.

### Fix

Two independent changes, either alone would have prevented this:

- Handle `SubstreamOpenFailure` (also `DialFailure`, `ConnectionClosed`) in the bitswap event loop, dropping `pending_outbound[P]` on failure. Requires a `SubstreamId → PeerId` map since the failure event carries no peer.
- Or: retry `open_substream_or_dial(P)` after a timeout if `pending_outbound[P]` hasn't drained.