### PR TITLE
fix(noise): size handshake read buffer with correct overhead

### DIFF
--- a/src/crypto/noise/mod.rs
+++ b/src/crypto/noise/mod.rs
@@ -257,9 +257,10 @@ impl NoiseContext {
         let mut message = BytesMut::zeroed(size as usize);
         io.read_exact(&mut message).await?;
 
-        // TODO: https://github.com/paritytech/litep2p/issues/332 use correct overhead.
-        let mut out = BytesMut::new();
-        out.resize(message.len() + 200, 0u8);
+        // Noise decryption strips the 16-byte AEAD (Poly1305) tag, so the decrypted
+        // plaintext is never larger than the ciphertext. `message.len()` is therefore
+        // a guaranteed-sufficient upper bound for the output buffer.
+        let mut out = BytesMut::zeroed(message.len());
 
         let NoiseState::Handshake(ref mut noise) = self.noise else {
             tracing::error!(target: LOG_TARGET, "invalid state to read handshake message");


### PR DESCRIPTION
## Description

`read_handshake_message` allocated its decryption output buffer as `message.len() + 200` — an arbitrary overhead flagged with a `TODO`.

Closes #332