### PR TITLE
webrtc: support wildcard listen addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,6 +1936,7 @@ dependencies = [
  "prost-build",
  "quickcheck",
  "quinn 0.9.4",
+ "quinn-udp 0.6.1",
  "rand 0.8.6",
  "rcgen 0.14.8",
  "ring 0.17.14",
@@ -2846,6 +2847,19 @@ dependencies = [
  "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.4",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ dependencies = [
  "libp2p",
  "mockall",
  "multiaddr",
+ "multibase",
  "multihash",
  "multihash-codetable",
  "network-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ rcgen = { version = "0.14.5", optional = true }
 
 # WebRTC related dependencies. WebRTC is an experimental feature flag. The dependencies must be updated.
 str0m = { version = "0.21.0", default-features = false, features = ["openssl", "vendored"], optional = true }
+quinn-udp = { version = "0.6.1", default-features = false, features = ["tracing"], optional = true }
 # End of WebRTC related dependencies.
 
 # Fuzzing related dependencies.
@@ -132,7 +133,7 @@ fuzz = [
 # Unstable / experimental feature flags. These features are not guaranteed to be stable and may change in the future.
 # They are not yet suitable for production use-cases and should be used with caution.
 quic = ["dep:webpki", "dep:quinn", "dep:rustls", "dep:ring", "dep:rcgen"]
-webrtc = ["dep:str0m"]
+webrtc = ["dep:str0m", "dep:quinn-udp"]
 rsa = ["dep:ring"]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ip_network = "0.4"
 libc = "0.2.158"
 mockall = "0.13.1"
 multiaddr = "0.18.2"
+multibase = "0.9.2"
 multihash = { version = "0.19.4", default-features = false, features = ["std"] }
 multihash-codetable = { version = "0.2.1", default-features = false, features = [
     "sha2",

--- a/src/transport/webrtc/certificate.rs
+++ b/src/transport/webrtc/certificate.rs
@@ -6,6 +6,8 @@
 //!
 //! litep2p does not persist the certificate itself, persistence is left to the caller.
 
+use crate::types::multihash::Multihash;
+use multihash_codetable::MultihashDigest as _;
 use str0m::{config::DtlsCert, crypto::CryptoError, error::DtlsError, RtcError};
 
 /// Local certificate & key used for DTLS connections.
@@ -44,13 +46,13 @@ impl DtlsCertificate {
     }
 
     /// Get the certificate certhash for WebRTC multiaddress.
-    pub fn certhash() -> Multihash<64> {
-        multihash_codetable::Code::Sha2_256.digest(&dtls_cert.certificate)
+    pub fn certhash(&self) -> Multihash<64> {
+        multihash_codetable::Code::Sha2_256.digest(&self.certificate)
     }
 
     /// Certhash string representation as in multiaddress.
-    pub fn certhash_b64() -> String {
-        multibase::encode(multibase::Base::Base64Url, self.certhash())
+    pub fn certhash_b64(&self) -> String {
+        multibase::encode(multibase::Base::Base64Url, self.certhash().to_bytes())
     }
 
     /// Returns the raw certificate and private-key bytes.

--- a/src/transport/webrtc/certificate.rs
+++ b/src/transport/webrtc/certificate.rs
@@ -8,9 +8,12 @@
 
 use str0m::{config::DtlsCert, crypto::CryptoError, error::DtlsError, RtcError};
 
+/// Local certificate & key used for DTLS connections.
 #[derive(Debug)]
 pub struct DtlsCertificate {
+    /// Certificate as X.509 DER.
     certificate: Vec<u8>,
+    /// Matching private key as PKCS#8 DER.
     private_key: Vec<u8>,
 }
 

--- a/src/transport/webrtc/certificate.rs
+++ b/src/transport/webrtc/certificate.rs
@@ -43,6 +43,16 @@ impl DtlsCertificate {
         })
     }
 
+    /// Get the certificate certhash for WebRTC multiaddress.
+    pub fn certhash() -> Multihash<64> {
+        multihash_codetable::Code::Sha2_256.digest(&dtls_cert.certificate)
+    }
+
+    /// Certhash string representation as in multiaddress.
+    pub fn certhash_b64() -> String {
+        multibase::encode(multibase::Base::Base64Url, self.certhash())
+    }
+
     /// Returns the raw certificate and private-key bytes.
     pub fn as_parts(&self) -> (&Vec<u8>, &Vec<u8>) {
         (&self.certificate, &self.private_key)

--- a/src/transport/webrtc/config.rs
+++ b/src/transport/webrtc/config.rs
@@ -30,9 +30,9 @@ use crate::transport::webrtc::certificate::DtlsCertificate;
 /// otherwise, the WebRTC transport is not initialized.
 #[derive(Debug)]
 pub struct Config {
-    /// WebRTC listening address.
+    /// WebRTC listen addresses.
     ///
-    /// Unspecified addresses (`0.0.0.0` / `[::]`) are not supported.
+    /// Wildcard addresses are expanded to specific interface addresses when advertised.
     pub listen_addresses: Vec<Multiaddr>,
 
     /// Connection datagram buffer size.

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -31,6 +31,7 @@ use crate::{
             schema::webrtc::message::Flag,
             substream::{Message, Substream as WebRtcSubstream, SubstreamHandle},
             util::{extract_framed_message, WebRtcMessage},
+            AddressPair,
         },
         Endpoint, SUBSTREAM_OPEN_TIMEOUT,
     },
@@ -50,7 +51,6 @@ use tokio::{net::UdpSocket, sync::mpsc::Receiver};
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    net::SocketAddr,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -244,11 +244,8 @@ pub struct WebRtcConnection {
     /// Endpoint.
     endpoint: Endpoint,
 
-    /// Peer address
-    peer_address: SocketAddr,
-
-    /// Local address.
-    local_address: SocketAddr,
+    /// Addresses of the session.
+    addrs: AddressPair,
 
     /// Transport socket.
     socket: Arc<UdpSocket>,
@@ -296,8 +293,7 @@ impl WebRtcConnection {
     pub fn new(
         rtc: Rtc,
         peer: PeerId,
-        peer_address: SocketAddr,
-        local_address: SocketAddr,
+        addrs: AddressPair,
         socket: Arc<UdpSocket>,
         protocol_set: ProtocolSet,
         endpoint: Endpoint,
@@ -307,8 +303,7 @@ impl WebRtcConnection {
             rtc,
             protocol_set,
             peer,
-            peer_address,
-            local_address,
+            addrs,
             socket,
             endpoint,
             dgram_rx,
@@ -1266,8 +1261,8 @@ impl WebRtcConnection {
                             Instant::now(),
                             Receive {
                                 proto: Str0mProtocol::Udp,
-                                source: self.peer_address,
-                                destination: self.local_address,
+                                source: self.addrs.remote,
+                                destination: self.addrs.local,
                                 contents,
                             },
                         );

--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -29,6 +29,7 @@ use crate::{
     transport::{
         webrtc::{
             schema::webrtc::message::Flag,
+            socket::WebRtcSocket,
             substream::{Message, Substream as WebRtcSubstream, SubstreamHandle},
             util::{extract_framed_message, WebRtcMessage},
             AddressPair,
@@ -47,7 +48,7 @@ use str0m::{
     net::{Protocol as Str0mProtocol, Receive},
     Event, IceConnectionState, Input, Output, Rtc,
 };
-use tokio::{net::UdpSocket, sync::mpsc::Receiver};
+use tokio::sync::mpsc::Receiver;
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -248,7 +249,7 @@ pub struct WebRtcConnection {
     addrs: AddressPair,
 
     /// Transport socket.
-    socket: Arc<UdpSocket>,
+    socket: Arc<WebRtcSocket>,
 
     /// RX channel for receiving datagrams from the transport.
     dgram_rx: Receiver<Vec<u8>>,
@@ -294,7 +295,7 @@ impl WebRtcConnection {
         rtc: Rtc,
         peer: PeerId,
         addrs: AddressPair,
-        socket: Arc<UdpSocket>,
+        socket: Arc<WebRtcSocket>,
         protocol_set: ProtocolSet,
         endpoint: Endpoint,
         dgram_rx: Receiver<Vec<u8>>,
@@ -1129,7 +1130,9 @@ impl WebRtcConnection {
                         "transmit data",
                     );
 
-                    if let Err(error) = self.socket.try_send_to(&v.contents, v.destination) {
+                    if let Err(error) =
+                        self.socket.try_send_to(&v.contents, v.destination, self.addrs.local.ip())
+                    {
                         if error.kind() == std::io::ErrorKind::WouldBlock {
                             tracing::trace!(
                                 target: LOG_TARGET,

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -73,7 +73,7 @@ impl WebRtcListener {
             };
 
             listen_sockets.push((sockaddr, Arc::new(socket)));
-            listen_multi_addresses.extend(Self::build_listen_addresses(sockaddr, certhash)?);
+            listen_multi_addresses.extend(Self::build_listen_addresses(sockaddr, certhash));
         }
 
         if listen_sockets.is_empty() {
@@ -94,22 +94,19 @@ impl WebRtcListener {
 
     /// Build the multiaddresses to advertise for a socket bound to `sockaddr`.
     ///
-    /// A wildcard listen address is advertised as all matching interface addresses
-    /// (link-local IPv6 excluded).
-    fn build_listen_addresses(
-        sockaddr: SocketAddr,
-        certhash: Multihash<64>,
-    ) -> crate::Result<Vec<Multiaddr>> {
+    /// A wildcard listen address is advertised as all matching interface addresses (link-local IPv6
+    /// excluded).
+    fn build_listen_addresses(sockaddr: SocketAddr, certhash: Multihash<64>) -> Vec<Multiaddr> {
         let addresses: Vec<SocketAddr> = if sockaddr.ip().is_unspecified() {
             NetworkInterface::show()
-                .map_err(|error| {
+                .unwrap_or_else(|error| {
                     tracing::warn!(
                         target: LOG_TARGET,
                         ?error,
                         "failed to fetch network interfaces",
                     );
-                    Error::Other("failed to fetch network interfaces".to_string())
-                })?
+                    Vec::new()
+                })
                 .into_iter()
                 .flat_map(|iface| {
                     iface.addr.into_iter().filter_map(|iface_address| {
@@ -129,7 +126,15 @@ impl WebRtcListener {
             vec![sockaddr]
         };
 
-        Ok(addresses
+        if addresses.is_empty() {
+            tracing::warn!(
+                target: LOG_TARGET,
+                ?sockaddr,
+                "no interface addresses to advertise for the listen address",
+            );
+        }
+
+        addresses
             .into_iter()
             .map(|address| {
                 Multiaddr::empty()
@@ -138,7 +143,7 @@ impl WebRtcListener {
                     .with(Protocol::WebRTCDirect)
                     .with(Protocol::Certhash(certhash))
             })
-            .collect())
+            .collect()
     }
 
     /// Buffer size [`Self::poll_recv_from`] needs to never truncate a read, i.e. the largest
@@ -324,7 +329,7 @@ mod tests {
     #[test]
     fn concrete_listen_address_is_advertised_as_is() {
         let sockaddr: SocketAddr = "192.0.2.1:1234".parse().unwrap();
-        let addresses = WebRtcListener::build_listen_addresses(sockaddr, certhash()).unwrap();
+        let addresses = WebRtcListener::build_listen_addresses(sockaddr, certhash());
 
         assert_eq!(addresses.len(), 1);
         assert_eq!(unpack_address(&addresses[0]), (sockaddr, certhash()));
@@ -333,8 +338,7 @@ mod tests {
     #[test]
     fn wildcard_v4_expands_to_interface_addresses() {
         let addresses =
-            WebRtcListener::build_listen_addresses("0.0.0.0:1234".parse().unwrap(), certhash())
-                .unwrap();
+            WebRtcListener::build_listen_addresses("0.0.0.0:1234".parse().unwrap(), certhash());
 
         assert!(!addresses.is_empty());
         for address in &addresses {
@@ -349,8 +353,7 @@ mod tests {
     #[test]
     fn wildcard_v6_expands_without_link_local() {
         let addresses =
-            WebRtcListener::build_listen_addresses("[::]:1234".parse().unwrap(), certhash())
-                .unwrap();
+            WebRtcListener::build_listen_addresses("[::]:1234".parse().unwrap(), certhash());
 
         assert!(!addresses.is_empty());
         for address in &addresses {

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -277,3 +277,102 @@ impl WebRtcListener {
         Ok(socket_address)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::future::poll_fn;
+    use multihash_codetable::MultihashDigest;
+    use std::net::Ipv4Addr;
+
+    fn certhash() -> Multihash<64> {
+        multihash_codetable::Code::Sha2_256.digest(b"certificate")
+    }
+
+    fn unpack_address(address: &Multiaddr) -> (SocketAddr, Multihash<64>) {
+        let mut iter = address.iter();
+        let ip = match iter.next() {
+            Some(Protocol::Ip4(ip)) => IpAddr::V4(ip),
+            Some(Protocol::Ip6(ip)) => IpAddr::V6(ip),
+            protocol => panic!("unexpected protocol: {protocol:?}"),
+        };
+        let Some(Protocol::Udp(port)) = iter.next() else {
+            panic!("expected `Udp`");
+        };
+        assert!(matches!(iter.next(), Some(Protocol::WebRTCDirect)));
+        let Some(Protocol::Certhash(hash)) = iter.next() else {
+            panic!("expected `Certhash`");
+        };
+        assert!(iter.next().is_none());
+        (SocketAddr::new(ip, port), hash)
+    }
+
+    #[test]
+    fn concrete_listen_address_is_advertised_as_is() {
+        let sockaddr: SocketAddr = "192.0.2.1:1234".parse().unwrap();
+        let addresses = WebRtcListener::build_listen_addresses(sockaddr, certhash()).unwrap();
+
+        assert_eq!(addresses.len(), 1);
+        assert_eq!(unpack_address(&addresses[0]), (sockaddr, certhash()));
+    }
+
+    #[test]
+    fn wildcard_v4_expands_to_interface_addresses() {
+        let addresses =
+            WebRtcListener::build_listen_addresses("0.0.0.0:1234".parse().unwrap(), certhash())
+                .unwrap();
+
+        assert!(!addresses.is_empty());
+        for address in &addresses {
+            let (sockaddr, hash) = unpack_address(address);
+            assert!(sockaddr.is_ipv4());
+            assert!(!sockaddr.ip().is_unspecified());
+            assert_eq!(sockaddr.port(), 1234);
+            assert_eq!(hash, certhash());
+        }
+    }
+
+    #[test]
+    fn wildcard_v6_expands_without_link_local() {
+        let addresses =
+            WebRtcListener::build_listen_addresses("[::]:1234".parse().unwrap(), certhash())
+                .unwrap();
+
+        assert!(!addresses.is_empty());
+        for address in &addresses {
+            let (sockaddr, hash) = unpack_address(address);
+            let IpAddr::V6(ip) = sockaddr.ip() else {
+                panic!("expected IPv6, got {sockaddr}");
+            };
+            assert!(!ip.is_unspecified());
+            assert_ne!(ip.segments()[0], 0xfe80);
+            assert_eq!(sockaddr.port(), 1234);
+            assert_eq!(hash, certhash());
+        }
+    }
+
+    #[tokio::test]
+    async fn wildcard_listener_reports_address_pair() {
+        let (mut listener, _) = WebRtcListener::new(
+            vec!["/ip4/0.0.0.0/udp/0/webrtc-direct".parse().unwrap()],
+            certhash(),
+        )
+        .unwrap();
+        let port = listener.listen_sockets[0].0.port();
+
+        let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        sender.send_to(b"litep2p", (Ipv4Addr::LOCALHOST, port)).await.unwrap();
+
+        let mut buf = [0u8; 1500];
+        let (addrs, meta, _) = poll_fn(|cx| listener.poll_recv_from(cx, &mut buf)).await.unwrap();
+
+        assert_eq!(
+            addrs,
+            AddressPair {
+                local: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+                remote: sender.local_addr().unwrap(),
+            }
+        );
+        assert_eq!(&buf[..meta.len], b"litep2p");
+    }
+}

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -10,6 +10,7 @@ use std::{
 
 use futures_timer::Delay;
 use multiaddr::{multihash::Multihash, Multiaddr, Protocol};
+use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use quinn_udp::{RecvMeta, UdpSockRef, UdpSocketState};
 use socket2::{Domain, Socket, Type};
 use tokio::{io::Interest, net::UdpSocket};
@@ -41,14 +42,6 @@ impl WebRtcListener {
         let handle_multiaddr =
             |listen_socket| -> crate::Result<(UdpSocket, UdpSocketState, SocketAddr)> {
                 let listen_socket = Self::get_socket_address(&listen_socket)?;
-                // Unspecified addresses (`0.0.0.0` / `[::]`) are rejected,
-                // WebRTC ICE candidates must carry a concrete IP, so the listener must
-                // be bound to a specific address of a local interface.
-                if listen_socket.ip().is_unspecified() {
-                    return Err(Error::Other(
-                        "WebRTC cannot listen on an unspecified address".to_string(),
-                    ));
-                }
 
                 let socket = if listen_socket.is_ipv4() {
                     Socket::new(Domain::IPV4, Type::DGRAM, Some(socket2::Protocol::UDP))?
@@ -79,13 +72,52 @@ impl WebRtcListener {
             };
 
             listen_sockets.push((listen_socket, Arc::new(socket), state));
-            listen_multi_addresses.push(
-                Multiaddr::empty()
-                    .with(Protocol::from(listen_socket.ip()))
-                    .with(Protocol::Udp(listen_socket.port()))
-                    .with(Protocol::WebRTCDirect)
-                    .with(Protocol::Certhash(certificate)),
-            );
+
+            // A wildcard listen address is advertised as all matching
+            // interface addresses (link-local IPv6 excluded).
+            let advertised: Vec<SocketAddr> = if listen_socket.ip().is_unspecified() {
+                NetworkInterface::show()
+                    .map_err(|error| {
+                        tracing::warn!(
+                            target: LOG_TARGET,
+                            ?error,
+                            "failed to fetch network interfaces",
+                        );
+                        Error::Other("failed to fetch network interfaces".to_string())
+                    })?
+                    .into_iter()
+                    .flat_map(|record| {
+                        record.addr.into_iter().filter_map(|iface_address| {
+                            match (iface_address, listen_socket.is_ipv4()) {
+                                (Addr::V4(inner), true) => Some(SocketAddr::new(
+                                    IpAddr::V4(inner.ip),
+                                    listen_socket.port(),
+                                )),
+                                (Addr::V6(inner), false) => match inner.ip.segments().first() {
+                                    Some(0xfe80) => None,
+                                    _ => Some(SocketAddr::new(
+                                        IpAddr::V6(inner.ip),
+                                        listen_socket.port(),
+                                    )),
+                                },
+                                _ => None,
+                            }
+                        })
+                    })
+                    .collect()
+            } else {
+                vec![listen_socket]
+            };
+
+            for address in advertised {
+                listen_multi_addresses.push(
+                    Multiaddr::empty()
+                        .with(Protocol::from(address.ip()))
+                        .with(Protocol::Udp(address.port()))
+                        .with(Protocol::WebRTCDirect)
+                        .with(Protocol::Certhash(certificate)),
+                );
+            }
         }
 
         if listen_sockets.is_empty() {
@@ -104,10 +136,17 @@ impl WebRtcListener {
         ))
     }
 
+    /// Get the socket receiving datagrams destined to `local` address,
+    /// either bound to it exactly or to a matching wildcard address.
     pub(super) fn socket(&self, local: &SocketAddr) -> Option<Arc<UdpSocket>> {
         self.listen_sockets
             .iter()
-            .find(|(addr, ..)| local == addr)
+            .find(|(addr, ..)| {
+                addr == local
+                    || (addr.ip().is_unspecified()
+                        && addr.port() == local.port()
+                        && addr.is_ipv4() == local.is_ipv4())
+            })
             .map(|(_, socket, _)| socket.clone())
     }
 
@@ -152,10 +191,28 @@ impl WebRtcListener {
                             )
                         }) {
                             Ok(_) => {
+                                // The local IP of the session comes from
+                                // `IP_PKTINFO`/`IPV6_PKTINFO`; fall back to the
+                                // bound address on platforms not reporting it.
+                                let local = SocketAddr::new(
+                                    meta.dst_ip.unwrap_or_else(|| local.ip()),
+                                    local.port(),
+                                );
+                                if local.ip().is_unspecified() {
+                                    // Wildcard socket & no `dst_ip`: the local
+                                    // address is unknown, drop the datagram.
+                                    // Can't happen on *nix.
+                                    tracing::debug!(
+                                        target: LOG_TARGET,
+                                        ?local,
+                                        "dropping datagram without destination address",
+                                    );
+                                    continue;
+                                }
                                 self.next_listener = idx;
                                 return Poll::Ready(Ok((
                                     AddressPair {
-                                        local: *local,
+                                        local,
                                         remote: meta.addr,
                                     },
                                     meta,

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -1,6 +1,6 @@
 use std::{
     future::Future,
-    io,
+    io::{self, IoSliceMut},
     net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::Arc,
@@ -10,8 +10,9 @@ use std::{
 
 use futures_timer::Delay;
 use multiaddr::{multihash::Multihash, Multiaddr, Protocol};
+use quinn_udp::{RecvMeta, UdpSockRef, UdpSocketState};
 use socket2::{Domain, Socket, Type};
-use tokio::{io::ReadBuf, net::UdpSocket};
+use tokio::{io::Interest, net::UdpSocket};
 
 use super::AddressPair;
 use crate::{error::AddressError, Error};
@@ -20,8 +21,8 @@ const LOG_TARGET: &str = "litep2p::webrtc::listener";
 
 /// WebRtc listener.
 pub(super) struct WebRtcListener {
-    /// Bound sockets paired with their local address.
-    listen_sockets: Vec<(SocketAddr, Arc<UdpSocket>)>,
+    /// Bound sockets paired with their local address and `quinn-udp` socket state.
+    listen_sockets: Vec<(SocketAddr, Arc<UdpSocket>, UdpSocketState)>,
 
     /// Index of the socket to poll first on the next call (round-robin).
     next_listener: usize,
@@ -37,35 +38,39 @@ impl WebRtcListener {
         let mut listen_multi_addresses = Vec::with_capacity(multiaddr_listen_addresses.len());
         let mut listen_sockets = Vec::with_capacity(multiaddr_listen_addresses.len());
 
-        let handle_multiaddr = |listen_socket| -> crate::Result<(UdpSocket, SocketAddr)> {
-            let listen_socket = Self::get_socket_address(&listen_socket)?;
-            // Unspecified addresses (`0.0.0.0` / `[::]`) are rejected,
-            // WebRTC ICE candidates must carry a concrete IP, so the listener must
-            // be bound to a specific address of a local interface.
-            if listen_socket.ip().is_unspecified() {
-                return Err(Error::Other(
-                    "WebRTC cannot listen on an unspecified address".to_string(),
-                ));
-            }
+        let handle_multiaddr =
+            |listen_socket| -> crate::Result<(UdpSocket, UdpSocketState, SocketAddr)> {
+                let listen_socket = Self::get_socket_address(&listen_socket)?;
+                // Unspecified addresses (`0.0.0.0` / `[::]`) are rejected,
+                // WebRTC ICE candidates must carry a concrete IP, so the listener must
+                // be bound to a specific address of a local interface.
+                if listen_socket.ip().is_unspecified() {
+                    return Err(Error::Other(
+                        "WebRTC cannot listen on an unspecified address".to_string(),
+                    ));
+                }
 
-            let socket = if listen_socket.is_ipv4() {
-                Socket::new(Domain::IPV4, Type::DGRAM, Some(socket2::Protocol::UDP))?
-            } else {
-                let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(socket2::Protocol::UDP))?;
-                socket.set_only_v6(true)?;
-                socket
+                let socket = if listen_socket.is_ipv4() {
+                    Socket::new(Domain::IPV4, Type::DGRAM, Some(socket2::Protocol::UDP))?
+                } else {
+                    let socket =
+                        Socket::new(Domain::IPV6, Type::DGRAM, Some(socket2::Protocol::UDP))?;
+                    socket.set_only_v6(true)?;
+                    socket
+                };
+
+                socket.bind(&listen_socket.into())?;
+                socket.set_nonblocking(true)?;
+
+                let socket = UdpSocket::from_std(socket.into())?;
+                // Sets up `IP_PKTINFO`/`IPV6_RECVPKTINFO` & GRO where available.
+                let state = UdpSocketState::new(UdpSockRef::from(&socket))?;
+                let listen_socket = socket.local_addr()?;
+                Ok((socket, state, listen_socket))
             };
 
-            socket.bind(&listen_socket.into())?;
-            socket.set_nonblocking(true)?;
-
-            let socket = UdpSocket::from_std(socket.into())?;
-            let listen_socket = socket.local_addr()?;
-            Ok((socket, listen_socket))
-        };
-
         for listen_socket in multiaddr_listen_addresses {
-            let (socket, listen_socket) = match handle_multiaddr(listen_socket) {
+            let (socket, state, listen_socket) = match handle_multiaddr(listen_socket) {
                 Ok(res) => res,
                 Err(err) => {
                     tracing::warn!(target: LOG_TARGET, ?err, "failed to bind listen address");
@@ -73,7 +78,7 @@ impl WebRtcListener {
                 }
             };
 
-            listen_sockets.push((listen_socket, Arc::new(socket)));
+            listen_sockets.push((listen_socket, Arc::new(socket), state));
             listen_multi_addresses.push(
                 Multiaddr::empty()
                     .with(Protocol::from(listen_socket.ip()))
@@ -102,15 +107,19 @@ impl WebRtcListener {
     pub(super) fn socket(&self, local: &SocketAddr) -> Option<Arc<UdpSocket>> {
         self.listen_sockets
             .iter()
-            .find(|(addr, _)| local == addr)
-            .map(|(_, socket)| socket.clone())
+            .find(|(addr, ..)| local == addr)
+            .map(|(_, socket, _)| socket.clone())
     }
 
+    /// Poll the sockets for an inbound read.
+    ///
+    /// The filled part of `buf` (`meta.len` bytes) may contain multiple GRO-coalesced
+    /// datagrams of `meta.stride` bytes each, with only the last one possibly shorter.
     pub(super) fn poll_recv_from(
         &mut self,
         cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<io::Result<AddressPair>> {
+        buf: &mut [u8],
+    ) -> Poll<io::Result<(AddressPair, RecvMeta)>> {
         let n_listener = self.listen_sockets.len();
         debug_assert!(n_listener > 0);
 
@@ -127,27 +136,59 @@ impl WebRtcListener {
         let mut any_pending = false;
 
         loop {
-            let (local, socket) = &self.listen_sockets[idx];
+            let (local, socket, state) = &self.listen_sockets[idx];
             idx = (idx + 1) % n_listener;
 
-            match socket.poll_recv_from(cx, buf) {
-                Poll::Ready(Ok(remote)) => {
-                    self.next_listener = idx;
-                    return Poll::Ready(Ok(AddressPair {
-                        local: *local,
-                        remote,
-                    }));
+            loop {
+                match socket.poll_recv_ready(cx) {
+                    Poll::Ready(Ok(())) => {
+                        let mut meta = RecvMeta::default();
+                        let mut iov = [IoSliceMut::new(&mut *buf)];
+                        match socket.try_io(Interest::READABLE, || {
+                            state.recv(
+                                UdpSockRef::from(socket.as_ref()),
+                                &mut iov,
+                                std::slice::from_mut(&mut meta),
+                            )
+                        }) {
+                            Ok(_) => {
+                                self.next_listener = idx;
+                                return Poll::Ready(Ok((
+                                    AddressPair {
+                                        local: *local,
+                                        remote: meta.addr,
+                                    },
+                                    meta,
+                                )));
+                            }
+                            // Readiness was a false positive; re-poll to register the waker
+                            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                            // All `UdpSocket` errors are transient, no connection to terminate
+                            Err(e) => {
+                                tracing::debug!(
+                                    target: LOG_TARGET,
+                                    ?local,
+                                    ?e,
+                                    "failed to receive a datagram",
+                                );
+                                break;
+                            }
+                        }
+                    }
+                    Poll::Ready(Err(e)) => {
+                        tracing::debug!(
+                            target: LOG_TARGET,
+                            ?local,
+                            ?e,
+                            "failed to poll socket readiness",
+                        );
+                        break;
+                    }
+                    Poll::Pending => {
+                        any_pending = true;
+                        break;
+                    }
                 }
-                // All UdpSocket errors are transient and noone
-                // of them implies a complete shutdown of the socket.
-                // Log the error but do not tear down the WebRtc instance.
-                Poll::Ready(Err(e)) => tracing::debug!(
-                    target: LOG_TARGET,
-                    ?local,
-                    ?e,
-                    "failed to receive a datagram",
-                ),
-                Poll::Pending => any_pending = true,
             }
 
             // Each socket that returned Pending registered its waker,

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -136,20 +136,6 @@ impl WebRtcListener {
         ))
     }
 
-    /// Get the socket receiving datagrams destined to `local` address,
-    /// either bound to it exactly or to a matching wildcard address.
-    pub(super) fn socket(&self, local: &SocketAddr) -> Option<Arc<UdpSocket>> {
-        self.listen_sockets
-            .iter()
-            .find(|(addr, ..)| {
-                addr == local
-                    || (addr.ip().is_unspecified()
-                        && addr.port() == local.port()
-                        && addr.is_ipv4() == local.is_ipv4())
-            })
-            .map(|(_, socket, _)| socket.clone())
-    }
-
     /// Poll the sockets for an inbound read.
     ///
     /// The filled part of `buf` (`meta.len` bytes) may contain multiple GRO-coalesced
@@ -158,7 +144,7 @@ impl WebRtcListener {
         &mut self,
         cx: &mut Context<'_>,
         buf: &mut [u8],
-    ) -> Poll<io::Result<(AddressPair, RecvMeta)>> {
+    ) -> Poll<io::Result<(AddressPair, RecvMeta, Arc<UdpSocket>)>> {
         let n_listener = self.listen_sockets.len();
         debug_assert!(n_listener > 0);
 
@@ -216,6 +202,7 @@ impl WebRtcListener {
                                         remote: meta.addr,
                                     },
                                     meta,
+                                    socket.clone(),
                                 )));
                             }
                             // Readiness was a false positive; re-poll to register the waker

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -1,6 +1,6 @@
 use std::{
     future::Future,
-    io::{self, IoSliceMut},
+    io,
     net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::Arc,
@@ -11,19 +11,19 @@ use std::{
 use futures_timer::Delay;
 use multiaddr::{multihash::Multihash, Multiaddr, Protocol};
 use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
-use quinn_udp::{RecvMeta, UdpSockRef, UdpSocketState};
+use quinn_udp::RecvMeta;
 use socket2::{Domain, Socket, Type};
-use tokio::{io::Interest, net::UdpSocket};
+use tokio::net::UdpSocket;
 
 use super::AddressPair;
-use crate::{error::AddressError, Error};
+use crate::{error::AddressError, transport::webrtc::socket::WebRtcSocket, Error};
 
 const LOG_TARGET: &str = "litep2p::webrtc::listener";
 
 /// WebRtc listener.
 pub(super) struct WebRtcListener {
-    /// Bound sockets paired with their local address and `quinn-udp` socket state.
-    listen_sockets: Vec<(SocketAddr, Arc<UdpSocket>, UdpSocketState)>,
+    /// Bound sockets paired with their local address.
+    listen_sockets: Vec<(SocketAddr, Arc<WebRtcSocket>)>,
 
     /// Index of the socket to poll first on the next call (round-robin).
     next_listener: usize,
@@ -39,7 +39,7 @@ impl WebRtcListener {
         let mut listen_multi_addresses = Vec::with_capacity(listen_addresses.len());
         let mut listen_sockets = Vec::with_capacity(listen_addresses.len());
 
-        let handle_multiaddr = |address| -> crate::Result<(UdpSocket, UdpSocketState, SocketAddr)> {
+        let handle_multiaddr = |address| -> crate::Result<(WebRtcSocket, SocketAddr)> {
             let sockaddr = Self::get_socket_address(&address)?;
 
             let socket = if sockaddr.is_ipv4() {
@@ -54,15 +54,13 @@ impl WebRtcListener {
             socket.set_nonblocking(true)?;
 
             let socket = UdpSocket::from_std(socket.into())?;
-            // Sets up `IP_PKTINFO`/`IPV6_RECVPKTINFO` & GRO where available.
-            let socket_state = UdpSocketState::new(UdpSockRef::from(&socket))?;
             // Re-read the bound address to resolve an ephemeral port (`/udp/0`).
             let sockaddr = socket.local_addr()?;
-            Ok((socket, socket_state, sockaddr))
+            Ok((WebRtcSocket::new(socket)?, sockaddr))
         };
 
         for multiaddr in listen_addresses {
-            let (socket, socket_state, sockaddr) = match handle_multiaddr(multiaddr) {
+            let (socket, sockaddr) = match handle_multiaddr(multiaddr) {
                 Ok(res) => res,
                 Err(err) => {
                     tracing::warn!(target: LOG_TARGET, ?err, "failed to bind listen address");
@@ -70,7 +68,7 @@ impl WebRtcListener {
                 }
             };
 
-            listen_sockets.push((sockaddr, Arc::new(socket), socket_state));
+            listen_sockets.push((sockaddr, Arc::new(socket)));
             listen_multi_addresses.extend(Self::build_listen_addresses(sockaddr, certhash)?);
         }
 
@@ -147,7 +145,7 @@ impl WebRtcListener {
         &mut self,
         cx: &mut Context<'_>,
         buf: &mut [u8],
-    ) -> Poll<io::Result<(AddressPair, RecvMeta, Arc<UdpSocket>)>> {
+    ) -> Poll<io::Result<(AddressPair, RecvMeta, Arc<WebRtcSocket>)>> {
         let n_listener = self.listen_sockets.len();
         debug_assert!(n_listener > 0);
 
@@ -164,70 +162,47 @@ impl WebRtcListener {
         let mut any_pending = false;
 
         loop {
-            let (local, socket, state) = &self.listen_sockets[idx];
+            let (local, socket) = &self.listen_sockets[idx];
             idx = (idx + 1) % n_listener;
 
             loop {
-                match socket.poll_recv_ready(cx) {
-                    Poll::Ready(Ok(())) => {
-                        let mut meta = RecvMeta::default();
-                        let mut iov = [IoSliceMut::new(&mut *buf)];
-                        match socket.try_io(Interest::READABLE, || {
-                            state.recv(
-                                UdpSockRef::from(socket.as_ref()),
-                                &mut iov,
-                                std::slice::from_mut(&mut meta),
-                            )
-                        }) {
-                            Ok(_) => {
-                                // The local IP of the session comes from
-                                // `IP_PKTINFO`/`IPV6_PKTINFO`; fall back to the
-                                // bound address on platforms not reporting it.
-                                let local = SocketAddr::new(
-                                    meta.dst_ip.unwrap_or_else(|| local.ip()),
-                                    local.port(),
-                                );
-                                if local.ip().is_unspecified() {
-                                    // Wildcard socket & no `dst_ip`: the local
-                                    // address is unknown, drop the datagram.
-                                    // Can't happen on *nix.
-                                    tracing::debug!(
-                                        target: LOG_TARGET,
-                                        ?local,
-                                        "dropping datagram without destination address",
-                                    );
-                                    continue;
-                                }
-                                self.next_listener = idx;
-                                return Poll::Ready(Ok((
-                                    AddressPair {
-                                        local,
-                                        remote: meta.addr,
-                                    },
-                                    meta,
-                                    socket.clone(),
-                                )));
-                            }
-                            // Readiness was a false positive; re-poll to register the waker
-                            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                            // All `UdpSocket` errors are transient, no connection to terminate
-                            Err(e) => {
-                                tracing::debug!(
-                                    target: LOG_TARGET,
-                                    ?local,
-                                    ?e,
-                                    "failed to receive a datagram",
-                                );
-                                break;
-                            }
+                match socket.poll_recv(cx, buf) {
+                    Poll::Ready(Ok(meta)) => {
+                        // The local IP of the session comes from
+                        // `IP_PKTINFO`/`IPV6_PKTINFO`; fall back to the
+                        // bound address on platforms not reporting it.
+                        let local = SocketAddr::new(
+                            meta.dst_ip.unwrap_or_else(|| local.ip()),
+                            local.port(),
+                        );
+                        if local.ip().is_unspecified() {
+                            // Wildcard socket & no `dst_ip`: the local
+                            // address is unknown, drop the datagram.
+                            // Can't happen on *nix.
+                            tracing::debug!(
+                                target: LOG_TARGET,
+                                ?local,
+                                "dropping datagram without destination address",
+                            );
+                            continue;
                         }
+                        self.next_listener = idx;
+                        return Poll::Ready(Ok((
+                            AddressPair {
+                                local,
+                                remote: meta.addr,
+                            },
+                            meta,
+                            socket.clone(),
+                        )));
                     }
+                    // All `UdpSocket` errors are transient, no connection to terminate
                     Poll::Ready(Err(e)) => {
                         tracing::debug!(
                             target: LOG_TARGET,
                             ?local,
                             ?e,
-                            "failed to poll socket readiness",
+                            "failed to receive a datagram",
                         );
                         break;
                     }

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -33,37 +33,36 @@ pub(super) struct WebRtcListener {
 
 impl WebRtcListener {
     pub(super) fn new(
-        multiaddr_listen_addresses: Vec<Multiaddr>,
-        certificate: Multihash<64>,
+        listen_addresses: Vec<Multiaddr>,
+        certhash: Multihash<64>,
     ) -> crate::Result<(Self, Vec<Multiaddr>)> {
-        let mut listen_multi_addresses = Vec::with_capacity(multiaddr_listen_addresses.len());
-        let mut listen_sockets = Vec::with_capacity(multiaddr_listen_addresses.len());
+        let mut listen_multi_addresses = Vec::with_capacity(listen_addresses.len());
+        let mut listen_sockets = Vec::with_capacity(listen_addresses.len());
 
-        let handle_multiaddr =
-            |listen_socket| -> crate::Result<(UdpSocket, UdpSocketState, SocketAddr)> {
-                let listen_socket = Self::get_socket_address(&listen_socket)?;
+        let handle_multiaddr = |address| -> crate::Result<(UdpSocket, UdpSocketState, SocketAddr)> {
+            let sockaddr = Self::get_socket_address(&address)?;
 
-                let socket = if listen_socket.is_ipv4() {
-                    Socket::new(Domain::IPV4, Type::DGRAM, Some(socket2::Protocol::UDP))?
-                } else {
-                    let socket =
-                        Socket::new(Domain::IPV6, Type::DGRAM, Some(socket2::Protocol::UDP))?;
-                    socket.set_only_v6(true)?;
-                    socket
-                };
-
-                socket.bind(&listen_socket.into())?;
-                socket.set_nonblocking(true)?;
-
-                let socket = UdpSocket::from_std(socket.into())?;
-                // Sets up `IP_PKTINFO`/`IPV6_RECVPKTINFO` & GRO where available.
-                let state = UdpSocketState::new(UdpSockRef::from(&socket))?;
-                let listen_socket = socket.local_addr()?;
-                Ok((socket, state, listen_socket))
+            let socket = if sockaddr.is_ipv4() {
+                Socket::new(Domain::IPV4, Type::DGRAM, Some(socket2::Protocol::UDP))?
+            } else {
+                let socket = Socket::new(Domain::IPV6, Type::DGRAM, Some(socket2::Protocol::UDP))?;
+                socket.set_only_v6(true)?;
+                socket
             };
 
-        for listen_socket in multiaddr_listen_addresses {
-            let (socket, state, listen_socket) = match handle_multiaddr(listen_socket) {
+            socket.bind(&sockaddr.into())?;
+            socket.set_nonblocking(true)?;
+
+            let socket = UdpSocket::from_std(socket.into())?;
+            // Sets up `IP_PKTINFO`/`IPV6_RECVPKTINFO` & GRO where available.
+            let socket_state = UdpSocketState::new(UdpSockRef::from(&socket))?;
+            // Re-read the bound address to resolve an ephemeral port (`/udp/0`).
+            let sockaddr = socket.local_addr()?;
+            Ok((socket, socket_state, sockaddr))
+        };
+
+        for multiaddr in listen_addresses {
+            let (socket, socket_state, sockaddr) = match handle_multiaddr(multiaddr) {
                 Ok(res) => res,
                 Err(err) => {
                     tracing::warn!(target: LOG_TARGET, ?err, "failed to bind listen address");
@@ -71,53 +70,8 @@ impl WebRtcListener {
                 }
             };
 
-            listen_sockets.push((listen_socket, Arc::new(socket), state));
-
-            // A wildcard listen address is advertised as all matching
-            // interface addresses (link-local IPv6 excluded).
-            let advertised: Vec<SocketAddr> = if listen_socket.ip().is_unspecified() {
-                NetworkInterface::show()
-                    .map_err(|error| {
-                        tracing::warn!(
-                            target: LOG_TARGET,
-                            ?error,
-                            "failed to fetch network interfaces",
-                        );
-                        Error::Other("failed to fetch network interfaces".to_string())
-                    })?
-                    .into_iter()
-                    .flat_map(|record| {
-                        record.addr.into_iter().filter_map(|iface_address| {
-                            match (iface_address, listen_socket.is_ipv4()) {
-                                (Addr::V4(inner), true) => Some(SocketAddr::new(
-                                    IpAddr::V4(inner.ip),
-                                    listen_socket.port(),
-                                )),
-                                (Addr::V6(inner), false) => match inner.ip.segments().first() {
-                                    Some(0xfe80) => None,
-                                    _ => Some(SocketAddr::new(
-                                        IpAddr::V6(inner.ip),
-                                        listen_socket.port(),
-                                    )),
-                                },
-                                _ => None,
-                            }
-                        })
-                    })
-                    .collect()
-            } else {
-                vec![listen_socket]
-            };
-
-            for address in advertised {
-                listen_multi_addresses.push(
-                    Multiaddr::empty()
-                        .with(Protocol::from(address.ip()))
-                        .with(Protocol::Udp(address.port()))
-                        .with(Protocol::WebRTCDirect)
-                        .with(Protocol::Certhash(certificate)),
-                );
-            }
+            listen_sockets.push((sockaddr, Arc::new(socket), socket_state));
+            listen_multi_addresses.extend(Self::build_listen_addresses(sockaddr, certhash)?);
         }
 
         if listen_sockets.is_empty() {
@@ -134,6 +88,55 @@ impl WebRtcListener {
             },
             listen_multi_addresses,
         ))
+    }
+
+    /// Build the multiaddresses to advertise for a socket bound to `sockaddr`.
+    ///
+    /// A wildcard listen address is advertised as all matching interface addresses
+    /// (link-local IPv6 excluded).
+    fn build_listen_addresses(
+        sockaddr: SocketAddr,
+        certhash: Multihash<64>,
+    ) -> crate::Result<Vec<Multiaddr>> {
+        let addresses: Vec<SocketAddr> = if sockaddr.ip().is_unspecified() {
+            NetworkInterface::show()
+                .map_err(|error| {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        ?error,
+                        "failed to fetch network interfaces",
+                    );
+                    Error::Other("failed to fetch network interfaces".to_string())
+                })?
+                .into_iter()
+                .flat_map(|iface| {
+                    iface.addr.into_iter().filter_map(|iface_address| {
+                        match (iface_address, sockaddr.is_ipv4()) {
+                            (Addr::V4(addr), true) =>
+                                Some(SocketAddr::new(IpAddr::V4(addr.ip), sockaddr.port())),
+                            (Addr::V6(addr), false) => match addr.ip.segments().first() {
+                                Some(0xfe80) => None,
+                                _ => Some(SocketAddr::new(IpAddr::V6(addr.ip), sockaddr.port())),
+                            },
+                            _ => None,
+                        }
+                    })
+                })
+                .collect()
+        } else {
+            vec![sockaddr]
+        };
+
+        Ok(addresses
+            .into_iter()
+            .map(|address| {
+                Multiaddr::empty()
+                    .with(Protocol::from(address.ip()))
+                    .with(Protocol::Udp(address.port()))
+                    .with(Protocol::WebRTCDirect)
+                    .with(Protocol::Certhash(certhash))
+            })
+            .collect())
     }
 
     /// Poll the sockets for an inbound read.

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -16,7 +16,11 @@ use socket2::{Domain, Socket, Type};
 use tokio::net::UdpSocket;
 
 use super::AddressPair;
-use crate::{error::AddressError, transport::webrtc::socket::WebRtcSocket, Error};
+use crate::{
+    error::AddressError,
+    transport::webrtc::socket::{WebRtcSocket, MAX_DATAGRAM_SIZE},
+    Error,
+};
 
 const LOG_TARGET: &str = "litep2p::webrtc::listener";
 
@@ -135,6 +139,16 @@ impl WebRtcListener {
                     .with(Protocol::Certhash(certhash))
             })
             .collect())
+    }
+
+    /// Buffer size [`Self::poll_recv_from`] needs to never truncate a read, i.e. the largest
+    /// read any of the bound sockets can produce.
+    pub(super) fn max_read_size(&self) -> usize {
+        self.listen_sockets
+            .iter()
+            .map(|(_, socket)| socket.max_read_size())
+            .max()
+            .unwrap_or(MAX_DATAGRAM_SIZE)
     }
 
     /// Poll the sockets for an inbound read.

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -1,3 +1,25 @@
+// Copyright 2026 litep2p developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Listener for WebRTC.
+
 use std::{
     future::Future,
     io,

--- a/src/transport/webrtc/listener.rs
+++ b/src/transport/webrtc/listener.rs
@@ -131,11 +131,11 @@ impl WebRtcListener {
             idx = (idx + 1) % n_listener;
 
             match socket.poll_recv_from(cx, buf) {
-                Poll::Ready(Ok(source)) => {
+                Poll::Ready(Ok(remote)) => {
                     self.next_listener = idx;
                     return Poll::Ready(Ok(AddressPair {
                         local: *local,
-                        source,
+                        remote,
                     }));
                 }
                 // All UdpSocket errors are transient and noone

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -88,10 +88,6 @@ const LOG_TARGET: &str = "litep2p::webrtc";
 const REMOTE_FINGERPRINT: &str =
     "sha-256 FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF";
 
-/// Capacity of the buffer used for a single socket read. GRO can coalesce up to
-/// (64 KiB - IP/UDP headers) of same-flow datagrams into one read.
-const WEBRTC_BUFFER_SIZE: usize = 64 * 1024;
-
 /// Connection context.
 struct ConnectionContext {
     /// Remote peer ID.
@@ -450,6 +446,7 @@ impl TransportBuilder for WebRtcTransport {
 
         let (listener, listen_multi_addresses) =
             WebRtcListener::new(config.listen_addresses, cert_hash)?;
+        let read_buffer = vec![0; listener.max_read_size()];
 
         Ok((
             Self {
@@ -463,7 +460,7 @@ impl TransportBuilder for WebRtcTransport {
                 timeouts: HashMap::new(),
                 pending_events: VecDeque::new(),
                 datagram_buffer_size: config.datagram_buffer_size,
-                read_buffer: vec![0; WEBRTC_BUFFER_SIZE],
+                read_buffer,
             },
             listen_multi_addresses,
         ))

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -88,9 +88,9 @@ const LOG_TARGET: &str = "litep2p::webrtc";
 const REMOTE_FINGERPRINT: &str =
     "sha-256 FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF";
 
-/// Capacity of the buffer used for a single socket read. GRO can coalesce
-/// up to 64 KiB of same-flow datagrams into one read.
-const WEBRTC_BUFFER_SIZE: usize = u16::MAX as usize;
+/// Capacity of the buffer used for a single socket read. GRO can coalesce up to
+/// (64 KiB - IP/UDP headers) of same-flow datagrams into one read.
+const WEBRTC_BUFFER_SIZE: usize = 64 * 1024;
 
 /// Connection context.
 struct ConnectionContext {

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -434,7 +434,7 @@ impl TransportBuilder for WebRtcTransport {
             ));
         }
 
-        tracing::info!(
+        tracing::debug!(
             target: LOG_TARGET,
             listen_addresses = ?config.listen_addresses,
             "start webrtc transport",

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -47,10 +47,7 @@ use str0m::{
     Candidate, Input, Rtc, RtcError,
 };
 
-use tokio::{
-    io::ReadBuf,
-    sync::mpsc::{channel, error::TrySendError, Sender},
-};
+use tokio::sync::mpsc::{channel, error::TrySendError, Sender};
 
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
@@ -90,8 +87,9 @@ const LOG_TARGET: &str = "litep2p::webrtc";
 const REMOTE_FINGERPRINT: &str =
     "sha-256 FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF:FF";
 
-/// Max Capacity of a WebRtc buffer used to receive a single inbound UDP datagram.
-const WEBRTC_BUFFER_SIZE: usize = 16 * 1024;
+/// Capacity of the buffer used for a single socket read. GRO can coalesce
+/// up to 64 KiB of same-flow datagrams into one read.
+const WEBRTC_BUFFER_SIZE: usize = u16::MAX as usize;
 
 /// Connection context.
 struct ConnectionContext {
@@ -655,8 +653,7 @@ impl Stream for WebRtcTransport {
         }
 
         loop {
-            let mut read_buf = ReadBuf::new(&mut this.read_buffer);
-            let addrs = match this.listener.poll_recv_from(cx, &mut read_buf) {
+            let (addrs, meta) = match this.listener.poll_recv_from(cx, &mut this.read_buffer) {
                 // No error is expected to be returned by the listener.
                 Poll::Ready(Err(error)) => {
                     tracing::info!(
@@ -667,13 +664,42 @@ impl Stream for WebRtcTransport {
                     return Poll::Ready(None);
                 }
                 Poll::Pending => break,
-                Poll::Ready(Ok(addrs)) => addrs,
+                Poll::Ready(Ok(res)) => res,
             };
 
-            let buf = read_buf.filled().to_vec();
-            match this.on_socket_input(addrs, buf) {
-                Ok(false) => {}
-                Ok(true) => loop {
+            // `stride == 0` is only possible with `len == 0`
+            // (`quinn-udp` sets `stride = len` when GRO info is absent),
+            // normalize it to keep the loop below finite.
+            let stride = if meta.stride == 0 {
+                meta.len
+            } else {
+                meta.stride
+            };
+
+            // The read may contain multiple GRO-coalesced datagrams,
+            // feed them to the connection one by one.
+            let mut should_poll = false;
+            let mut offset = 0;
+            while offset < meta.len {
+                let len = stride.min(meta.len - offset);
+                let datagram = this.read_buffer[offset..offset + len].to_vec();
+                offset += len;
+
+                match this.on_socket_input(addrs, datagram) {
+                    Ok(poll) => should_poll |= poll,
+                    Err(error) => {
+                        tracing::debug!(
+                            target: LOG_TARGET,
+                            ?addrs,
+                            ?error,
+                            "failed to handle datagram",
+                        );
+                    }
+                }
+            }
+
+            if should_poll {
+                loop {
                     match this.poll_connection(&addrs) {
                         ConnectionEvent::ConnectionEstablished { peer, endpoint } => {
                             this.connections
@@ -701,14 +727,6 @@ impl Stream for WebRtcTransport {
                             break;
                         }
                     }
-                },
-                Err(error) => {
-                    tracing::debug!(
-                        target: LOG_TARGET,
-                        ?addrs,
-                        ?error,
-                        "failed to handle datagram",
-                    );
                 }
             }
         }

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -47,7 +47,10 @@ use str0m::{
     Candidate, Input, Rtc, RtcError,
 };
 
-use tokio::sync::mpsc::{channel, error::TrySendError, Sender};
+use tokio::{
+    net::UdpSocket,
+    sync::mpsc::{channel, error::TrySendError, Sender},
+};
 
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
@@ -255,24 +258,15 @@ impl WebRtcTransport {
                 opening::WebRtcEvent::Transmit {
                     destination,
                     datagram,
-                } => {
-                    let Some(socket) = self.listener.socket(&addrs.local) else {
-                        tracing::warn!(
-                            target: LOG_TARGET,
-                            ?addrs,
-                            "no socket bound to local address in listener, dropping outbound datagram",
-                        );
-                        continue;
-                    };
-                    if let Err(error) = socket.try_send_to(&datagram, destination) {
+                } =>
+                    if let Err(error) = connection.socket().try_send_to(&datagram, destination) {
                         tracing::warn!(
                             target: LOG_TARGET,
                             ?addrs,
                             ?error,
                             "failed to send datagram",
                         );
-                    }
-                }
+                    },
                 opening::WebRtcEvent::ConnectionClosed => return ConnectionEvent::ConnectionClosed,
                 opening::WebRtcEvent::ConnectionOpened { peer, endpoint } => {
                     return ConnectionEvent::ConnectionEstablished { peer, endpoint };
@@ -289,7 +283,12 @@ impl WebRtcTransport {
     /// until it timeouts.
     ///
     /// Returns `true` if the client should be polled.
-    fn on_socket_input(&mut self, addrs: AddressPair, buffer: Vec<u8>) -> crate::Result<bool> {
+    fn on_socket_input(
+        &mut self,
+        addrs: AddressPair,
+        socket: &Arc<UdpSocket>,
+        buffer: Vec<u8>,
+    ) -> crate::Result<bool> {
         if let Entry::Occupied(mut entry) = self.open.entry(addrs) {
             let ConnectionContext {
                 peer,
@@ -404,6 +403,7 @@ impl WebRtcTransport {
             noise_channel_id,
             self.context.keypair.clone(),
             addrs,
+            socket.clone(),
         );
         self.opening.insert(addrs, connection);
 
@@ -539,6 +539,7 @@ impl Transport for WebRtcTransport {
             Error::InvalidState
         })?;
 
+        let socket = connection.socket().clone();
         let rtc = connection.on_accept()?;
         let (tx, rx) = channel(self.datagram_buffer_size);
         let mut protocol_set = self.context.protocol_set(connection_id);
@@ -561,15 +562,6 @@ impl Transport for WebRtcTransport {
                 connection_id,
             },
         );
-
-        let Some(socket) = self.listener.socket(&addrs.local) else {
-            tracing::warn!(
-                target: LOG_TARGET,
-                ?addrs,
-                "no socket for local address; aborting connection"
-            );
-            return Err(Error::InvalidState);
-        };
 
         Ok(Box::pin(async move {
             // First, notify all protocols about the connection establishment
@@ -654,19 +646,20 @@ impl Stream for WebRtcTransport {
         }
 
         loop {
-            let (addrs, meta) = match this.listener.poll_recv_from(cx, &mut this.read_buffer) {
-                // No error is expected to be returned by the listener.
-                Poll::Ready(Err(error)) => {
-                    tracing::info!(
-                        target: LOG_TARGET,
-                        ?error,
-                        "webrtc udp socket closed",
-                    );
-                    return Poll::Ready(None);
-                }
-                Poll::Pending => break,
-                Poll::Ready(Ok(res)) => res,
-            };
+            let (addrs, meta, socket) =
+                match this.listener.poll_recv_from(cx, &mut this.read_buffer) {
+                    // No error is expected to be returned by the listener.
+                    Poll::Ready(Err(error)) => {
+                        tracing::info!(
+                            target: LOG_TARGET,
+                            ?error,
+                            "webrtc udp socket closed",
+                        );
+                        return Poll::Ready(None);
+                    }
+                    Poll::Pending => break,
+                    Poll::Ready(Ok(res)) => res,
+                };
 
             // `stride == 0` is only possible with `len == 0`
             // (`quinn-udp` sets `stride = len` when GRO info is absent),
@@ -686,7 +679,7 @@ impl Stream for WebRtcTransport {
                 let datagram = this.read_buffer[offset..offset + len].to_vec();
                 offset += len;
 
-                match this.on_socket_input(addrs, datagram) {
+                match this.on_socket_input(addrs, &socket, datagram) {
                     Ok(poll) => should_poll |= poll,
                     Err(error) => {
                         tracing::debug!(

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -256,12 +256,20 @@ impl WebRtcTransport {
                     if let Err(error) =
                         connection.socket().try_send_to(&datagram, destination, addrs.local.ip())
                     {
-                        tracing::warn!(
-                            target: LOG_TARGET,
-                            ?addrs,
-                            ?error,
-                            "failed to send datagram",
-                        );
+                        if error.kind() == std::io::ErrorKind::WouldBlock {
+                            tracing::trace!(
+                                target: LOG_TARGET,
+                                ?addrs,
+                                "UDP send buffer full, dropping datagram (str0m will retransmit)",
+                            );
+                        } else {
+                            tracing::warn!(
+                                target: LOG_TARGET,
+                                ?addrs,
+                                ?error,
+                                "failed to send datagram",
+                            );
+                        }
                     },
                 opening::WebRtcEvent::ConnectionClosed => return ConnectionEvent::ConnectionClosed,
                 opening::WebRtcEvent::ConnectionOpened { peer, endpoint } => {

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -125,11 +125,12 @@ enum ConnectionEvent {
     },
 }
 
-/// Endpoints of a received UDP datagram: which local socket received it,
+/// Endpoints of a received UDP datagram: its local destination address,
 /// and the remote socket that sent it.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 struct AddressPair {
-    /// Address of the local listening socket that received the datagram.
+    /// Local destination address of the datagram;
+    /// a concrete IP even for wildcard listening sockets.
     local: SocketAddr,
     /// Address of the remote peer that sent the datagram.
     remote: SocketAddr,

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -134,7 +134,7 @@ struct AddressPair {
     /// Address of the local listening socket that received the datagram.
     local: SocketAddr,
     /// Address of the remote peer that sent the datagram.
-    source: SocketAddr,
+    remote: SocketAddr,
 }
 
 /// WebRTC transport.
@@ -174,8 +174,8 @@ pub(crate) struct WebRtcTransport {
 }
 
 impl WebRtcTransport {
-    /// Create RTC client and open channel for Noise handshake.
-    fn make_rtc_client(
+    /// Create [`str0m::Rtc`] object for a new session and open a channel for Noise handshake.
+    fn make_rtc(
         &self,
         ufrag: &str,
         pass: &str,
@@ -387,13 +387,12 @@ impl WebRtcTransport {
         );
 
         // create new `Rtc` object for the peer and give it the received STUN message
-        let (mut rtc, noise_channel_id) =
-            self.make_rtc_client(ufrag, pass, addrs.source, addrs.local)?;
+        let (mut rtc, noise_channel_id) = self.make_rtc(ufrag, pass, addrs.remote, addrs.local)?;
 
         rtc.handle_input(Input::Receive(
             Instant::now(),
             Receive {
-                source: addrs.source,
+                source: addrs.remote,
                 proto: Str0mProtocol::Udp,
                 destination: addrs.local,
                 contents,
@@ -406,7 +405,7 @@ impl WebRtcTransport {
             connection_id,
             noise_channel_id,
             self.context.keypair.clone(),
-            addrs.source,
+            addrs.remote,
             addrs.local,
         );
         self.opening.insert(addrs, connection);
@@ -444,7 +443,7 @@ impl TransportBuilder for WebRtcTransport {
         let dtls_cert: DtlsCert = match config.certificate {
             Some(certificate) => certificate.into(),
             None => {
-                tracing::debug!(target: LOG_TARGET, "generating temporary WebRtc certificate");
+                tracing::debug!(target: LOG_TARGET, "generating temporary WebRTC certificate");
                 DtlsCertificate::new()?.into()
             }
         };
@@ -583,7 +582,7 @@ impl Transport for WebRtcTransport {
             let connection = WebRtcConnection::new(
                 rtc,
                 peer,
-                addrs.source,
+                addrs.remote,
                 addrs.local,
                 socket,
                 protocol_set,

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -441,25 +441,22 @@ impl TransportBuilder for WebRtcTransport {
             "start webrtc transport",
         );
 
-        let dtls_cert: DtlsCert = match config.certificate {
-            Some(certificate) => certificate.into(),
+        let dtls_cert = match config.certificate {
+            Some(certificate) => certificate,
             None => {
                 tracing::debug!(target: LOG_TARGET, "generating temporary WebRTC certificate");
-                DtlsCertificate::new()?.into()
+                DtlsCertificate::new()?
             }
         };
 
-        // OpenSsl is used as crypto backend to generate the certificate, it uses sha256.
-        let cert_hash = multihash_codetable::Code::Sha2_256.digest(&dtls_cert.certificate);
-
         let (listener, listen_multi_addresses) =
-            WebRtcListener::new(config.listen_addresses, cert_hash)?;
+            WebRtcListener::new(config.listen_addresses, dtls_cert.certhash())?;
         let read_buffer = vec![0; listener.max_read_size()];
 
         Ok((
             Self {
                 context,
-                dtls_cert,
+                dtls_cert: dtls_cert.into(),
                 listener,
                 open: HashMap::new(),
                 closed_connections: FuturesUnordered::new(),

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -26,7 +26,7 @@ use crate::{
         manager::TransportHandle,
         webrtc::{
             config::Config, connection::WebRtcConnection, listener::WebRtcListener,
-            opening::OpeningWebRtcConnection,
+            opening::OpeningWebRtcConnection, socket::WebRtcSocket,
         },
         Endpoint, Transport, TransportBuilder, TransportEvent,
     },
@@ -47,10 +47,7 @@ use str0m::{
     Candidate, Input, Rtc, RtcError,
 };
 
-use tokio::{
-    net::UdpSocket,
-    sync::mpsc::{channel, error::TrySendError, Sender},
-};
+use tokio::sync::mpsc::{channel, error::TrySendError, Sender};
 
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
@@ -67,6 +64,7 @@ mod certificate;
 mod connection;
 mod listener;
 mod opening;
+mod socket;
 mod substream;
 mod util;
 
@@ -259,7 +257,9 @@ impl WebRtcTransport {
                     destination,
                     datagram,
                 } =>
-                    if let Err(error) = connection.socket().try_send_to(&datagram, destination) {
+                    if let Err(error) =
+                        connection.socket().try_send_to(&datagram, destination, addrs.local.ip())
+                    {
                         tracing::warn!(
                             target: LOG_TARGET,
                             ?addrs,
@@ -286,7 +286,7 @@ impl WebRtcTransport {
     fn on_socket_input(
         &mut self,
         addrs: AddressPair,
-        socket: &Arc<UdpSocket>,
+        socket: &Arc<WebRtcSocket>,
         buffer: Vec<u8>,
     ) -> crate::Result<bool> {
         if let Entry::Occupied(mut entry) = self.open.entry(addrs) {

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -38,7 +38,6 @@ use futures::{future::BoxFuture, stream::FuturesUnordered, Future, Stream, Strea
 use futures_timer::Delay;
 use hickory_resolver::TokioResolver;
 use multiaddr::Multiaddr;
-use multihash_codetable::MultihashDigest;
 use str0m::{
     channel::{ChannelConfig, ChannelId},
     config::DtlsCert,

--- a/src/transport/webrtc/mod.rs
+++ b/src/transport/webrtc/mod.rs
@@ -179,8 +179,7 @@ impl WebRtcTransport {
         &self,
         ufrag: &str,
         pass: &str,
-        source: SocketAddr,
-        destination: SocketAddr,
+        addrs: &AddressPair,
     ) -> crate::Result<(Rtc, ChannelId)> {
         let mut rtc = Rtc::builder()
             .set_ice_lite(true)
@@ -188,10 +187,10 @@ impl WebRtcTransport {
             .set_fingerprint_verification(false)
             .build(std::time::Instant::now());
         rtc.add_local_candidate(
-            Candidate::host(destination, Str0mProtocol::Udp).map_err(RtcError::Ice)?,
+            Candidate::host(addrs.local, Str0mProtocol::Udp).map_err(RtcError::Ice)?,
         );
         rtc.add_remote_candidate(
-            Candidate::host(source, Str0mProtocol::Udp).map_err(RtcError::Ice)?,
+            Candidate::host(addrs.remote, Str0mProtocol::Udp).map_err(RtcError::Ice)?,
         );
         rtc.direct_api().set_remote_fingerprint(
             REMOTE_FINGERPRINT
@@ -387,7 +386,7 @@ impl WebRtcTransport {
         );
 
         // create new `Rtc` object for the peer and give it the received STUN message
-        let (mut rtc, noise_channel_id) = self.make_rtc(ufrag, pass, addrs.remote, addrs.local)?;
+        let (mut rtc, noise_channel_id) = self.make_rtc(ufrag, pass, &addrs)?;
 
         rtc.handle_input(Input::Receive(
             Instant::now(),
@@ -405,8 +404,7 @@ impl WebRtcTransport {
             connection_id,
             noise_channel_id,
             self.context.keypair.clone(),
-            addrs.remote,
-            addrs.local,
+            addrs,
         );
         self.opening.insert(addrs, connection);
 
@@ -579,16 +577,8 @@ impl Transport for WebRtcTransport {
             protocol_set.report_connection_established(peer, endpoint_clone).await?;
 
             // After protocols are notified, create connection and spawn event loop
-            let connection = WebRtcConnection::new(
-                rtc,
-                peer,
-                addrs.remote,
-                addrs.local,
-                socket,
-                protocol_set,
-                endpoint,
-                rx,
-            );
+            let connection =
+                WebRtcConnection::new(rtc, peer, addrs, socket, protocol_set, endpoint, rx);
 
             executor.run(Box::pin(async move {
                 connection.run_event_loop().await;

--- a/src/transport/webrtc/opening.rs
+++ b/src/transport/webrtc/opening.rs
@@ -44,7 +44,9 @@ use str0m::{
     Event, IceConnectionState, Input, Output, Rtc,
 };
 
-use std::{net::SocketAddr, time::Instant};
+use tokio::net::UdpSocket;
+
+use std::{net::SocketAddr, sync::Arc, time::Instant};
 
 /// Logging target for the file.
 const LOG_TARGET: &str = "litep2p::webrtc::connection";
@@ -116,6 +118,9 @@ pub struct OpeningWebRtcConnection {
     /// Addresses of the session.
     addrs: AddressPair,
 
+    /// Socket the session's datagrams are received on and sent from.
+    socket: Arc<UdpSocket>,
+
     /// Inbound noise-channel byte buffer for reassembling protobuf frames.
     ///
     /// The libp2p-go msgio implementation issues two separate `Write` calls:
@@ -167,6 +172,7 @@ impl OpeningWebRtcConnection {
         noise_channel_id: ChannelId,
         id_keypair: Keypair,
         addrs: AddressPair,
+        socket: Arc<UdpSocket>,
     ) -> OpeningWebRtcConnection {
         tracing::trace!(
             target: LOG_TARGET,
@@ -182,6 +188,7 @@ impl OpeningWebRtcConnection {
             noise_channel_id,
             id_keypair,
             addrs,
+            socket,
             noise_recv_buffer: BytesMut::new(),
         }
     }
@@ -189,6 +196,11 @@ impl OpeningWebRtcConnection {
     /// Returns the [`ConnectionId`] assigned to this opening connection.
     pub fn connection_id(&self) -> &ConnectionId {
         &self.connection_id
+    }
+
+    /// Socket the session's datagrams are received on and sent from.
+    pub fn socket(&self) -> &Arc<UdpSocket> {
+        &self.socket
     }
 
     /// Get remote fingerprint to bytes.

--- a/src/transport/webrtc/opening.rs
+++ b/src/transport/webrtc/opening.rs
@@ -25,6 +25,7 @@ use crate::{
     crypto::{ed25519::Keypair, noise::NoiseContext},
     transport::{
         webrtc::{
+            socket::WebRtcSocket,
             util::{extract_framed_message, WebRtcMessage},
             AddressPair,
         },
@@ -43,8 +44,6 @@ use str0m::{
     net::{DatagramRecv, DatagramSend, Protocol as Str0mProtocol, Receive},
     Event, IceConnectionState, Input, Output, Rtc,
 };
-
-use tokio::net::UdpSocket;
 
 use std::{net::SocketAddr, sync::Arc, time::Instant};
 
@@ -119,7 +118,7 @@ pub struct OpeningWebRtcConnection {
     addrs: AddressPair,
 
     /// Socket the session's datagrams are received on and sent from.
-    socket: Arc<UdpSocket>,
+    socket: Arc<WebRtcSocket>,
 
     /// Inbound noise-channel byte buffer for reassembling protobuf frames.
     ///
@@ -172,7 +171,7 @@ impl OpeningWebRtcConnection {
         noise_channel_id: ChannelId,
         id_keypair: Keypair,
         addrs: AddressPair,
-        socket: Arc<UdpSocket>,
+        socket: Arc<WebRtcSocket>,
     ) -> OpeningWebRtcConnection {
         tracing::trace!(
             target: LOG_TARGET,
@@ -199,7 +198,7 @@ impl OpeningWebRtcConnection {
     }
 
     /// Socket the session's datagrams are received on and sent from.
-    pub fn socket(&self) -> &Arc<UdpSocket> {
+    pub fn socket(&self) -> &Arc<WebRtcSocket> {
         &self.socket
     }
 

--- a/src/transport/webrtc/opening.rs
+++ b/src/transport/webrtc/opening.rs
@@ -24,7 +24,10 @@ use crate::{
     config::Role,
     crypto::{ed25519::Keypair, noise::NoiseContext},
     transport::{
-        webrtc::util::{extract_framed_message, WebRtcMessage},
+        webrtc::{
+            util::{extract_framed_message, WebRtcMessage},
+            AddressPair,
+        },
         Endpoint,
     },
     types::ConnectionId,
@@ -110,11 +113,8 @@ pub struct OpeningWebRtcConnection {
     /// Local keypair.
     id_keypair: Keypair,
 
-    /// Peer address
-    peer_address: SocketAddr,
-
-    /// Local address.
-    local_address: SocketAddr,
+    /// Addresses of the session.
+    addrs: AddressPair,
 
     /// Inbound noise-channel byte buffer for reassembling protobuf frames.
     ///
@@ -166,13 +166,12 @@ impl OpeningWebRtcConnection {
         connection_id: ConnectionId,
         noise_channel_id: ChannelId,
         id_keypair: Keypair,
-        peer_address: SocketAddr,
-        local_address: SocketAddr,
+        addrs: AddressPair,
     ) -> OpeningWebRtcConnection {
         tracing::trace!(
             target: LOG_TARGET,
             ?connection_id,
-            ?peer_address,
+            ?addrs,
             "new connection opened",
         );
 
@@ -182,8 +181,7 @@ impl OpeningWebRtcConnection {
             connection_id,
             noise_channel_id,
             id_keypair,
-            peer_address,
-            local_address,
+            addrs,
             noise_recv_buffer: BytesMut::new(),
         }
     }
@@ -224,7 +222,7 @@ impl OpeningWebRtcConnection {
         tracing::trace!(
             target: LOG_TARGET,
             connection_id = ?self.connection_id,
-            peer = ?self.peer_address,
+            peer = ?self.addrs.remote,
             "send initial noise handshake",
         );
 
@@ -262,7 +260,7 @@ impl OpeningWebRtcConnection {
             tracing::error!(
                 target: LOG_TARGET,
                 connection_id = ?self.connection_id,
-                peer = ?self.peer_address,
+                peer = ?self.addrs.remote,
                 ?error,
                 "failed to handle timeout for `Rtc`"
             );
@@ -287,7 +285,7 @@ impl OpeningWebRtcConnection {
         tracing::trace!(
             target: LOG_TARGET,
             connection_id = ?self.connection_id,
-            peer = ?self.peer_address,
+            peer = ?self.addrs.remote,
             len = data.len(),
             buffered = self.noise_recv_buffer.len(),
             "noise channel data received",
@@ -301,7 +299,7 @@ impl OpeningWebRtcConnection {
                 tracing::trace!(
                     target: LOG_TARGET,
                     connection_id = ?self.connection_id,
-                    peer = ?self.peer_address,
+                    peer = ?self.addrs.remote,
                     buffered = self.noise_recv_buffer.len(),
                     "incomplete noise frame, waiting for more bytes",
                 );
@@ -312,7 +310,7 @@ impl OpeningWebRtcConnection {
         tracing::trace!(
             target: LOG_TARGET,
             connection_id = ?self.connection_id,
-            peer = ?self.peer_address,
+            peer = ?self.addrs.remote,
             "handle noise handshake reply",
         );
 
@@ -331,7 +329,7 @@ impl OpeningWebRtcConnection {
             tracing::debug!(
                 target: LOG_TARGET,
                 connection_id = ?self.connection_id,
-                peer = ?self.peer_address,
+                peer = ?self.addrs.remote,
                 "non-payload frame during noise handshake, closing channel"
             );
             return Err(Error::ConnectionClosed);
@@ -341,7 +339,7 @@ impl OpeningWebRtcConnection {
         tracing::trace!(
             target: LOG_TARGET,
             connection_id = ?self.connection_id,
-            peer = ?self.peer_address,
+            peer = ?self.addrs.remote,
             ?remote_peer_id,
             "remote reply parsed successfully",
         );
@@ -361,8 +359,8 @@ impl OpeningWebRtcConnection {
                 .map_err(|_| Error::InvalidCertificate)?;
 
         let address = Multiaddr::empty()
-            .with(Protocol::from(self.peer_address.ip()))
-            .with(Protocol::Udp(self.peer_address.port()))
+            .with(Protocol::from(self.addrs.remote.ip()))
+            .with(Protocol::Udp(self.addrs.remote.port()))
             .with(Protocol::WebRTCDirect)
             .with(Protocol::Certhash(certificate))
             .with(Protocol::P2p(remote_peer_id.into()));
@@ -379,7 +377,7 @@ impl OpeningWebRtcConnection {
         tracing::trace!(
             target: LOG_TARGET,
             connection_id = ?self.connection_id,
-            peer = ?self.peer_address,
+            peer = ?self.addrs.remote,
             "accept webrtc connection",
         );
 
@@ -413,16 +411,16 @@ impl OpeningWebRtcConnection {
     pub fn on_input(&mut self, buffer: DatagramRecv) -> crate::Result<()> {
         tracing::trace!(
             target: LOG_TARGET,
-            peer = ?self.peer_address,
+            peer = ?self.addrs.remote,
             "handle input from peer",
         );
 
         let message = Input::Receive(
             Instant::now(),
             Receive {
-                source: self.peer_address,
+                source: self.addrs.remote,
                 proto: Str0mProtocol::Udp,
-                destination: self.local_address,
+                destination: self.addrs.local,
                 contents: buffer,
             },
         );
@@ -432,7 +430,7 @@ impl OpeningWebRtcConnection {
         self.rtc.handle_input(message).map_err(|error| {
             tracing::debug!(
                 target: LOG_TARGET,
-                source = ?self.peer_address,
+                source = ?self.addrs.remote,
                 ?error,
                 "failed to handle data"
             );
@@ -446,7 +444,7 @@ impl OpeningWebRtcConnection {
             tracing::debug!(
                 target: LOG_TARGET,
                 connection_id = ?self.connection_id,
-                peer = ?self.peer_address,
+                peer = ?self.addrs.remote,
                 "`Rtc` is not alive, closing `WebRtcConnection`"
             );
 
@@ -460,7 +458,7 @@ impl OpeningWebRtcConnection {
                     tracing::debug!(
                         target: LOG_TARGET,
                         connection_id = ?self.connection_id,
-                        peer = ?self.peer_address,
+                        peer = ?self.addrs.remote,
                         ?error,
                         "`WebRtcConnection::poll_process()` failed",
                     );
@@ -474,7 +472,7 @@ impl OpeningWebRtcConnection {
                     tracing::trace!(
                         target: LOG_TARGET,
                         connection_id = ?self.connection_id,
-                        peer = ?self.peer_address,
+                        peer = ?self.addrs.remote,
                         "transmit data",
                     );
 
@@ -490,7 +488,7 @@ impl OpeningWebRtcConnection {
                             tracing::trace!(
                                 target: LOG_TARGET,
                                 connection_id = ?self.connection_id,
-                                peer = ?self.peer_address,
+                                peer = ?self.addrs.remote,
                                 "ice connection closed",
                             );
                             return WebRtcEvent::ConnectionClosed;
@@ -499,7 +497,7 @@ impl OpeningWebRtcConnection {
                         tracing::trace!(
                             target: LOG_TARGET,
                             connection_id = ?self.connection_id,
-                            peer = ?self.peer_address,
+                            peer = ?self.addrs.remote,
                             ?channel_id,
                             ?name,
                             "channel opened",
@@ -509,7 +507,7 @@ impl OpeningWebRtcConnection {
                             tracing::warn!(
                                 target: LOG_TARGET,
                                 connection_id = ?self.connection_id,
-                                peer = ?self.peer_address,
+                                peer = ?self.addrs.remote,
                                 ?channel_id,
                                 "ignoring opened channel",
                             );
@@ -529,7 +527,7 @@ impl OpeningWebRtcConnection {
                             tracing::debug!(
                                 target: LOG_TARGET,
                                 connection_id = ?self.connection_id,
-                                peer = ?self.peer_address,
+                                peer = ?self.addrs.remote,
                                 ?error,
                                 "noise channel open failed",
                             );
@@ -540,7 +538,7 @@ impl OpeningWebRtcConnection {
                         tracing::trace!(
                             target: LOG_TARGET,
                             connection_id = ?self.connection_id,
-                            peer = ?self.peer_address,
+                            peer = ?self.addrs.remote,
                             "data received over channel",
                         );
 
@@ -549,7 +547,7 @@ impl OpeningWebRtcConnection {
                                 target: LOG_TARGET,
                                 channel_id = ?data.id,
                                 connection_id = ?self.connection_id,
-                                peer = ?self.peer_address,
+                                peer = ?self.addrs.remote,
                                 "ignoring data from channel",
                             );
                             continue;
@@ -562,7 +560,7 @@ impl OpeningWebRtcConnection {
                                 tracing::debug!(
                                     target: LOG_TARGET,
                                     connection_id = ?self.connection_id,
-                                    peer = ?self.peer_address,
+                                    peer = ?self.addrs.remote,
                                     ?error,
                                     "noise channel data handling failed",
                                 );
@@ -574,7 +572,7 @@ impl OpeningWebRtcConnection {
                         tracing::debug!(
                             target: LOG_TARGET,
                             connection_id = ?self.connection_id,
-                            peer = ?self.peer_address,
+                            peer = ?self.addrs.remote,
                             ?channel_id,
                             "channel closed",
                         );
@@ -587,7 +585,7 @@ impl OpeningWebRtcConnection {
                                     tracing::debug!(
                                         target: LOG_TARGET,
                                         connection_id = ?self.connection_id,
-                                        peer = ?self.peer_address,
+                                        peer = ?self.addrs.remote,
                                         ?err,
                                         "Failed creating remote peer fingerprint"
                                     );
@@ -601,7 +599,7 @@ impl OpeningWebRtcConnection {
                                     tracing::debug!(
                                         target: LOG_TARGET,
                                         connection_id = ?self.connection_id,
-                                        peer = ?self.peer_address,
+                                        peer = ?self.addrs.remote,
                                         ?err,
                                         "Failed creating local peer fingerprint"
                                     );
@@ -618,7 +616,7 @@ impl OpeningWebRtcConnection {
                                     tracing::error!(
                                         target: LOG_TARGET,
                                         connection_id = ?self.connection_id,
-                                        peer = ?self.peer_address,
+                                        peer = ?self.addrs.remote,
                                         "NoiseContext failed with error {err}",
                                     );
 
@@ -629,7 +627,7 @@ impl OpeningWebRtcConnection {
                             tracing::debug!(
                                 target: LOG_TARGET,
                                 connection_id = ?self.connection_id,
-                                peer = ?self.peer_address,
+                                peer = ?self.addrs.remote,
                                 "connection opened",
                             );
 
@@ -639,7 +637,7 @@ impl OpeningWebRtcConnection {
                             tracing::debug!(
                                 target: LOG_TARGET,
                                 connection_id = ?self.connection_id,
-                                peer = ?self.peer_address,
+                                peer = ?self.addrs.remote,
                                 ?state,
                                 "invalid state for connection"
                             );

--- a/src/transport/webrtc/socket.rs
+++ b/src/transport/webrtc/socket.rs
@@ -29,7 +29,7 @@ use std::{
 use quinn_udp::{RecvMeta, Transmit, UdpSockRef, UdpSocketState};
 use tokio::{io::Interest, net::UdpSocket};
 
-/// UDP socket paired with its `quinn-udp` state.
+/// UDP socket with API for getting/setting local packet address & GRO support.
 pub(crate) struct WebRtcSocket {
     /// Tokio UDP socket.
     socket: UdpSocket,
@@ -88,5 +88,61 @@ impl WebRtcSocket {
         self.socket.try_io(Interest::WRITABLE, || {
             self.state.try_send(UdpSockRef::from(&self.socket), &transmit)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::future::poll_fn;
+    use std::net::Ipv4Addr;
+
+    async fn webrtc_socket() -> WebRtcSocket {
+        WebRtcSocket::new(UdpSocket::bind("0.0.0.0:0").await.expect("bind socket"))
+            .expect("wrap socket")
+    }
+
+    #[tokio::test]
+    async fn wildcard_recv_reports_destination_address() {
+        let receiver = webrtc_socket().await;
+        let port = receiver.socket.local_addr().unwrap().port();
+
+        let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        sender.send_to(b"litep2p", (Ipv4Addr::LOCALHOST, port)).await.unwrap();
+
+        let mut buf = [0u8; 1500];
+        let meta = poll_fn(|cx| receiver.poll_recv(cx, &mut buf)).await.unwrap();
+
+        assert_eq!(meta.dst_ip, Some(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert_eq!(meta.addr, sender.local_addr().unwrap());
+        assert_eq!(&buf[..meta.len], b"litep2p");
+    }
+
+    // MacOS does not support binding to anything other than 127.0.0.1 in the loopback range.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn send_sets_source_address() {
+        let src_ip = IpAddr::V4(Ipv4Addr::new(127, 3, 3, 7));
+        let sender = webrtc_socket().await;
+        let port = sender.socket.local_addr().unwrap().port();
+
+        let receiver = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let destination = receiver.local_addr().unwrap();
+
+        loop {
+            match sender.try_send_to(b"litep2p", destination, src_ip) {
+                Ok(()) => break,
+                // Freshly registered socket may not have observed writability yet
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock =>
+                    sender.socket.writable().await.unwrap(),
+                Err(e) => panic!("send failed: {e}"),
+            }
+        }
+
+        let mut buf = [0u8; 1500];
+        let (len, from) = receiver.recv_from(&mut buf).await.unwrap();
+
+        assert_eq!(from, SocketAddr::new(src_ip, port));
+        assert_eq!(&buf[..len], b"litep2p");
     }
 }

--- a/src/transport/webrtc/socket.rs
+++ b/src/transport/webrtc/socket.rs
@@ -36,7 +36,7 @@ const MAX_GRO_SEGMENT_SIZE: usize = 1500;
 /// Upper bound of a UDP payload size.
 pub(crate) const MAX_DATAGRAM_SIZE: usize = 64 * 1024;
 
-/// UDP socket with API for getting/setting local packet address & GRO support.
+/// Local packet address aware UDP socket with GRO support.
 pub(crate) struct WebRtcSocket {
     /// Tokio UDP socket.
     socket: UdpSocket,

--- a/src/transport/webrtc/socket.rs
+++ b/src/transport/webrtc/socket.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 litep2p developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! Sockets for WebRTC.
+
+use std::{
+    io::{self, IoSliceMut},
+    net::{IpAddr, SocketAddr},
+    task::{ready, Context, Poll},
+};
+
+use quinn_udp::{RecvMeta, Transmit, UdpSockRef, UdpSocketState};
+use tokio::{io::Interest, net::UdpSocket};
+
+/// UDP socket paired with its `quinn-udp` state.
+pub(crate) struct WebRtcSocket {
+    /// Tokio UDP socket.
+    socket: UdpSocket,
+    /// `quinn-udp` socket state.
+    state: UdpSocketState,
+}
+
+impl WebRtcSocket {
+    /// Wrap a socket, setting up `IP_PKTINFO`/`IPV6_RECVPKTINFO` & GRO where available.
+    pub(crate) fn new(socket: UdpSocket) -> io::Result<Self> {
+        let state = UdpSocketState::new(UdpSockRef::from(&socket))?;
+        Ok(Self { socket, state })
+    }
+
+    /// Poll a single read. The filled part of `buf` (`meta.len` bytes) may contain
+    /// multiple GRO-coalesced datagrams (see [`RecvMeta::stride`]).
+    pub(crate) fn poll_recv(
+        &self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<RecvMeta>> {
+        loop {
+            ready!(self.socket.poll_recv_ready(cx))?;
+
+            let mut meta = RecvMeta::default();
+            let mut iov = [IoSliceMut::new(&mut *buf)];
+            match self.socket.try_io(Interest::READABLE, || {
+                self.state.recv(
+                    UdpSockRef::from(&self.socket),
+                    &mut iov,
+                    std::slice::from_mut(&mut meta),
+                )
+            }) {
+                Ok(_) => return Poll::Ready(Ok(meta)),
+                // Readiness was a false positive; re-poll to register the waker
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Poll::Ready(Err(e)),
+            }
+        }
+    }
+
+    /// Send `datagram` to `destination` from `src_ip`.
+    pub(super) fn try_send_to(
+        &self,
+        datagram: &[u8],
+        destination: SocketAddr,
+        src_ip: IpAddr,
+    ) -> io::Result<()> {
+        let transmit = Transmit {
+            destination,
+            ecn: None,
+            contents: datagram,
+            segment_size: None,
+            src_ip: Some(src_ip),
+        };
+        self.socket.try_io(Interest::WRITABLE, || {
+            self.state.try_send(UdpSockRef::from(&self.socket), &transmit)
+        })
+    }
+}

--- a/src/transport/webrtc/socket.rs
+++ b/src/transport/webrtc/socket.rs
@@ -29,6 +29,13 @@ use std::{
 use quinn_udp::{RecvMeta, Transmit, UdpSockRef, UdpSocketState};
 use tokio::{io::Interest, net::UdpSocket};
 
+/// Upper bound of a GRO segment size. Segments are bounded by the path MTU;
+/// assume a conventional Ethernet MTU.
+const MAX_GRO_SEGMENT_SIZE: usize = 1500;
+
+/// Upper bound of a UDP payload size.
+pub(crate) const MAX_DATAGRAM_SIZE: usize = 64 * 1024;
+
 /// UDP socket with API for getting/setting local packet address & GRO support.
 pub(crate) struct WebRtcSocket {
     /// Tokio UDP socket.
@@ -42,6 +49,12 @@ impl WebRtcSocket {
     pub(crate) fn new(socket: UdpSocket) -> io::Result<Self> {
         let state = UdpSocketState::new(UdpSockRef::from(&socket))?;
         Ok(Self { socket, state })
+    }
+
+    /// Buffer size [`Self::poll_recv`] needs to never truncate a read: enough for the largest
+    /// GRO list the kernel can coalesce, and for a maximum-size datagram when GRO is off.
+    pub(crate) fn max_read_size(&self) -> usize {
+        (self.state.gro_segments() * MAX_GRO_SEGMENT_SIZE).max(MAX_DATAGRAM_SIZE)
     }
 
     /// Poll a single read. The filled part of `buf` (`meta.len` bytes) may contain

--- a/src/transport/webrtc/socket.rs
+++ b/src/transport/webrtc/socket.rs
@@ -72,7 +72,7 @@ impl WebRtcSocket {
     }
 
     /// Send `datagram` to `destination` from `src_ip`.
-    pub(super) fn try_send_to(
+    pub(crate) fn try_send_to(
         &self,
         datagram: &[u8],
         destination: SocketAddr,

--- a/src/transport/webrtc/socket.rs
+++ b/src/transport/webrtc/socket.rs
@@ -145,7 +145,7 @@ mod tests {
         loop {
             match sender.try_send_to(b"litep2p", destination, src_ip) {
                 Ok(()) => break,
-                // Freshly registered socket may not have observed writability yet
+                // `sendmsg` hit a full send buffer, wait for the socket to drain
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock =>
                     sender.socket.writable().await.unwrap(),
                 Err(e) => panic!("send failed: {e}"),

--- a/tests/connection/mod.rs
+++ b/tests/connection/mod.rs
@@ -27,6 +27,8 @@ use litep2p::{
     Litep2p, Litep2pEvent, PeerId,
 };
 
+#[cfg(feature = "webrtc")]
+use litep2p::transport::webrtc::config::Config as WebRtcConfig;
 #[cfg(feature = "websocket")]
 use litep2p::transport::websocket::config::Config as WebSocketConfig;
 #[cfg(feature = "quic")]
@@ -41,8 +43,10 @@ use tokio::net::UdpSocket;
 
 use crate::common::{add_transport, Transport};
 
-#[cfg(feature = "websocket")]
+#[cfg(any(feature = "webrtc", feature = "websocket"))]
 use std::collections::HashSet;
+#[cfg(feature = "webrtc")]
+use std::net::IpAddr;
 
 #[cfg(test)]
 mod failed_addresses_on_success;
@@ -1342,6 +1346,95 @@ async fn unspecified_listen_address_websocket() {
             }
         }
     }
+}
+
+// WebRTC cannot dial, so instead of connecting over every interface address like the tests
+// above, assert the wildcard listen addresses expand to exactly the addresses of the host.
+#[cfg(feature = "webrtc")]
+#[tokio::test]
+async fn unspecified_listen_address_webrtc() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let config = ConfigBuilder::new()
+        .with_keypair(Keypair::generate())
+        .with_webrtc(WebRtcConfig {
+            listen_addresses: vec![
+                "/ip4/0.0.0.0/udp/0/webrtc-direct".parse().unwrap(),
+                "/ip6/::/udp/0/webrtc-direct".parse().unwrap(),
+            ],
+            ..Default::default()
+        })
+        .build();
+
+    let litep2p = Litep2p::new(config).unwrap();
+    let peer = *litep2p.local_peer_id();
+
+    // Every address is expected to be
+    // `/ip{4,6}/<ip>/udp/<port>/webrtc-direct/certhash/<hash>/p2p/<peer>`.
+    let advertised: HashSet<(IpAddr, u16)> = litep2p
+        .listen_addresses()
+        .map(|address| {
+            let mut iter = address.iter();
+            let ip = match iter.next() {
+                Some(Protocol::Ip4(ip)) => IpAddr::V4(ip),
+                Some(Protocol::Ip6(ip)) => IpAddr::V6(ip),
+                protocol => panic!("unexpected protocol {protocol:?} in {address}"),
+            };
+            let Some(Protocol::Udp(port)) = iter.next() else {
+                panic!("expected `Udp` in {address}");
+            };
+            assert!(
+                matches!(iter.next(), Some(Protocol::WebRTCDirect)),
+                "{address}"
+            );
+            assert!(
+                matches!(iter.next(), Some(Protocol::Certhash(_))),
+                "{address}"
+            );
+            assert_eq!(iter.next(), Some(Protocol::P2p(peer.into())), "{address}");
+            assert_eq!(iter.next(), None, "{address}");
+
+            assert!(
+                !ip.is_unspecified(),
+                "wildcard address advertised: {address}"
+            );
+            // `/udp/0` must have been resolved to the actually bound port.
+            assert_ne!(port, 0, "unresolved ephemeral port: {address}");
+
+            (ip, port)
+        })
+        .collect();
+
+    // Both families are bound separately, so each gets its own ephemeral port. A family with
+    // no advertisable address on this host (e.g. IPv6 disabled) contributes nothing.
+    let ip4_port = advertised.iter().find(|(ip, _)| ip.is_ipv4()).map(|(_, port)| *port);
+    let ip6_port = advertised.iter().find(|(ip, _)| ip.is_ipv6()).map(|(_, port)| *port);
+
+    let mut expected = HashSet::new();
+    for iface in NetworkInterface::show().unwrap() {
+        for address in iface.addr {
+            match address {
+                network_interface::Addr::V4(record) =>
+                    if let Some(port) = ip4_port {
+                        expected.insert((IpAddr::V4(record.ip), port));
+                    },
+                network_interface::Addr::V6(record) => {
+                    // Link-local addresses are deliberately not advertised.
+                    if record.ip.segments()[0] != 0xfe80 {
+                        if let Some(port) = ip6_port {
+                            expected.insert((IpAddr::V6(record.ip), port));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Loopback always exists, so this also guards against both sets being vacuously empty.
+    assert!(!advertised.is_empty());
+    assert_eq!(advertised, expected);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Allow wildcard IPv4 & IPv6 WebRTC listen addresses, taking care of local addresses of inbound/outbound UDP packets.

Resolves https://github.com/paritytech/litep2p/issues/638.