### PR TITLE
fix(webrtc): decode errors during opening phase are not recoverable

### DIFF
--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -581,7 +581,21 @@ impl WebRtcConnection {
         );
 
         // Decode errors are not recoverable.
-        let payload = WebRtcMessage::decode(&data)?.payload.ok_or(Error::InvalidData)?;
+        let WebRtcMessage {
+            payload: Some(payload),
+            flag: None,
+        } = WebRtcMessage::decode(&data)
+            .map_err(|err| SubstreamError::NegotiationError(err.into()))?
+        else {
+            tracing::debug!(
+                target: LOG_TARGET,
+                peer = ?self.peer,
+                ?channel_id,
+                "non-payload frame during inbound opening, closing channel"
+            );
+            return Err(Error::ConnectionClosed);
+        };
+
         let protocols = self.protocol_set.protocols_with_keep_alives();
         let protocol_names = protocols.keys().cloned().collect();
         let (response, negotiated) =
@@ -666,11 +680,21 @@ impl WebRtcConnection {
             "handle opening outbound substream",
         );
 
-        let rtc_message = WebRtcMessage::decode(&data)
-            .map_err(|err| SubstreamError::NegotiationError(err.into()))?;
-        let message = rtc_message.payload.ok_or(SubstreamError::NegotiationError(
-            ParseError::InvalidData.into(),
-        ))?;
+        // Decode errors are not recoverable.
+        let WebRtcMessage {
+            payload: Some(message),
+            flag: None,
+        } = WebRtcMessage::decode(&data)
+            .map_err(|err| SubstreamError::NegotiationError(err.into()))?
+        else {
+            tracing::debug!(
+                target: LOG_TARGET,
+                peer = ?self.peer,
+                ?channel_id,
+                "non-payload frame during outbound opening, closing channel"
+            );
+            return Err(SubstreamError::ConnectionClosed);
+        };
 
         let protocol = match dialer_state.register_response(message)? {
             HandshakeResult::Succeeded(protocol) => protocol,

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use crate::{
-    error::{Error, ParseError, SubstreamError},
+    error::{Error, SubstreamError},
     multistream_select::{
         webrtc_listener_negotiate, HandshakeResult, ListenerSelectResult, NegotiationError,
         WebRtcDialerState,

--- a/src/transport/webrtc/opening.rs
+++ b/src/transport/webrtc/opening.rs
@@ -322,7 +322,20 @@ impl OpeningWebRtcConnection {
             return Err(Error::InvalidState);
         };
 
-        let message = WebRtcMessage::decode(&body)?.payload.ok_or(Error::InvalidData)?;
+        // Decode errors are not recoverable.
+        let WebRtcMessage {
+            payload: Some(message),
+            flag: None,
+        } = WebRtcMessage::decode(&body)?
+        else {
+            tracing::debug!(
+                target: LOG_TARGET,
+                connection_id = ?self.connection_id,
+                peer = ?self.peer_address,
+                "non-payload frame during noise handshake, closing channel"
+            );
+            return Err(Error::ConnectionClosed);
+        };
         let remote_peer_id = context.get_remote_peer_id(&message)?;
 
         tracing::trace!(


### PR DESCRIPTION
 Explanation of why being so strict over decoding errors within the opening phases can be found [here](https://github.com/paritytech/litep2p/issues/589#issuecomment-4733498232).

Closes #589 