### PR TITLE
Stop leaking hickory error types in litep2p public API

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,7 @@ use std::io::{self, ErrorKind};
 // Please note that this error is not propagated directly to the user.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Peer `{0}` does not exist")]
     PeerDoesntExist(PeerId),

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,9 +127,9 @@ pub enum Error {
     #[error("Failed to dial peer immediately")]
     ImmediateDialError(#[from] ImmediateDialError),
     #[error("Cannot read system DNS config: `{0}`")]
-    CannotReadSystemDnsConfig(hickory_resolver::net::NetError),
+    CannotReadSystemDnsConfig(DnsInitError),
     #[error("Failed to build DNS resolver: `{0}`")]
-    DnsResolverInit(hickory_resolver::net::NetError),
+    DnsResolverInit(DnsInitError),
 }
 
 /// Error type for address parsing.
@@ -426,6 +426,22 @@ pub enum DnsError {
     /// For example, DNSv4 was expected but DNSv6 was provided.
     #[error("DNS type is different from the provided IP address")]
     IpVersionMismatch,
+}
+
+/// Error during DNS resolver initialization.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct DnsInitError(String);
+
+impl DnsInitError {
+    /// Erase a resolver error into an opaque [`DnsInitError`] to stop leaking hickory error types
+    /// into public litep2p API.
+    ///
+    /// Takes `impl Display` rather than a concrete type because `read_system_conf` returns a
+    /// different error type per target OS.
+    pub(crate) fn new(error: impl std::fmt::Display) -> Self {
+        Self(error.to_string())
+    }
 }
 
 impl From<Multihash> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 use crate::{
     addresses::PublicAddresses,
     config::Litep2pConfig,
-    error::DialError,
+    error::{DialError, DnsInitError},
     protocol::{
         libp2p::{bitswap::Bitswap, identify::Identify, kademlia::Kademlia, ping::Ping},
         mdns::Mdns,
@@ -164,7 +164,7 @@ impl Litep2p {
 
         let (resolver_config, mut resolver_opts) = if litep2p_config.use_system_dns_config {
             hickory_resolver::system_conf::read_system_conf()
-                .map_err(Error::CannotReadSystemDnsConfig)?
+                .map_err(|error| Error::CannotReadSystemDnsConfig(DnsInitError::new(error)))?
         } else {
             (
                 ResolverConfig::udp_and_tcp(&GOOGLE),
@@ -177,7 +177,7 @@ impl Litep2p {
             TokioResolver::builder_with_config(resolver_config, TokioRuntimeProvider::default())
                 .with_options(resolver_opts)
                 .build()
-                .map_err(Error::DnsResolverInit)?,
+                .map_err(|error| Error::DnsResolverInit(DnsInitError::new(error)))?,
         );
 
         let supported_transports = Self::supported_transports(&litep2p_config);


### PR DESCRIPTION
This is what happened in litep2p <= v0.14.3 and forces us now to go to v0.15 because of the changes in hickory error types. Stop leaking so we can tolerate future hickory error type changes.

Also mark litep2p `Error` as non-exhaustive, so it can be safely extended in the future.