### PR TITLE
webrtc: use ordered & reliable data channels

### DIFF
--- a/src/transport/webrtc/connection.rs
+++ b/src/transport/webrtc/connection.rs
@@ -44,7 +44,7 @@ use bytes::{Bytes, BytesMut};
 use futures::{task::AtomicWaker, Stream, StreamExt};
 use indexmap::IndexMap;
 use str0m::{
-    channel::{Channel, ChannelConfig, ChannelId},
+    channel::{Channel, ChannelConfig, ChannelId, Reliability},
     net::{Protocol as Str0mProtocol, Receive},
     Event, IceConnectionState, Input, Output, Rtc,
 };
@@ -1038,8 +1038,8 @@ impl WebRtcConnection {
     ) {
         let channel_id = self.rtc.direct_api().create_data_channel(ChannelConfig {
             label: "".to_string(),
-            ordered: false,
-            reliability: Default::default(),
+            ordered: true,
+            reliability: Reliability::Reliable,
             negotiated: None,
             protocol: protocol.to_string(),
         });


### PR DESCRIPTION
Use ordered & reliable WebRTC data channels, because it is the only correct choice with litep2p stream-oriented substreams. This is also what smoldot does when opening WebRTC channels (so only litep2p-opened substreams were affected).

In particular, this fixes broken large message fragmentation causing invalid GRANDPA packets in Polkadot:
```
[WARN] [network] protocol-error; error=BadGrandpaNotification(DecodeGrandpaNotificationError(Verify))
[WARN] [network] protocol-error; error=BadGrandpaNotification(DecodeGrandpaNotificationError(Complete))
[WARN] [network] protocol-error; error=BadGrandpaNotification(DecodeGrandpaNotificationError(Complete))
[WARN] [network] protocol-error; error=BadGrandpaNotification(DecodeGrandpaNotificationError(Eof))
[WARN] [network] protocol-error; error=BadGrandpaNotification(DecodeGrandpaNotificationError(Tag))
...
```